### PR TITLE
trig rules lua serialization syntax fixed

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -1,3 +1,4 @@
+from .lua.serialize import dumps
 from .translation import String
 from enum import Enum
 
@@ -11,7 +12,7 @@ class Action:
         s = []
         for x in self.params:
             if isinstance(x, String):
-                s.append('getValueDictByKey("' + x.id + '")')
+                s.append("getValueDictByKey({})".format(dumps(x.id)))
             else:
                 s.append(str(x))
         return self.predicate + "(" + ", ".join(s) + ")"

--- a/dcs/condition.py
+++ b/dcs/condition.py
@@ -1,10 +1,12 @@
+from .lua.serialize import dumps
+
 class Condition:
     def __init__(self, predicate):
         self.predicate = predicate
         self.params = []
 
     def __repr__(self):
-        return self.predicate + "(" + ",".join(map(str, self.params)) + ")"
+        return self.predicate + "(" + ",".join(map(dumps, self.params)) + ")"
 
     def dict(self):
         d = {


### PR DESCRIPTION
This uses lua serializer dumps to correctly output arguments for trig rules inline lua code. 

Primary error was that string arguments for conditions were serialized without quotes, but I find some another places that could potentially bring the same issue.