### PR TITLE
Remove previous loadout before loading new one

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -14,7 +14,7 @@ class Action:
             if isinstance(x, String):
                 s.append("getValueDictByKey({})".format(dumps(x.id)))
             else:
-                s.append(str(x))
+                s.append(dumps(x))
         return self.predicate + "(" + ", ".join(s) + ")"
 
     def dict(self):

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -413,6 +413,8 @@ class FlyingGroup(MovingGroup):
         payload = self.units[0].unit_type.loadout_by_name(name)
         if payload:
             for p in self.units:
+                p.pylons.clear()
+
                 for x in payload:
                     p.load_pylon(x)
 


### PR DESCRIPTION
I don't know whether this is by design, but it does seem counter intuitive anyway.

+ that dumps update