### PR TITLE
Fix error in unittype.py for DCS World Steam Edition users

### DIFF
--- a/dcs/__init__.py
+++ b/dcs/__init__.py
@@ -18,5 +18,6 @@ from . import triggers
 from . import condition
 from . import action
 from . import forcedoptions
+from . import installation
 from .mapping import Point, Rectangle, Polygon
 from .mission import Mission

--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -5,8 +5,14 @@ TODO : add method 'is_using_open_beta', 'is_using_stable'
 TODO : [NICE to have] add method to check list of installed DCS modules (could be done either through windows registry, or through filesystem analysis ?)
 """
 
-import winreg
 import os
+
+is_windows_os = True
+try:
+    import winreg
+except ImportError:
+    is_windows_os = False
+    print("WARNING : Trying to run pydcs on non Windows machine")
 
 
 def is_using_dcs_steam_edition():
@@ -16,6 +22,8 @@ def is_using_dcs_steam_edition():
             -1 if DCS Steam Edition is registered in Steam apps but not installed,
             False if never installed in Steam
     """
+    if not is_windows_os:
+        return False
     try:
         # Note : Steam App ID for DCS World is 223750
         dcs_steam_app_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam\\Apps\\223750")
@@ -34,6 +42,8 @@ def is_using_dcs_standalone_edition():
     Check if DCS World standalone edition is installed on this computer
     :return True if Standalone is installed, False if it is not
     """
+    if not is_windows_os:
+        return False
     try:
         dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
         winreg.CloseKey(dcs_path_key)
@@ -126,6 +136,7 @@ def _find_steam_dcs_directory():
 
 
 if __name__ == "__main__":
+    print("Using Windows : " + str(is_windows_os))
     print("Using STEAM Edition : " + str(is_using_dcs_steam_edition()))
     print("Using Standalone Edition : " + str(is_using_dcs_standalone_edition()))
     print("DCS Installation directory : " + get_dcs_install_directory())

--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -71,6 +71,7 @@ def get_dcs_install_directory():
         return _find_steam_dcs_directory()
     else:
         print("Couldn't detect any installed DCS World version")
+        return ""
 
 
 def get_dcs_saved_games_directory():

--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -42,6 +42,35 @@ def is_using_dcs_standalone_edition():
         return False
 
 
+def get_dcs_install_directory():
+    """
+    Get the DCS World install directory for this computer
+    :return DCS World install directory
+    """
+    if is_using_dcs_standalone_edition():
+        try:
+            dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
+            path = winreg.QueryValueEx(dcs_path_key, "Path")
+            dcs_dir = path[0] + os.path.sep
+            winreg.CloseKey(dcs_path_key)
+            return dcs_dir
+        except Exception as e:
+            print("Couldn't detect DCS World installation folder")
+            return ""
+    elif is_using_dcs_steam_edition():
+        return _find_steam_dcs_directory()
+    else:
+        print("Couldn't detect any installed DCS World version")
+
+
+def get_dcs_saved_games_directory():
+    """
+    Get the save game directory for DCS World
+    :return: Save game directory as string
+    """
+    return os.path.join(os.path.expanduser("~"), "Saved Games", "DCS")
+
+
 def _find_steam_directory():
     """
     Get the Steam install directory for this computer from registry
@@ -94,35 +123,6 @@ def _find_steam_dcs_directory():
         if os.path.isdir(folder):
             return folder + os.path.sep
     return ""
-
-
-def get_dcs_install_directory():
-    """
-    Get the DCS World install directory for this computer
-    :return Steam installation path
-    """
-    if is_using_dcs_standalone_edition():
-        try:
-            dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
-            path = winreg.QueryValueEx(dcs_path_key, "Path")
-            dcs_dir = path[0] + os.path.sep
-            winreg.CloseKey(dcs_path_key)
-            return dcs_dir
-        except Exception as e:
-            print("Couldn't detect DCS World installation folder")
-            return ""
-    elif is_using_dcs_steam_edition():
-        return _find_steam_dcs_directory()
-    else:
-        print("Couldn't detect any installed DCS World version")
-
-
-def get_dcs_saved_games_directory():
-    """
-    Get the save game directory for DCS World
-    :return: Save game directory as string
-    """
-    return os.path.join(os.path.expanduser("~"), "Saved Games", "DCS")
 
 
 if __name__ == "__main__":

--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -1,0 +1,132 @@
+"""
+This utility classes provides methods to check players installed DCS environment.
+
+TODO : add method 'is_using_open_beta', 'is_using_stable'
+TODO : [NICE to have] add method to check list of installed DCS modules (could be done either through windows registry, or through filesystem analysis ?)
+"""
+
+import winreg
+import os
+
+
+def is_using_dcs_steam_edition():
+    """
+    Check if DCS World : Steam Edition version is installed on this computer
+    :return True if DCS Steam edition is installed,
+            -1 if DCS Steam Edition is registered in Steam apps but not installed,
+            False if never installed in Steam
+    """
+    try:
+        # Note : Steam App ID for DCS World is 223750
+        dcs_steam_app_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam\\Apps\\223750")
+        installed = winreg.QueryValueEx(dcs_steam_app_key, "Installed")
+        winreg.CloseKey(dcs_steam_app_key)
+        if installed[0] == 1:
+            return True
+        else:
+            return False
+    except FileNotFoundError as fnfe:
+        return False
+
+
+def is_using_dcs_standalone_edition():
+    """
+    Check if DCS World standalone edition is installed on this computer
+    :return True if Standalone is installed, False if it is not
+    """
+    try:
+        dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
+        winreg.CloseKey(dcs_path_key)
+        return True
+    except FileNotFoundError as fnfe:
+        return False
+
+
+def _find_steam_directory():
+    """
+    Get the Steam install directory for this computer from registry
+    :return Steam installation path
+    """
+    try:
+        steam_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam")
+        path = winreg.QueryValueEx(steam_key, "SteamPath")[0]
+        winreg.CloseKey(steam_key)
+        return path
+    except FileNotFoundError as fnfe:
+        print(fnfe)
+        return ""
+
+
+def _get_steam_library_folders():
+    """
+    Get the installation directory for Steam games
+    :return List of Steam library folders where games can be installed
+    """
+    try:
+        steam_dir = _find_steam_directory()
+        """        
+        For reference here is what the vdf file is supposed to look like : 
+
+        "LibraryFolders"
+        {
+            "TimeNextStatsReport"        "1561832478"
+            "ContentStatsID"        "-158337411110787451"
+            "1"        "D:\\Games\\Steam"
+            "2"        "E:\\Steam"
+        }
+        """
+        vdf_file_location = steam_dir + os.path.sep + "steamapps" + os.path.sep + "libraryfolders.vdf"
+        with open(vdf_file_location) as adf_file:
+            paths = [l.split("\"")[3] for l in adf_file.readlines()[1:] if ':\\\\' in l]
+            return paths
+    except Exception as e:
+        print(e)
+        return []
+
+
+def _find_steam_dcs_directory():
+    """
+    Find the DCS install directory for DCS World Steam Edition
+    :return: Install directory as string, empty string if not found
+    """
+    for library_folder in _get_steam_library_folders():
+        folder = library_folder + os.path.sep + "steamapps" + os.path.sep + "common" + os.path.sep + "DCSWorld"
+        if os.path.isdir(folder):
+            return folder + os.path.sep
+    return ""
+
+
+def get_dcs_install_directory():
+    """
+    Get the DCS World install directory for this computer
+    :return Steam installation path
+    """
+    if is_using_dcs_standalone_edition():
+        try:
+            dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
+            path = winreg.QueryValueEx(dcs_path_key, "Path")
+            dcs_dir = path[0] + os.path.sep
+            winreg.CloseKey(dcs_path_key)
+            return dcs_dir
+        except Exception as e:
+            print("Couldn't detect DCS World installation folder")
+            return ""
+    elif is_using_dcs_steam_edition():
+        return _find_steam_dcs_directory()
+    else:
+        print("Couldn't detect any installed DCS World version")
+
+
+def get_dcs_saved_games_directory():
+    """
+    Get the save game directory for DCS World
+    :return: Save game directory as string
+    """
+    return os.path.join(os.path.expanduser("~"), "Saved Games", "DCS")
+
+
+if __name__ == "__main__":
+    print("Using STEAM Edition : " + str(is_using_dcs_steam_edition()))
+    print("Using Standalone Edition : " + str(is_using_dcs_standalone_edition()))
+    print("DCS Installation directory : " + get_dcs_install_directory())
+    print("DCS saved games directory : " + get_dcs_saved_games_directory())

--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -1,4 +1,5 @@
 from . import lua
+from . import installation
 import os
 import re
 
@@ -61,25 +62,17 @@ class FlyingType(UnitType):
 
     pylons = {}
     payloads = None
-    dcs_dir = "C:\\Program Files\\Eagle Dynamics\\DCS World\\"
-    try:
-        import winreg
-        dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
-        path = winreg.QueryValueEx(dcs_path_key, "Path")
-        dcs_dir = path[0] + '\\'
-        winreg.CloseKey(dcs_path_key)
-    except ImportError:
-        pass
+    dcs_dir = installation.get_dcs_install_directory()
     payload_dirs = []
     dcs_aircraft_dir = os.path.join(dcs_dir, "CoreMods", "aircraft")
     if os.path.exists(dcs_aircraft_dir):
-        payload_dirs = [dcs_dir + "MissionEditor\\data\\scripts\\UnitPayloads"]
+        payload_dirs = [dcs_dir + os.path.join("MissionEditor", "data", "scripts", "UnitPayloads")]
         for entry in os.scandir(dcs_aircraft_dir):
             add_dir = os.path.join(dcs_aircraft_dir, entry.name, "UnitPayloads")
             if entry.is_dir() and os.path.exists(add_dir):
                 payload_dirs.append(add_dir)
     payload_dirs += [
-        os.path.join(os.path.expanduser("~"), "Saved Games\\DCS\\MissionEditor\\UnitPayloads"),
+        os.path.join(installation.get_dcs_saved_games_directory(), "MissionEditor", "UnitPayloads"),
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "payloads")
     ]
 


### PR DESCRIPTION
Hello,

I was having an error in 'unittype.py' when using "dcs_liberation" latest version (which is using pydcs). 

The error occured when the code was trying to determine the DCS install directory through the registry here :

https://github.com/pydcs/dcs/blob/5c33c556880247068e7c452ce539670bde976e8c/dcs/unittype.py#L65-L72

The thing is that for Steam edition users, there does not seem to be a "Path" value defined for "HKEY_CURRENT_USER\Software\Eagle Dynamics" in the registry to locate the DCS World installation folder.  

![image](https://user-images.githubusercontent.com/2546901/60300747-f128b400-992f-11e9-9c99-475fd9c8d17c.png)

I could have defined the registry value manually, but then every Steam users using pydcs would have had to do the same which is not ideal.

So i wrote a little module to abstract the search of the install directory (whether it's a steam or standalone version) and retrieve various infomations about the local DCS World installation. For standalone version users, i'm using the same code as before; and for steam users, it's a bit more difficult to find the install directory. The method is to : 

* Find the Steam install directory using the windows registry
* Find the directories where Steam can install games which is defined in a file in Steam installation directory
* Search for a DCSWorld folder in these directories.

(See the new installation.py file)

**Disclaimer :** 
I haven't tested this with DCS Standalone Edition installed on my computer, as i don't have it and didn't really wanted to risk ruining my own 100+Gb Steam DCS installation by installing it; 😁 





