### PR TITLE
Loading improvements

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -1432,7 +1432,8 @@ class AITaskPush(Action):
 
     @classmethod
     def create_from_dict(cls, d, mission):
-        return cls(d["ai_task"][0], d["ai_task"][1])
+        values = list(d["ai_task"].values())
+        return cls(values[0], values[1])
 
     def dict(self):
         d = super(AITaskPush, self).dict()

--- a/dcs/action.py
+++ b/dcs/action.py
@@ -492,6 +492,30 @@ class Explosion(Action):
         return d
 
 
+class Smoke(Action):
+    predicate = "a_effect_smoke"
+
+    def __init__(self, zone="", density=1, preset=1):
+        super(Smoke, self).__init__(Smoke.predicate)
+        self.zone = zone
+        self.params.append(self.zone)
+        self.density = density
+        self.params.append(self.density)
+        self.preset = preset
+        self.params.append(self.preset)
+
+    @classmethod
+    def create_from_dict(cls, d, mission):
+        return cls(d["zone"], d["density"], d["preset"])
+
+    def dict(self):
+        d = super(Smoke, self).dict()
+        d["zone"] = self.zone
+        d["density"] = self.density
+        d["preset"] = self.preset
+        return d
+
+
 class FallInTemplate(Action):
     predicate = "a_fall_in_template"
 
@@ -1552,6 +1576,7 @@ actions_map = {
     "a_explosion_marker": ExplodeWPMarker,
     "a_explosion_marker_unit": ExplodeWPMarkerOnUnit,
     "a_explosion": Explosion,
+    "a_effect_smoke": Smoke,
     "a_fall_in_template": FallInTemplate,
     "a_group_off": GroupAIOff,
     "a_group_on": GroupAIOn,

--- a/dcs/lua/parse.py
+++ b/dcs/lua/parse.py
@@ -302,8 +302,8 @@ def loads(tablestr, _globals: Optional[Dict[str, Any]] = None):
             return varnames
 
         def eat_comment(self):
-            if (self.buffer[self.pos] == '-' and
-               self.pos + 1 < self.buflen and
+            if (self.pos + 1 < self.buflen and
+                self.buffer[self.pos] == '-' and
                self.buffer[self.pos + 1] == '-'):
                 while not self.eob() and self.buffer[self.pos] != '\n':
                     self.pos += 1

--- a/dcs/point.py
+++ b/dcs/point.py
@@ -22,6 +22,7 @@ class PointAction(Enum):
     EchelonLeft = "EchelonL"
     EchelonRight = "EchelonR"
     FromGroundArea = "From Ground Area"
+    FromGroundAreaHot = "From Ground Area Hot"
     Custom = "Custom"
 
 

--- a/dcs/point.py
+++ b/dcs/point.py
@@ -21,6 +21,7 @@ class PointAction(Enum):
     Diamond = "Diamond"
     EchelonLeft = "EchelonL"
     EchelonRight = "EchelonR"
+    FromGroundArea = "From Ground Area"
     Custom = "Custom"
 
 
@@ -91,11 +92,11 @@ class PointProperties:
             self.vangle = 0
 
     def load_from_dict(self, d):
-        self.vnav = VNav(d["vnav"])
-        self.scale = Scale(d["scale"])
-        self.steer = Steer(d["steer"])
-        self.angle = d["angle"]
-        self.vangle = d["vangle"]
+        self.vnav = VNav(d.get("vnav", VNav.VNone.value))
+        self.scale = Scale(d.get("scale", Scale.None_.value))
+        self.steer = Steer(d.get("steer", Steer.None_.value))
+        self.angle = d.get("angle")
+        self.vangle = d.get("vangle")
 
     def dict(self):
         return {

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -811,6 +811,20 @@ class EWR(Task):
         super(EWR, self).__init__(self.Id)
 
 
+class GoToWaypoint(Task):
+    Id = "GoToWaypoint"
+
+    def __init__(self, fromIndex=None, toIndex=None):
+        super(GoToWaypoint, self).__init__(self.Id)
+
+        self.params = {}
+        if fromIndex:
+            self.params["fromWaypointIndex"] = fromIndex
+
+        if toIndex:
+            self.params["nWaypointIndx"] = toIndex
+
+
 tasks_map = {
     ControlledTask.Id: ControlledTask,
     EscortTaskAction.Id: EscortTaskAction,
@@ -835,6 +849,7 @@ tasks_map = {
     DisembarkFromTransport.Id: DisembarkFromTransport,
     CargoTransportation.Id: CargoTransportation,
     EWR.Id: EWR,
+    GoToWaypoint.Id: GoToWaypoint,
 }
 
 
@@ -1345,10 +1360,6 @@ class OptEngageAirWeapons(Option):
     def __init__(self, value=None):
         super(OptEngageAirWeapons, self).__init__(value)
 
-<<<<<<< HEAD
-
-=======
->>>>>>> Improved .miz loading compatibility; Added new tasks and options; Fixed invalid FARP instantiation
 class OptNoReportWaypointPass(Option):
     Key = 19
 
@@ -1363,7 +1374,6 @@ class OptRestrictAirToAirAttack(Option):
         super(OptRestrictAirToAirAttack, self).__init__(value)
 
 
-<<<<<<< HEAD
 class OptRTBOnOutOfAmmo(Option):
     Key = 10
 
@@ -1385,6 +1395,13 @@ class OptRestrictJettison(Option):
         super(OptRestrictJettison, self).__init__(value)
 
 
+class OptRadarUsing(Option):
+    Key = 3
+
+    def __init__(self, value=None):
+        super(OptRadarUsing, self).__init__(value)
+
+
 options = {
     OptDisparseUnderFire.Key: OptDisparseUnderFire,
     OptReactOnThreat.Key: OptReactOnThreat,
@@ -1396,4 +1413,5 @@ options = {
     OptRTBOnOutOfAmmo.Key: OptRTBOnOutOfAmmo,
     OptRTBOnBingoFuel.Key: OptRTBOnBingoFuel,
     OptRestrictJettison.Key: OptRestrictJettison,
+    OptRadarUsing.Key: OptRadarUsing,
 }

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -21,7 +21,7 @@ def _create_from_dict(d):
         else:
             t = wrappedactions[actionid].create_from_dict(d)
     elif _id == "EngageTargets":
-        t = engagetargets_tasks[d["key"]].create_from_dict(d)
+        t = engagetargets_tasks[d.get("key")].create_from_dict(d)
     else:
         t = tasks_map[_id].create_from_dict(d)
 
@@ -386,12 +386,22 @@ class FighterSweepTaskAction(Task):
         d["key"] = FighterSweepTaskAction.Key
         return d
 
+
+class EmptyTaskAction(Task):
+    @classmethod
+    def create_from_dict(cls, d):
+        t = cls(d["id"])
+        t.params = d["params"]
+        return t
+
+
 engagetargets_tasks = {
     AntishipStrikeTaskAction.Key: AntishipStrikeTaskAction,
     CASTaskAction.Key: CASTaskAction,
     CAPTaskAction.Key: CAPTaskAction,
     SEADTaskAction.Key: SEADTaskAction,
-    FighterSweepTaskAction.Key: FighterSweepTaskAction
+    FighterSweepTaskAction.Key: FighterSweepTaskAction,
+    None: EmptyTaskAction,
 }
 
 
@@ -794,6 +804,13 @@ class CargoTransportation(Task):
             self.params["zoneId"] = zoneid
 
 
+class EWR(Task):
+    Id = "EWR"
+
+    def __init__(self):
+        super(EWR, self).__init__(self.Id)
+
+
 tasks_map = {
     ControlledTask.Id: ControlledTask,
     EscortTaskAction.Id: EscortTaskAction,
@@ -816,7 +833,8 @@ tasks_map = {
     Embarking.Id: Embarking,
     EmbarkToTransport.Id: EmbarkToTransport,
     DisembarkFromTransport.Id: DisembarkFromTransport,
-    CargoTransportation.Id: CargoTransportation
+    CargoTransportation.Id: CargoTransportation,
+    EWR.Id: EWR,
 }
 
 
@@ -1327,7 +1345,10 @@ class OptEngageAirWeapons(Option):
     def __init__(self, value=None):
         super(OptEngageAirWeapons, self).__init__(value)
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Improved .miz loading compatibility; Added new tasks and options; Fixed invalid FARP instantiation
 class OptNoReportWaypointPass(Option):
     Key = 19
 
@@ -1342,6 +1363,7 @@ class OptRestrictAirToAirAttack(Option):
         super(OptRestrictAirToAirAttack, self).__init__(value)
 
 
+<<<<<<< HEAD
 class OptRTBOnOutOfAmmo(Option):
     Key = 10
 

--- a/dcs/triggers.py
+++ b/dcs/triggers.py
@@ -173,15 +173,15 @@ class TriggerContinious(TriggerRule):
 class TriggerStart(TriggerRule):
     predicate = "triggerStart"
 
-    def __init__(self, comment=""):
-        super(TriggerStart, self).__init__(Event.NoEvent, comment)
+    def __init__(self, event: Event =Event.NoEvent, comment=""):
+        super(TriggerStart, self).__init__(event, comment)
 
 
 class TriggerCondition(TriggerRule):
     predicate = "triggerFront"
 
-    def __init__(self, comment=""):
-        super(TriggerCondition, self).__init__(Event.NoEvent, comment)
+    def __init__(self, event: Event =Event.NoEvent, comment=""):
+        super(TriggerCondition, self).__init__(event, comment)
 
 trigger_map = {
     TriggerOnce.predicate: TriggerOnce,

--- a/dcs/triggers.py
+++ b/dcs/triggers.py
@@ -84,6 +84,7 @@ class Event(Enum):
     TookControl = "took control"
     RefuelStop = "refuel stop"
     Failure = "failure"
+    MissionStart="mission start"
 
 
 class TriggerRule:

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -333,9 +333,9 @@ class FARP(Static):
 
     def load_from_dict(self, d):
         super(FARP, self).load_from_dict(d)
-        self.heliport_frequency = d["heliport_frequency"]
-        self.heliport_modulation = d["heliport_modulation"]
-        self.heliport_callsign_id = int(d["heliport_callsign_id"])
+        self.heliport_frequency = d.get("heliport_frequency")
+        self.heliport_modulation = d.get("heliport_modulation")
+        self.heliport_callsign_id = d.get("heliport_callsign_id", 0)
 
     def dict(self):
         d = super(FARP, self).dict()

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -213,7 +213,9 @@ class MovingGroup(Group):
         self.task = d.get("task")  # ships don't have a task
         self.spawn_probability = d.get("probability", 1.0)
         for t in d.get("tasks", []):
-            self.tasks.append(task._create_from_dict(d["task"]["params"]["tasks"][t]))
+            task_dict = d["tasks"][t]
+            self.tasks.append(task._create_from_dict(task_dict))
+
         self.task_selected = d.get("taskSelected", False)
         self.late_activation = d.get("lateActivation", False)
 


### PR DESCRIPTION
Same PR as before, but I've omitted parser commit and rebased to current master.

One thing I'm not sure about is that I've changed constructor signature of `TriggerStart` and `TriggerCondition` to be in line of the other `Trigger` classes, and I'm not sure whether that was the mistake or it should've been fixed elsewhere (`TriggerRule/create_from_dict` will always invoke constructor with two arguments - `event` and `comment`). I don't have enough time to investigate so it would be great if you can comment on this.

## Original description:

### Lots of minor additions to support some specific .miz files.
I've loaded mission file of GAW/PGAW and those were the only fixes I needed to implement. A couple of new options as well, but I was too lazy to add enums for them as well.
Good job @rp- , those were the only fixes I needed to implement, and mission file was 112k lines long!

### Preserve miscellaneous files in archive
So pretty much anything that was in loaded .miz will be included during saving. The missions that I've loaded included stuff like Config and Kneeboard folders which were ignored during loading.