### PR TITLE
data-export: version 2.5.6.49798

### DIFF
--- a/dcs/__init__.py
+++ b/dcs/__init__.py
@@ -19,5 +19,6 @@ from . import condition
 from . import action
 from . import forcedoptions
 from . import installation
+from . import nav_target_point
 from .mapping import Point, Rectangle, Polygon
 from .mission import Mission

--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -102,7 +102,7 @@ class Russia(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             ARV_BTR_RD = vehicles.Armor.ARV_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
@@ -111,6 +111,9 @@ class Russia(Country):
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             MBT_T_90 = vehicles.Armor.MBT_T_90
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -190,6 +193,8 @@ class Russia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -249,6 +254,8 @@ class Russia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -294,6 +301,7 @@ class Russia(Country):
         FFG_11540_Neustrashimy = ships.FFG_11540_Neustrashimy
         Bulk_cargo_ship_Yakushev = ships.Bulk_cargo_ship_Yakushev
         Dry_cargo_ship_Ivanov = ships.Dry_cargo_ship_Ivanov
+        CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
 
     class CallsignHelipad:
         Otkrytka = "Otkrytka"
@@ -439,6 +447,9 @@ class Ukraine(Country):
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -446,7 +457,6 @@ class Ukraine(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_a_tank_yellow = vehicles.Carriage.Coach_a_tank_yellow
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
@@ -486,6 +496,7 @@ class Ukraine(Country):
         Tu_142 = planes.Tu_142
         Tu_160 = planes.Tu_160
         Yak_52 = planes.Yak_52
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -508,6 +519,8 @@ class Ukraine(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -536,6 +549,7 @@ class Ukraine(Country):
         Plane.Tu_142,
         Plane.Tu_160,
         Plane.Yak_52,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -558,6 +572,8 @@ class Ukraine(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -638,13 +654,9 @@ class USA(Country):
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
             AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
-            AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
-            SAM_SA_18_Igla_MANPADS = vehicles.AirDefence.SAM_SA_18_Igla_MANPADS
-            SAM_SA_18_Igla_comm = vehicles.AirDefence.SAM_SA_18_Igla_comm
             Rapier_FSA_Launcher = vehicles.AirDefence.Rapier_FSA_Launcher
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
@@ -683,14 +695,16 @@ class USA(Country):
             SPG_M1128_Stryker_MGS = vehicles.Armor.SPG_M1128_Stryker_MGS
             ATGM_M1134_Stryker = vehicles.Armor.ATGM_M1134_Stryker
             APC_M2A1 = vehicles.Armor.APC_M2A1
-            APC_MTLB = vehicles.Armor.APC_MTLB
             TPz_Fuchs = vehicles.Armor.TPz_Fuchs
-            ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
 
         class Locomotive:
             ES44AH = vehicles.Locomotive.ES44AH
@@ -700,11 +714,15 @@ class USA(Country):
 
         class Carriage:
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Wellcarnsc = vehicles.Carriage.Wellcarnsc
             Boxcartrinity = vehicles.Carriage.Boxcartrinity
             Tankcartrinity = vehicles.Carriage.Tankcartrinity
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -738,6 +756,7 @@ class USA(Country):
         S_3B_Tanker = planes.S_3B_Tanker
         S_3B = planes.S_3B
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         An_26B = planes.An_26B
         B_17G = planes.B_17G
         F_16A_MLU = planes.F_16A_MLU
@@ -752,7 +771,6 @@ class USA(Country):
         L_39C = planes.L_39C
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
-        Su_27 = planes.Su_27
         MQ_9_Reaper = planes.MQ_9_Reaper
         Christen_Eagle_II = planes.Christen_Eagle_II
         AV8BNA = planes.AV8BNA
@@ -772,7 +790,8 @@ class USA(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -797,6 +816,7 @@ class USA(Country):
         Plane.S_3B_Tanker,
         Plane.S_3B,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.An_26B,
         Plane.B_17G,
         Plane.F_16A_MLU,
@@ -811,7 +831,6 @@ class USA(Country):
         Plane.L_39C,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
-        Plane.Su_27,
         Plane.MQ_9_Reaper,
         Plane.Christen_Eagle_II,
         Plane.AV8BNA,
@@ -831,7 +850,8 @@ class USA(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -879,6 +899,10 @@ class USA(Country):
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         LHA_1_Tarawa = ships.LHA_1_Tarawa
+        USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
+        CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
+        CVN_73_George_Washington = ships.CVN_73_George_Washington
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -1058,7 +1082,6 @@ class Turkey(Country):
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
-            TPz_Fuchs = vehicles.Armor.TPz_Fuchs
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
 
@@ -1091,9 +1114,11 @@ class Turkey(Country):
         KC_135 = planes.KC_135
         C_17A = planes.C_17A
         E_3A = planes.E_3A
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_86F_Sabre = planes.F_86F_Sabre
         KC135MPRS = planes.KC135MPRS
         RQ_1A_Predator = planes.RQ_1A_Predator
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -1117,6 +1142,8 @@ class Turkey(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -1128,9 +1155,11 @@ class Turkey(Country):
         Plane.KC_135,
         Plane.C_17A,
         Plane.E_3A,
+        Plane.F_16C_bl_52d,
         Plane.F_86F_Sabre,
         Plane.KC135MPRS,
         Plane.RQ_1A_Predator,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -1154,6 +1183,8 @@ class Turkey(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -1240,12 +1271,16 @@ class UK(Country):
             TPz_Fuchs = vehicles.Armor.TPz_Fuchs
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -1254,9 +1289,6 @@ class UK(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -1276,7 +1308,7 @@ class UK(Country):
         C_130 = planes.C_130
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
-        B_17G = planes.B_17G
+        TF_51D = planes.TF_51D
         C_17A = planes.C_17A
         E_3A = planes.E_3A
         SpitfireLFMkIX = planes.SpitfireLFMkIX
@@ -1305,7 +1337,9 @@ class UK(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        B_17G = planes.B_17G
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -1313,7 +1347,7 @@ class UK(Country):
         Plane.C_130,
         Plane.P_51D,
         Plane.P_51D_30_NA,
-        Plane.B_17G,
+        Plane.TF_51D,
         Plane.C_17A,
         Plane.E_3A,
         Plane.SpitfireLFMkIX,
@@ -1342,7 +1376,9 @@ class UK(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.B_17G,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -1440,9 +1476,13 @@ class France(Country):
             APC_M2A1 = vehicles.Armor.APC_M2A1
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -1451,7 +1491,6 @@ class France(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -1470,7 +1509,6 @@ class France(Country):
         Mirage_2000_5 = planes.Mirage_2000_5
         C_130 = planes.C_130
         P_51D = planes.P_51D
-        B_17G = planes.B_17G
         C_17A = planes.C_17A
         E_2C = planes.E_2C
         E_3A = planes.E_3A
@@ -1482,6 +1520,7 @@ class France(Country):
         MQ_9_Reaper = planes.MQ_9_Reaper
         M_2000C = planes.M_2000C
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         P_51D_30_NA = planes.P_51D_30_NA
         AJS37 = planes.AJS37
@@ -1500,6 +1539,8 @@ class France(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -1507,7 +1548,6 @@ class France(Country):
         Plane.Mirage_2000_5,
         Plane.C_130,
         Plane.P_51D,
-        Plane.B_17G,
         Plane.C_17A,
         Plane.E_2C,
         Plane.E_3A,
@@ -1519,6 +1559,7 @@ class France(Country):
         Plane.MQ_9_Reaper,
         Plane.M_2000C,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.P_51D_30_NA,
         Plane.AJS37,
@@ -1537,6 +1578,8 @@ class France(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -1639,12 +1682,15 @@ class Germany(Country):
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -1696,11 +1742,17 @@ class Germany(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
@@ -1709,7 +1761,6 @@ class Germany(Country):
             ES44AH = vehicles.Locomotive.ES44AH
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_covered_wagon_G10 = vehicles.Carriage.German_covered_wagon_G10
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
@@ -1760,6 +1811,8 @@ class Germany(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -1799,6 +1852,8 @@ class Germany(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.MiG_19P,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -1823,6 +1878,8 @@ class Germany(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Germany, self).__init__(Germany.id, Germany.name)
@@ -1865,12 +1922,15 @@ class USAFAggressors(Country):
             Infantry_SMLE_No_4_Mk_1 = vehicles.Infantry.Infantry_SMLE_No_4_Mk_1
 
         class AirDefence:
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
             EWR_1L13 = vehicles.AirDefence.EWR_1L13
             SAM_SA_19_Tunguska_2S6 = vehicles.AirDefence.SAM_SA_19_Tunguska_2S6
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
@@ -1995,16 +2055,18 @@ class USAFAggressors(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             ARV_BTR_RD = vehicles.Armor.ARV_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
@@ -2014,9 +2076,13 @@ class USAFAggressors(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
@@ -2033,8 +2099,8 @@ class USAFAggressors(Country):
             MBT_Merkava_Mk__4 = vehicles.Armor.MBT_Merkava_Mk__4
             IFV_Marder = vehicles.Armor.IFV_Marder
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
-            ZTZ_96B = vehicles.Armor.ZTZ_96B
             ZBD_04A = vehicles.Armor.ZBD_04A
+            ZTZ_96B = vehicles.Armor.ZTZ_96B
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             APC_M1126_Stryker_ICV = vehicles.Armor.APC_M1126_Stryker_ICV
             SPG_M1128_Stryker_MGS = vehicles.Armor.SPG_M1128_Stryker_MGS
@@ -2042,6 +2108,8 @@ class USAFAggressors(Country):
             IFV_MCV_80 = vehicles.Armor.IFV_MCV_80
 
         class MissilesSS:
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
             Silkworm_Radar = vehicles.MissilesSS.Silkworm_Radar
 
@@ -2068,9 +2136,14 @@ class USAFAggressors(Country):
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
 
     class Plane:
         A_10C = planes.A_10C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -2095,6 +2168,8 @@ class USAFAggressors(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         A_50 = planes.A_50
         An_26B = planes.An_26B
         An_30M = planes.An_30M
@@ -2109,6 +2184,7 @@ class USAFAggressors(Country):
         MiG_29A = planes.MiG_29A
         MiG_31 = planes.MiG_31
         P_51D = planes.P_51D
+        TF_51D = planes.TF_51D
         Su_17M4 = planes.Su_17M4
         Su_24M = planes.Su_24M
         Su_24MR = planes.Su_24MR
@@ -2122,6 +2198,8 @@ class USAFAggressors(Country):
         Yak_40 = planes.Yak_40
         C_130 = planes.C_130
         MiG_29S = planes.MiG_29S
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_16A_MLU = planes.F_16A_MLU
         Tornado_IDS = planes.Tornado_IDS
         P_51D_30_NA = planes.P_51D_30_NA
@@ -2130,10 +2208,8 @@ class USAFAggressors(Country):
         F_16A = planes.F_16A
         MQ_9_Reaper = planes.MQ_9_Reaper
         RQ_1A_Predator = planes.RQ_1A_Predator
-        TF_51D = planes.TF_51D
         F_A_18C = planes.F_A_18C
         F_4E = planes.F_4E
-        FW_190A8 = planes.FW_190A8
         Su_33 = planes.Su_33
         Su_25TM = planes.Su_25TM
         Su_30 = planes.Su_30
@@ -2142,12 +2218,10 @@ class USAFAggressors(Country):
         F_15C = planes.F_15C
         F_15E = planes.F_15E
         KC_135 = planes.KC_135
-        F_16C_bl_52d = planes.F_16C_bl_52d
         E_2C = planes.E_2C
         MiG_29G = planes.MiG_29G
         Mirage_2000_5 = planes.Mirage_2000_5
         F_A_18A = planes.F_A_18A
-        F_16C_bl_50 = planes.F_16C_bl_50
         KJ_2000 = planes.KJ_2000
         A_10A = planes.A_10A
         B_1B = planes.B_1B
@@ -2161,6 +2235,7 @@ class USAFAggressors(Country):
 
     planes = [
         Plane.A_10C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -2185,6 +2260,8 @@ class USAFAggressors(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.A_50,
         Plane.An_26B,
         Plane.An_30M,
@@ -2199,6 +2276,7 @@ class USAFAggressors(Country):
         Plane.MiG_29A,
         Plane.MiG_31,
         Plane.P_51D,
+        Plane.TF_51D,
         Plane.Su_17M4,
         Plane.Su_24M,
         Plane.Su_24MR,
@@ -2212,6 +2290,8 @@ class USAFAggressors(Country):
         Plane.Yak_40,
         Plane.C_130,
         Plane.MiG_29S,
+        Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.F_16A_MLU,
         Plane.Tornado_IDS,
         Plane.P_51D_30_NA,
@@ -2220,10 +2300,8 @@ class USAFAggressors(Country):
         Plane.F_16A,
         Plane.MQ_9_Reaper,
         Plane.RQ_1A_Predator,
-        Plane.TF_51D,
         Plane.F_A_18C,
         Plane.F_4E,
-        Plane.FW_190A8,
         Plane.Su_33,
         Plane.Su_25TM,
         Plane.Su_30,
@@ -2232,12 +2310,10 @@ class USAFAggressors(Country):
         Plane.F_15C,
         Plane.F_15E,
         Plane.KC_135,
-        Plane.F_16C_bl_52d,
         Plane.E_2C,
         Plane.MiG_29G,
         Plane.Mirage_2000_5,
         Plane.F_A_18A,
-        Plane.F_16C_bl_50,
         Plane.KJ_2000,
         Plane.A_10A,
         Plane.B_1B,
@@ -2295,7 +2371,10 @@ class USAFAggressors(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
         FFL_1124_4_Grisha = ships.FFL_1124_4_Grisha
+        SSK_877 = ships.SSK_877
         Bulk_cargo_ship_Yakushev = ships.Bulk_cargo_ship_Yakushev
         Dry_cargo_ship_Ivanov = ships.Dry_cargo_ship_Ivanov
         Tanker_Elnya_160 = ships.Tanker_Elnya_160
@@ -2309,16 +2388,21 @@ class USAFAggressors(Country):
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         LCVP__Higgins_boat = ships.LCVP__Higgins_boat
+        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
         CGN_1144_2_Pyotr_Velikiy = ships.CGN_1144_2_Pyotr_Velikiy
-        SSK_877 = ships.SSK_877
+        CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
-        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
+        Type_093 = ships.Type_093
         CVN_70_Carl_Vinson = ships.CVN_70_Carl_Vinson
         Ticonderoga_class = ships.Ticonderoga_class
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LHA_1_Tarawa = ships.LHA_1_Tarawa
+        USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
+        CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
+        CVN_73_George_Washington = ships.CVN_73_George_Washington
 
     def __init__(self):
         super(USAFAggressors, self).__init__(USAFAggressors.id, USAFAggressors.name)
@@ -2368,8 +2452,12 @@ class Canada(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             APC_M2A1 = vehicles.Armor.APC_M2A1
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -2397,11 +2485,13 @@ class Canada(Country):
         P_51D = planes.P_51D
         F_A_18C = planes.F_A_18C
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_17A = planes.C_17A
         E_3A = planes.E_3A
         F_86F_Sabre = planes.F_86F_Sabre
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -2422,7 +2512,8 @@ class Canada(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -2430,11 +2521,13 @@ class Canada(Country):
         Plane.P_51D,
         Plane.F_A_18C,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_17A,
         Plane.E_3A,
         Plane.F_86F_Sabre,
         Plane.Hawk,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -2455,7 +2548,8 @@ class Canada(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -2510,7 +2604,7 @@ class Spain(Country):
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             SAM_Patriot_AMG_AN_MRC_137 = vehicles.AirDefence.SAM_Patriot_AMG_AN_MRC_137
             SAM_Patriot_ECS_AN_MSQ_104 = vehicles.AirDefence.SAM_Patriot_ECS_AN_MSQ_104
             SAM_Patriot_LN_M901 = vehicles.AirDefence.SAM_Patriot_LN_M901
@@ -2597,6 +2691,8 @@ class Spain(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -2633,6 +2729,8 @@ class Spain(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -2659,6 +2757,7 @@ class Spain(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
 
     def __init__(self):
         super(Spain, self).__init__(Spain.id, Spain.name)
@@ -2728,7 +2827,11 @@ class TheNetherlands(Country):
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
@@ -2756,11 +2859,13 @@ class TheNetherlands(Country):
         F_16A_MLU = planes.F_16A_MLU
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_17A = planes.C_17A
         E_3A = planes.E_3A
         F_16A = planes.F_16A
         F_16C_bl_50 = planes.F_16C_bl_50
         MQ_9_Reaper = planes.MQ_9_Reaper
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -2784,7 +2889,8 @@ class TheNetherlands(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -2792,11 +2898,13 @@ class TheNetherlands(Country):
         Plane.F_16A_MLU,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_17A,
         Plane.E_3A,
         Plane.F_16A,
         Plane.F_16C_bl_50,
         Plane.MQ_9_Reaper,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -2820,7 +2928,8 @@ class TheNetherlands(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -2905,7 +3014,11 @@ class Belgium(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -2935,6 +3048,7 @@ class Belgium(Country):
         C_17A = planes.C_17A
         E_3A = planes.E_3A
         F_16A = planes.F_16A
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -2959,6 +3073,8 @@ class Belgium(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -2969,6 +3085,7 @@ class Belgium(Country):
         Plane.C_17A,
         Plane.E_3A,
         Plane.F_16A,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -2993,6 +3110,8 @@ class Belgium(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -3097,6 +3216,7 @@ class Norway(Country):
         E_3A = planes.E_3A
         F_16A = planes.F_16A
         F_86F_Sabre = planes.F_86F_Sabre
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -3120,6 +3240,8 @@ class Norway(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -3131,6 +3253,7 @@ class Norway(Country):
         Plane.E_3A,
         Plane.F_16A,
         Plane.F_86F_Sabre,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -3154,6 +3277,8 @@ class Norway(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -3255,9 +3380,9 @@ class Denmark(Country):
         P_51D = planes.P_51D
         B_17G = planes.B_17G
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         F_16A = planes.F_16A
         F_86F_Sabre = planes.F_86F_Sabre
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -3281,6 +3406,8 @@ class Denmark(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -3290,9 +3417,9 @@ class Denmark(Country):
         Plane.P_51D,
         Plane.B_17G,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.F_16A,
         Plane.F_86F_Sabre,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -3316,6 +3443,8 @@ class Denmark(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -3403,8 +3532,10 @@ class Israel(Country):
             APC_M2A1 = vehicles.Armor.APC_M2A1
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -3413,8 +3544,6 @@ class Israel(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -3437,13 +3566,16 @@ class Israel(Country):
         F_4E = planes.F_4E
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         B_17G = planes.B_17G
         E_2C = planes.E_2C
         F_16A = planes.F_16A
+        F_16C_bl_50 = planes.F_16C_bl_50
         MiG_21Bis = planes.MiG_21Bis
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
@@ -3463,7 +3595,8 @@ class Israel(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -3474,13 +3607,16 @@ class Israel(Country):
         Plane.F_4E,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.B_17G,
         Plane.E_2C,
         Plane.F_16A,
+        Plane.F_16C_bl_50,
         Plane.MiG_21Bis,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.AJS37,
         Plane.AV8BNA,
@@ -3500,7 +3636,8 @@ class Israel(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -3659,6 +3796,7 @@ class Georgia(Country):
         P_51D = planes.P_51D
         L_39C = planes.L_39C
         Yak_52 = planes.Yak_52
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -3681,6 +3819,8 @@ class Georgia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
     planes = [
@@ -3693,6 +3833,7 @@ class Georgia(Country):
         Plane.P_51D,
         Plane.L_39C,
         Plane.Yak_52,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -3715,6 +3856,8 @@ class Georgia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
+        Plane.A_20G,
+        Plane.Ju_88A4,
         Plane.TF_51D,
     ]
 
@@ -3841,6 +3984,7 @@ class Insurgents(Country):
 
     class Plane:
         P_51D = planes.P_51D
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -3864,9 +4008,12 @@ class Insurgents(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.P_51D,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -3890,6 +4037,8 @@ class Insurgents(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4028,6 +4177,8 @@ class Abkhazia(Country):
         P_51D = planes.P_51D
         L_39C = planes.L_39C
         Yak_52 = planes.Yak_52
+        TF_51D = planes.TF_51D
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4050,7 +4201,8 @@ class Abkhazia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.Su_25,
@@ -4059,6 +4211,8 @@ class Abkhazia(Country):
         Plane.P_51D,
         Plane.L_39C,
         Plane.Yak_52,
+        Plane.TF_51D,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4081,7 +4235,8 @@ class Abkhazia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4211,6 +4366,7 @@ class SouthOssetia(Country):
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
 
     class Plane:
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4234,8 +4390,11 @@ class SouthOssetia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4259,6 +4418,8 @@ class SouthOssetia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4361,6 +4522,7 @@ class Italy(Country):
         P_51D = planes.P_51D
         Tornado_IDS = planes.Tornado_IDS
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_17A = planes.C_17A
         E_3A = planes.E_3A
         F_16A = planes.F_16A
@@ -4369,6 +4531,7 @@ class Italy(Country):
         RQ_1A_Predator = planes.RQ_1A_Predator
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4390,7 +4553,8 @@ class Italy(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -4399,6 +4563,7 @@ class Italy(Country):
         Plane.P_51D,
         Plane.Tornado_IDS,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_17A,
         Plane.E_3A,
         Plane.F_16A,
@@ -4407,6 +4572,7 @@ class Italy(Country):
         Plane.RQ_1A_Predator,
         Plane.AV8BNA,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4428,7 +4594,8 @@ class Italy(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4502,9 +4669,13 @@ class Australia(Country):
             APC_M113 = vehicles.Armor.APC_M113
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             APC_M2A1 = vehicles.Armor.APC_M2A1
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             ES44AH = vehicles.Locomotive.ES44AH
@@ -4532,11 +4703,13 @@ class Australia(Country):
         P_51D = planes.P_51D
         F_A_18C = planes.F_A_18C
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_17A = planes.C_17A
         F_4E = planes.F_4E
         F_A_18A = planes.F_A_18A
         MQ_9_Reaper = planes.MQ_9_Reaper
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4559,7 +4732,8 @@ class Australia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        TF_51D = planes.TF_51D
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -4567,11 +4741,13 @@ class Australia(Country):
         Plane.P_51D,
         Plane.F_A_18C,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_17A,
         Plane.F_4E,
         Plane.F_A_18A,
         Plane.MQ_9_Reaper,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4594,7 +4770,8 @@ class Australia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.TF_51D,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4620,6 +4797,7 @@ class Australia(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         LCVP__Higgins_boat = ships.LCVP__Higgins_boat
@@ -4689,8 +4867,10 @@ class Switzerland(Country):
         F_A_18C = planes.F_A_18C
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         F_5E_3 = planes.F_5E_3
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4712,14 +4892,18 @@ class Switzerland(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.F_A_18C,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.F_5E_3,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4741,6 +4925,8 @@ class Switzerland(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4771,11 +4957,6 @@ class Austria(Country):
 
     class Vehicle:
 
-        class Artillery:
-            MLRS_9A52_Smerch = vehicles.Artillery.MLRS_9A52_Smerch
-            MLRS_9A52_Smerch = vehicles.Artillery.MLRS_9A52_Smerch
-            MLRS_9A52_Smerch = vehicles.Artillery.MLRS_9A52_Smerch
-
         class AirDefence:
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
@@ -4794,7 +4975,9 @@ class Austria(Country):
 
         class Armor:
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
@@ -4803,7 +4986,6 @@ class Austria(Country):
             ES44AH = vehicles.Locomotive.ES44AH
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_covered_wagon_G10 = vehicles.Carriage.German_covered_wagon_G10
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
@@ -4822,6 +5004,7 @@ class Austria(Country):
         C_130 = planes.C_130
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -4843,12 +5026,15 @@ class Austria(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.C_130,
         Plane.F_5E,
         Plane.F_5E_3,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -4870,6 +5056,8 @@ class Austria(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -4987,13 +5175,16 @@ class Belarus(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             ARV_BTR_RD = vehicles.Armor.ARV_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -5002,7 +5193,6 @@ class Belarus(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_a_tank_yellow = vehicles.Carriage.Coach_a_tank_yellow
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
@@ -5032,6 +5222,7 @@ class Belarus(Country):
         MiG_25PD = planes.MiG_25PD
         Su_30 = planes.Su_30
         Yak_52 = planes.Yak_52
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -5053,6 +5244,8 @@ class Belarus(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -5070,6 +5263,7 @@ class Belarus(Country):
         Plane.MiG_25PD,
         Plane.Su_30,
         Plane.Yak_52,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -5091,6 +5285,8 @@ class Belarus(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -5157,11 +5353,14 @@ class Bulgaria(Country):
             SAM_SA_18_Igla_MANPADS = vehicles.AirDefence.SAM_SA_18_Igla_MANPADS
             SAM_SA_18_Igla_comm = vehicles.AirDefence.SAM_SA_18_Igla_comm
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -5202,11 +5401,17 @@ class Bulgaria(Country):
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -5215,7 +5420,6 @@ class Bulgaria(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -5234,7 +5438,6 @@ class Bulgaria(Country):
         L_39ZA = planes.L_39ZA
         An_26B = planes.An_26B
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         MiG_15bis = planes.MiG_15bis
         MiG_21Bis = planes.MiG_21Bis
         MiG_23MLD = planes.MiG_23MLD
@@ -5244,6 +5447,8 @@ class Bulgaria(Country):
         Su_25 = planes.Su_25
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -5263,14 +5468,14 @@ class Bulgaria(Country):
         I_16 = planes.I_16
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.L_39ZA,
         Plane.An_26B,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.MiG_15bis,
         Plane.MiG_21Bis,
         Plane.MiG_23MLD,
@@ -5280,6 +5485,8 @@ class Bulgaria(Country):
         Plane.Su_25,
         Plane.Yak_40,
         Plane.Yak_52,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -5299,7 +5506,8 @@ class Bulgaria(Country):
         Plane.I_16,
         Plane.L_39C,
         Plane.M_2000C,
-        Plane.MiG_19P,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -5321,6 +5529,8 @@ class Bulgaria(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Bulgaria, self).__init__(Bulgaria.id, Bulgaria.name)
@@ -5380,9 +5590,16 @@ class CzechRepublic(Country):
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             APC_M2A1 = vehicles.Armor.APC_M2A1
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -5391,7 +5608,6 @@ class CzechRepublic(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -5409,12 +5625,12 @@ class CzechRepublic(Country):
         A_10C = planes.A_10C
         L_39ZA = planes.L_39ZA
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         L_39C = planes.L_39C
         MiG_29A = planes.MiG_29A
         Su_17M4 = planes.Su_17M4
         Su_25 = planes.Su_25
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -5437,17 +5653,19 @@ class CzechRepublic(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.L_39ZA,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.L_39C,
         Plane.MiG_29A,
         Plane.Su_17M4,
         Plane.Su_25,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -5470,6 +5688,8 @@ class CzechRepublic(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -5519,7 +5739,7 @@ class China(Country):
             SAM_SA_10_S_300PS_CP_54K6 = vehicles.AirDefence.SAM_SA_10_S_300PS_CP_54K6
             SAM_SR_P_19 = vehicles.AirDefence.SAM_SR_P_19
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_ZU_23_on_Ural_375 = vehicles.AirDefence.AAA_ZU_23_on_Ural_375
@@ -5547,8 +5767,8 @@ class China(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            ZTZ_96B = vehicles.Armor.ZTZ_96B
             ZBD_04A = vehicles.Armor.ZBD_04A
+            ZTZ_96B = vehicles.Armor.ZTZ_96B
 
         class MissilesSS:
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
@@ -5583,13 +5803,14 @@ class China(Country):
         An_30M = planes.An_30M
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
-        B_17G = planes.B_17G
-        C_130 = planes.C_130
+        TF_51D = planes.TF_51D
         MiG_15bis = planes.MiG_15bis
         Su_30 = planes.Su_30
         I_16 = planes.I_16
         J_11A = planes.J_11A
         KJ_2000 = planes.KJ_2000
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -5608,9 +5829,10 @@ class China(Country):
         Hawk = planes.Hawk
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -5621,13 +5843,14 @@ class China(Country):
         Plane.An_30M,
         Plane.P_51D,
         Plane.P_51D_30_NA,
-        Plane.B_17G,
-        Plane.C_130,
+        Plane.TF_51D,
         Plane.MiG_15bis,
         Plane.Su_30,
         Plane.I_16,
         Plane.J_11A,
         Plane.KJ_2000,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -5646,9 +5869,10 @@ class China(Country):
         Plane.Hawk,
         Plane.L_39C,
         Plane.M_2000C,
-        Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -5656,8 +5880,6 @@ class China(Country):
         Mi_8MT = helicopters.Mi_8MT
         Mi_26 = helicopters.Mi_26
         Ka_27 = helicopters.Ka_27
-        CH_47D = helicopters.CH_47D
-        UH_60A = helicopters.UH_60A
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -5668,8 +5890,6 @@ class China(Country):
         Helicopter.Mi_8MT,
         Helicopter.Mi_26,
         Helicopter.Ka_27,
-        Helicopter.CH_47D,
-        Helicopter.UH_60A,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -5678,9 +5898,11 @@ class China(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        SSK_877 = ships.SSK_877
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
+        Type_093 = ships.Type_093
 
     def __init__(self):
         super(China, self).__init__(China.id, China.name)
@@ -5741,8 +5963,8 @@ class Croatia(Country):
     class Plane:
         A_10C = planes.A_10C
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         MiG_21Bis = planes.MiG_21Bis
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -5765,12 +5987,14 @@ class Croatia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.MiG_21Bis,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -5793,6 +6017,8 @@ class Croatia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -5904,8 +6130,10 @@ class Egypt(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
 
         class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
             Silkworm_Radar = vehicles.MissilesSS.Silkworm_Radar
 
@@ -5916,8 +6144,6 @@ class Egypt(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Wellcarnsc = vehicles.Carriage.Wellcarnsc
             Boxcartrinity = vehicles.Carriage.Boxcartrinity
             Tankcartrinity = vehicles.Carriage.Tankcartrinity
@@ -5941,6 +6167,7 @@ class Egypt(Country):
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
         M_2000C = planes.M_2000C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
@@ -5960,6 +6187,8 @@ class Egypt(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -5971,6 +6200,7 @@ class Egypt(Country):
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
         Plane.M_2000C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.AJS37,
         Plane.AV8BNA,
@@ -5990,6 +6220,8 @@ class Egypt(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -6017,6 +6249,8 @@ class Egypt(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
+        FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
 
     def __init__(self):
         super(Egypt, self).__init__(Egypt.id, Egypt.name)
@@ -6039,7 +6273,7 @@ class Finland(Country):
 
         class AirDefence:
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
@@ -6054,10 +6288,13 @@ class Finland(Country):
             SAM_SA_18_Igla_comm = vehicles.AirDefence.SAM_SA_18_Igla_comm
             Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -6096,11 +6333,16 @@ class Finland(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -6128,6 +6370,7 @@ class Finland(Country):
         MiG_21Bis = planes.MiG_21Bis
         Hawk = planes.Hawk
         I_16 = planes.I_16
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -6148,6 +6391,8 @@ class Finland(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -6155,6 +6400,7 @@ class Finland(Country):
         Plane.MiG_21Bis,
         Plane.Hawk,
         Plane.I_16,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -6175,6 +6421,8 @@ class Finland(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -6194,6 +6442,8 @@ class Finland(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Finland, self).__init__(Finland.id, Finland.name)
@@ -6240,7 +6490,7 @@ class Greece(Country):
             SAM_SA_10_S_300PS_LN_5P85D = vehicles.AirDefence.SAM_SA_10_S_300PS_LN_5P85D
             SAM_SA_10_S_300PS_CP_54K6 = vehicles.AirDefence.SAM_SA_10_S_300PS_CP_54K6
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
 
         class Fortification:
@@ -6269,7 +6519,9 @@ class Greece(Country):
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -6278,7 +6530,6 @@ class Greece(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -6302,8 +6553,8 @@ class Greece(Country):
         Yak_40 = planes.Yak_40
         P_51D = planes.P_51D
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         M_2000C = planes.M_2000C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -6326,6 +6577,8 @@ class Greece(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -6337,8 +6590,8 @@ class Greece(Country):
         Plane.Yak_40,
         Plane.P_51D,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.M_2000C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -6361,6 +6614,8 @@ class Greece(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -6428,12 +6683,15 @@ class Hungary(Country):
             SAM_SA_18_Igla_MANPADS = vehicles.AirDefence.SAM_SA_18_Igla_MANPADS
             SAM_SA_18_Igla_comm = vehicles.AirDefence.SAM_SA_18_Igla_comm
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -6473,10 +6731,16 @@ class Hungary(Country):
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -6485,7 +6749,6 @@ class Hungary(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -6504,12 +6767,12 @@ class Hungary(Country):
         L_39ZA = planes.L_39ZA
         An_26B = planes.An_26B
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         MiG_15bis = planes.MiG_15bis
         MiG_21Bis = planes.MiG_21Bis
         MiG_29S = planes.MiG_29S
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -6530,18 +6793,20 @@ class Hungary(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.L_39ZA,
         Plane.An_26B,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.MiG_15bis,
         Plane.MiG_21Bis,
         Plane.MiG_29S,
         Plane.Yak_40,
         Plane.Yak_52,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -6562,6 +6827,8 @@ class Hungary(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.MiG_19P,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -6583,6 +6850,8 @@ class Hungary(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Hungary, self).__init__(Hungary.id, Hungary.name)
@@ -6678,6 +6947,7 @@ class India(Country):
         MQ_9_Reaper = planes.MQ_9_Reaper
         M_2000C = planes.M_2000C
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -6698,6 +6968,8 @@ class India(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -6713,6 +6985,7 @@ class India(Country):
         Plane.MQ_9_Reaper,
         Plane.M_2000C,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -6733,6 +7006,8 @@ class India(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -6760,6 +7035,8 @@ class India(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
+        SSK_877 = ships.SSK_877
         FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
 
     def __init__(self):
@@ -6840,6 +7117,7 @@ class Iran(Country):
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
 
         class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
             Silkworm_Radar = vehicles.MissilesSS.Silkworm_Radar
 
@@ -6850,7 +7128,6 @@ class Iran(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -6875,11 +7152,11 @@ class Iran(Country):
         F_14A = planes.F_14A
         F_4E = planes.F_4E
         C_130 = planes.C_130
-        B_17G = planes.B_17G
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
         Su_25T = planes.Su_25T
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -6900,6 +7177,8 @@ class Iran(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -6912,11 +7191,11 @@ class Iran(Country):
         Plane.F_14A,
         Plane.F_4E,
         Plane.C_130,
-        Plane.B_17G,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
         Plane.Su_25T,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -6937,6 +7216,8 @@ class Iran(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7045,6 +7326,7 @@ class Iraq(Country):
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
 
         class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
             Silkworm_Radar = vehicles.MissilesSS.Silkworm_Radar
 
@@ -7055,7 +7337,6 @@ class Iraq(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -7073,6 +7354,8 @@ class Iraq(Country):
         A_10C = planes.A_10C
         An_26B = planes.An_26B
         C_130 = planes.C_130
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_86F_Sabre = planes.F_86F_Sabre
         L_39C = planes.L_39C
         MiG_21Bis = planes.MiG_21Bis
@@ -7080,6 +7363,7 @@ class Iraq(Country):
         MiG_29A = planes.MiG_29A
         Su_24M = planes.Su_24M
         Su_25 = planes.Su_25
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7100,11 +7384,15 @@ class Iraq(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.An_26B,
         Plane.C_130,
+        Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.F_86F_Sabre,
         Plane.L_39C,
         Plane.MiG_21Bis,
@@ -7112,6 +7400,7 @@ class Iraq(Country):
         Plane.MiG_29A,
         Plane.Su_24M,
         Plane.Su_25,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -7132,6 +7421,8 @@ class Iraq(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7187,12 +7478,15 @@ class Japan(Country):
             SAM_Patriot_STR_AN_MPQ_53 = vehicles.AirDefence.SAM_Patriot_STR_AN_MPQ_53
             Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -7221,11 +7515,16 @@ class Japan(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -7249,12 +7548,12 @@ class Japan(Country):
 
     class Plane:
         A_10C = planes.A_10C
-        B_17G = planes.B_17G
         C_130 = planes.C_130
         E_2C = planes.E_2C
         F_15C = planes.F_15C
         F_86F_Sabre = planes.F_86F_Sabre
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7276,15 +7575,17 @@ class Japan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
-        Plane.B_17G,
         Plane.C_130,
         Plane.E_2C,
         Plane.F_15C,
         Plane.F_86F_Sabre,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -7306,6 +7607,8 @@ class Japan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7333,6 +7636,8 @@ class Japan(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Japan, self).__init__(Japan.id, Japan.name)
@@ -7441,9 +7746,12 @@ class Kazakhstan(Country):
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_Cobra = vehicles.Armor.APC_Cobra
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             ES44AH = vehicles.Locomotive.ES44AH
@@ -7452,7 +7760,6 @@ class Kazakhstan(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Wellcarnsc = vehicles.Carriage.Wellcarnsc
             Boxcartrinity = vehicles.Carriage.Boxcartrinity
             Tankcartrinity = vehicles.Carriage.Tankcartrinity
@@ -7481,6 +7788,7 @@ class Kazakhstan(Country):
         Su_24MR = planes.Su_24MR
         IL_76MD = planes.IL_76MD
         L_39C = planes.L_39C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7503,6 +7811,8 @@ class Kazakhstan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -7519,6 +7829,7 @@ class Kazakhstan(Country):
         Plane.Su_24MR,
         Plane.IL_76MD,
         Plane.L_39C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -7541,6 +7852,8 @@ class Kazakhstan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7609,10 +7922,12 @@ class NorthKorea(Country):
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
         class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
             SS_N_2_Silkworm = vehicles.MissilesSS.SS_N_2_Silkworm
             Silkworm_Radar = vehicles.MissilesSS.Silkworm_Radar
 
@@ -7623,8 +7938,6 @@ class NorthKorea(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -7645,6 +7958,7 @@ class NorthKorea(Country):
         MiG_29A = planes.MiG_29A
         MiG_29S = planes.MiG_29S
         Su_25 = planes.Su_25
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7666,6 +7980,8 @@ class NorthKorea(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -7674,6 +7990,7 @@ class NorthKorea(Country):
         Plane.MiG_29A,
         Plane.MiG_29S,
         Plane.Su_25,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -7695,6 +8012,8 @@ class NorthKorea(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7794,8 +8113,11 @@ class Pakistan(Country):
         C_130 = planes.C_130
         F_16A = planes.F_16A
         F_16A_MLU = planes.F_16A_MLU
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_86F_Sabre = planes.F_86F_Sabre
         IL_78M = planes.IL_78M
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7818,6 +8140,8 @@ class Pakistan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -7825,8 +8149,11 @@ class Pakistan(Country):
         Plane.C_130,
         Plane.F_16A,
         Plane.F_16A_MLU,
+        Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.F_86F_Sabre,
         Plane.IL_78M,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -7849,6 +8176,8 @@ class Pakistan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -7934,13 +8263,20 @@ class Poland(Country):
             APC_MTLB = vehicles.Armor.APC_MTLB
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
@@ -7949,8 +8285,6 @@ class Poland(Country):
             ES44AH = vehicles.Locomotive.ES44AH
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_covered_wagon_G10 = vehicles.Carriage.German_covered_wagon_G10
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
@@ -7971,15 +8305,18 @@ class Poland(Country):
         Su_17M4 = planes.Su_17M4
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         An_26B = planes.An_26B
         C_130 = planes.C_130
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
+        F_16C_bl_52d = planes.F_16C_bl_52d
         MiG_15bis = planes.MiG_15bis
         MiG_21Bis = planes.MiG_21Bis
         MiG_29G = planes.MiG_29G
         Yak_40 = planes.Yak_40
         I_16 = planes.I_16
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -7998,8 +8335,9 @@ class Poland(Country):
         Hawk = planes.Hawk
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -8008,15 +8346,18 @@ class Poland(Country):
         Plane.Su_17M4,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.An_26B,
         Plane.C_130,
         Plane.C_17A,
-        Plane.E_3A,
+        Plane.F_16C_bl_52d,
         Plane.MiG_15bis,
         Plane.MiG_21Bis,
         Plane.MiG_29G,
         Plane.Yak_40,
         Plane.I_16,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8035,8 +8376,9 @@ class Poland(Country):
         Plane.Hawk,
         Plane.L_39C,
         Plane.M_2000C,
-        Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8058,6 +8400,9 @@ class Poland(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Oliver_Hazzard_Perry_class = ships.Oliver_Hazzard_Perry_class
+        SSK_877 = ships.SSK_877
+        FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         LCVP__Higgins_boat = ships.LCVP__Higgins_boat
@@ -8090,12 +8435,15 @@ class Romania(Country):
             SAM_SA_6_Kub_STR_9S91 = vehicles.AirDefence.SAM_SA_6_Kub_STR_9S91
             SAM_SA_9_Strela_1_9P31 = vehicles.AirDefence.SAM_SA_9_Strela_1_9P31
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -8135,10 +8483,16 @@ class Romania(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -8147,7 +8501,6 @@ class Romania(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -8166,13 +8519,14 @@ class Romania(Country):
         An_26B = planes.An_26B
         C_130 = planes.C_130
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         F_16A_MLU = planes.F_16A_MLU
         L_39ZA = planes.L_39ZA
         MiG_15bis = planes.MiG_15bis
         MiG_29A = planes.MiG_29A
         Yak_52 = planes.Yak_52
         I_16 = planes.I_16
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -8191,21 +8545,23 @@ class Romania(Country):
         Hawk = planes.Hawk
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.An_26B,
         Plane.C_130,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.F_16A_MLU,
         Plane.L_39ZA,
         Plane.MiG_15bis,
         Plane.MiG_29A,
         Plane.Yak_52,
         Plane.I_16,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8224,8 +8580,9 @@ class Romania(Country):
         Plane.Hawk,
         Plane.L_39C,
         Plane.M_2000C,
-        Plane.MiG_19P,
         Plane.MiG_21Bis,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8248,6 +8605,10 @@ class Romania(Country):
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
         FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
+        SSK_877 = ships.SSK_877
+        FSG_1241_1MP_Molniya = ships.FSG_1241_1MP_Molniya
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(Romania, self).__init__(Romania.id, Romania.name)
@@ -8342,6 +8703,7 @@ class SaudiArabia(Country):
         F_86F_Sabre = planes.F_86F_Sabre
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -8360,6 +8722,8 @@ class SaudiArabia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -8374,6 +8738,7 @@ class SaudiArabia(Country):
         Plane.F_86F_Sabre,
         Plane.Hawk,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8392,6 +8757,8 @@ class SaudiArabia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8530,6 +8897,7 @@ class Serbia(Country):
         An_26B = planes.An_26B
         MiG_29S = planes.MiG_29S
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -8552,6 +8920,8 @@ class Serbia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -8560,6 +8930,7 @@ class Serbia(Country):
         Plane.An_26B,
         Plane.MiG_29S,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8582,6 +8953,8 @@ class Serbia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8664,6 +9037,9 @@ class Slovakia(Country):
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -8671,7 +9047,6 @@ class Slovakia(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -8690,10 +9065,10 @@ class Slovakia(Country):
         L_39ZA = planes.L_39ZA
         An_26B = planes.An_26B
         C_17A = planes.C_17A
-        E_3A = planes.E_3A
         L_39C = planes.L_39C
         MiG_29A = planes.MiG_29A
         Su_25 = planes.Su_25
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -8716,16 +9091,18 @@ class Slovakia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.L_39ZA,
         Plane.An_26B,
         Plane.C_17A,
-        Plane.E_3A,
         Plane.L_39C,
         Plane.MiG_29A,
         Plane.Su_25,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8748,6 +9125,8 @@ class Slovakia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8849,13 +9228,17 @@ class SouthKorea(Country):
         A_10C = planes.A_10C
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_130 = planes.C_130
         F_15E = planes.F_15E
         F_4E = planes.F_4E
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_86F_Sabre = planes.F_86F_Sabre
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -8875,18 +9258,24 @@ class SouthKorea(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_130,
         Plane.F_15E,
         Plane.F_4E,
         Plane.F_5E,
         Plane.F_5E_3,
+        Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.F_86F_Sabre,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -8906,6 +9295,8 @@ class SouthKorea(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -8991,10 +9382,12 @@ class Sweden(Country):
         A_10C = planes.A_10C
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         B_17G = planes.B_17G
         C_130 = planes.C_130
         AJS37 = planes.AJS37
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9016,15 +9409,19 @@ class Sweden(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.B_17G,
         Plane.C_130,
         Plane.AJS37,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9046,6 +9443,8 @@ class Sweden(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9132,6 +9531,9 @@ class Syria(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -9139,7 +9541,6 @@ class Syria(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -9163,6 +9564,7 @@ class Syria(Country):
         MiG_29A = planes.MiG_29A
         Su_24M = planes.Su_24M
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9184,6 +9586,8 @@ class Syria(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9195,6 +9599,7 @@ class Syria(Country):
         Plane.MiG_29A,
         Plane.Su_24M,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9216,6 +9621,8 @@ class Syria(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9293,6 +9700,9 @@ class Yemen(Country):
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -9300,7 +9710,6 @@ class Yemen(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -9323,6 +9732,7 @@ class Yemen(Country):
         L_39C = planes.L_39C
         MiG_29S = planes.MiG_29S
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9343,6 +9753,8 @@ class Yemen(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9353,6 +9765,7 @@ class Yemen(Country):
         Plane.L_39C,
         Plane.MiG_29S,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9373,6 +9786,8 @@ class Yemen(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9460,6 +9875,9 @@ class Vietnam(Country):
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -9467,7 +9885,6 @@ class Vietnam(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -9494,6 +9911,7 @@ class Vietnam(Country):
         Su_30 = planes.Su_30
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9512,6 +9930,8 @@ class Vietnam(Country):
         M_2000C = planes.M_2000C
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9526,6 +9946,7 @@ class Vietnam(Country):
         Plane.Su_30,
         Plane.Yak_40,
         Plane.Yak_52,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9544,6 +9965,8 @@ class Vietnam(Country):
         Plane.M_2000C,
         Plane.MiG_15bis,
         Plane.MiG_19P,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9651,6 +10074,7 @@ class Venezuela(Country):
         F_16A = planes.F_16A
         F_86F_Sabre = planes.F_86F_Sabre
         Su_30 = planes.Su_30
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9673,6 +10097,8 @@ class Venezuela(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9680,6 +10106,7 @@ class Venezuela(Country):
         Plane.F_16A,
         Plane.F_86F_Sabre,
         Plane.Su_30,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9702,6 +10129,8 @@ class Venezuela(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9784,6 +10213,7 @@ class Tunisia(Country):
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9804,6 +10234,8 @@ class Tunisia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9811,6 +10243,7 @@ class Tunisia(Country):
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9831,6 +10264,8 @@ class Tunisia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -9919,6 +10354,7 @@ class Thailand(Country):
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
         L_39ZA = planes.L_39ZA
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -9939,6 +10375,8 @@ class Thailand(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -9949,6 +10387,7 @@ class Thailand(Country):
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
         Plane.L_39ZA,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -9969,6 +10408,8 @@ class Thailand(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10070,6 +10511,7 @@ class Sudan(Country):
         MiG_29S = planes.MiG_29S
         Su_24M = planes.Su_24M
         Su_25 = planes.Su_25
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10091,6 +10533,8 @@ class Sudan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -10101,6 +10545,7 @@ class Sudan(Country):
         Plane.MiG_29S,
         Plane.Su_24M,
         Plane.Su_25,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10122,6 +10567,8 @@ class Sudan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10203,9 +10650,11 @@ class Philippines(Country):
         C_130 = planes.C_130
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         F_86F_Sabre = planes.F_86F_Sabre
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10226,15 +10675,19 @@ class Philippines(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.C_130,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.F_86F_Sabre,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10255,6 +10708,8 @@ class Philippines(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10357,7 +10812,10 @@ class Morocco(Country):
         C_130 = planes.C_130
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10378,13 +10836,18 @@ class Morocco(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.C_130,
         Plane.F_5E,
         Plane.F_5E_3,
+        Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10405,6 +10868,8 @@ class Morocco(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10486,11 +10951,11 @@ class Mexico(Country):
 
     class Plane:
         A_10C = planes.A_10C
-        B_17G = planes.B_17G
         C_130 = planes.C_130
         E_2C = planes.E_2C
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10512,14 +10977,16 @@ class Mexico(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
-        Plane.B_17G,
         Plane.C_130,
         Plane.E_2C,
         Plane.F_5E,
         Plane.F_5E_3,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10541,6 +11008,8 @@ class Mexico(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10628,6 +11097,7 @@ class Malaysia(Country):
         Su_30 = planes.Su_30
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10647,6 +11117,8 @@ class Malaysia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -10656,6 +11128,7 @@ class Malaysia(Country):
         Plane.Su_30,
         Plane.Hawk,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10675,6 +11148,8 @@ class Malaysia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10754,6 +11229,9 @@ class Libya(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -10761,7 +11239,6 @@ class Libya(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -10782,6 +11259,7 @@ class Libya(Country):
         MiG_21Bis = planes.MiG_21Bis
         Su_24M = planes.Su_24M
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10803,6 +11281,8 @@ class Libya(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -10811,6 +11291,7 @@ class Libya(Country):
         Plane.MiG_21Bis,
         Plane.Su_24M,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10832,6 +11313,8 @@ class Libya(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -10932,6 +11415,7 @@ class Jordan(Country):
         Hawk = planes.Hawk
         C_101EB = planes.C_101EB
         C_101CC = planes.C_101CC
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -10950,6 +11434,8 @@ class Jordan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -10961,6 +11447,7 @@ class Jordan(Country):
         Plane.Hawk,
         Plane.C_101EB,
         Plane.C_101CC,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -10979,6 +11466,8 @@ class Jordan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11079,15 +11568,18 @@ class Indonesia(Country):
         A_10C = planes.A_10C
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         C_130 = planes.C_130
         F_16A = planes.F_16A
         F_16A_MLU = planes.F_16A_MLU
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         Su_27 = planes.Su_27
         Su_30 = planes.Su_30
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11107,20 +11599,25 @@ class Indonesia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.C_130,
         Plane.F_16A,
         Plane.F_16A_MLU,
+        Plane.F_16C_bl_52d,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.Su_27,
         Plane.Su_30,
         Plane.Hawk,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11140,6 +11637,8 @@ class Indonesia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11215,6 +11714,7 @@ class Honduras(Country):
         F_5E_3 = planes.F_5E_3
         C_101EB = planes.C_101EB
         C_101CC = planes.C_101CC
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11234,6 +11734,8 @@ class Honduras(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -11242,6 +11744,7 @@ class Honduras(Country):
         Plane.F_5E_3,
         Plane.C_101EB,
         Plane.C_101CC,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11261,6 +11764,8 @@ class Honduras(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11369,6 +11874,7 @@ class Ethiopia(Country):
         Su_25T = planes.Su_25T
         Su_27 = planes.Su_27
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11387,6 +11893,8 @@ class Ethiopia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -11399,6 +11907,7 @@ class Ethiopia(Country):
         Plane.Su_25T,
         Plane.Su_27,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11417,6 +11926,8 @@ class Ethiopia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11511,12 +12022,14 @@ class Chile(Country):
         P_51D = planes.P_51D
         KC_135 = planes.KC_135
         F_16C_bl_50 = planes.F_16C_bl_50
+        F_16C_bl_52d = planes.F_16C_bl_52d
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         KC135MPRS = planes.KC135MPRS
         C_130 = planes.C_130
         C_101EB = planes.C_101EB
         C_101CC = planes.C_101CC
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11535,6 +12048,8 @@ class Chile(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -11543,12 +12058,14 @@ class Chile(Country):
         Plane.P_51D,
         Plane.KC_135,
         Plane.F_16C_bl_50,
+        Plane.F_16C_bl_52d,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.KC135MPRS,
         Plane.C_130,
         Plane.C_101EB,
         Plane.C_101CC,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11567,6 +12084,8 @@ class Chile(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11673,6 +12192,7 @@ class Brazil(Country):
         F_5E_3 = planes.F_5E_3
         M_2000C = planes.M_2000C
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11692,6 +12212,8 @@ class Brazil(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -11701,6 +12223,7 @@ class Brazil(Country):
         Plane.F_5E_3,
         Plane.M_2000C,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11720,6 +12243,8 @@ class Brazil(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11820,6 +12345,7 @@ class Bahrain(Country):
         F_5E = planes.F_5E
         F_5E_3 = planes.F_5E_3
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -11840,12 +12366,15 @@ class Bahrain(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.F_5E,
         Plane.F_5E_3,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -11866,6 +12395,8 @@ class Bahrain(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -11906,12 +12437,15 @@ class ThirdReich(Country):
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
         class AirDefence:
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -11937,11 +12471,16 @@ class ThirdReich(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -11990,6 +12529,8 @@ class ThirdReich(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -12018,6 +12559,8 @@ class ThirdReich(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -12037,6 +12580,8 @@ class ThirdReich(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(ThirdReich, self).__init__(ThirdReich.id, ThirdReich.name)
@@ -12087,8 +12632,15 @@ class Yugoslavia(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             APC_M2A1 = vehicles.Armor.APC_M2A1
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -12116,6 +12668,7 @@ class Yugoslavia(Country):
         MiG_21Bis = planes.MiG_21Bis
         MiG_29A = planes.MiG_29A
         Yak_40 = planes.Yak_40
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -12138,6 +12691,8 @@ class Yugoslavia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -12145,6 +12700,7 @@ class Yugoslavia(Country):
         Plane.MiG_21Bis,
         Plane.MiG_29A,
         Plane.Yak_40,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -12167,6 +12723,8 @@ class Yugoslavia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -12251,7 +12809,7 @@ class USSR(Country):
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -12293,7 +12851,7 @@ class USSR(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             ARV_BTR_RD = vehicles.Armor.ARV_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
@@ -12303,10 +12861,17 @@ class USSR(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -12321,9 +12886,6 @@ class USSR(Country):
             Coach_a_tank_yellow = vehicles.Carriage.Coach_a_tank_yellow
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             German_covered_wagon_G10 = vehicles.Carriage.German_covered_wagon_G10
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             German_tank_wagon = vehicles.Carriage.German_tank_wagon
@@ -12351,6 +12913,7 @@ class USSR(Country):
         MiG_29A = planes.MiG_29A
         MiG_31 = planes.MiG_31
         P_51D = planes.P_51D
+        TF_51D = planes.TF_51D
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
         Su_17M4 = planes.Su_17M4
@@ -12365,6 +12928,8 @@ class USSR(Country):
         Tu_95MS = planes.Tu_95MS
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
@@ -12380,7 +12945,8 @@ class USSR(Country):
         FA_18C_hornet = planes.FA_18C_hornet
         Hawk = planes.Hawk
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -12402,6 +12968,7 @@ class USSR(Country):
         Plane.MiG_29A,
         Plane.MiG_31,
         Plane.P_51D,
+        Plane.TF_51D,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
         Plane.Su_17M4,
@@ -12416,6 +12983,8 @@ class USSR(Country):
         Plane.Tu_95MS,
         Plane.Yak_40,
         Plane.Yak_52,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.AJS37,
         Plane.AV8BNA,
@@ -12431,7 +13000,8 @@ class USSR(Country):
         Plane.FA_18C_hornet,
         Plane.Hawk,
         Plane.M_2000C,
-        Plane.MiG_19P,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -12460,6 +13030,7 @@ class USSR(Country):
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
         FFL_1124_4_Grisha = ships.FFL_1124_4_Grisha
+        SSK_877 = ships.SSK_877
         Bulk_cargo_ship_Yakushev = ships.Bulk_cargo_ship_Yakushev
         Dry_cargo_ship_Ivanov = ships.Dry_cargo_ship_Ivanov
         Tanker_Elnya_160 = ships.Tanker_Elnya_160
@@ -12491,12 +13062,15 @@ class ItalianSocialRepublic(Country):
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
         class AirDefence:
-            AAA_Flak_18 = vehicles.AirDefence.AAA_Flak_18
+            AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_Flak_38 = vehicles.AirDefence.AAA_Flak_38
-            AAA_Flak_36 = vehicles.AirDefence.AAA_Flak_36
-            AAA_Flak_37 = vehicles.AirDefence.AAA_Flak_37
+            AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_Vierling_38 = vehicles.AirDefence.AAA_Flak_Vierling_38
             AAA_Kdo_G_40 = vehicles.AirDefence.AAA_Kdo_G_40
+            Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
+            Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
+            AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -12522,11 +13096,16 @@ class ItalianSocialRepublic(Country):
             HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
-            Jagdpanther_G1 = vehicles.Armor.Jagdpanther_G1
-            Jagdpanzer_IV = vehicles.Armor.Jagdpanzer_IV
+            TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
+            TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
+            Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
+
+        class MissilesSS:
+            V_1_ramp = vehicles.MissilesSS.V_1_ramp
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -12550,6 +13129,7 @@ class ItalianSocialRepublic(Country):
 
     class Plane:
         A_10C = planes.A_10C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -12573,9 +13153,12 @@ class ItalianSocialRepublic(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -12599,6 +13182,8 @@ class ItalianSocialRepublic(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -12618,6 +13203,8 @@ class ItalianSocialRepublic(Country):
 
     class Ship:
         Armed_speedboat = ships.Armed_speedboat
+        Uboat_VIIC_U_flak = ships.Uboat_VIIC_U_flak
+        Schnellboot_type_S130 = ships.Schnellboot_type_S130
 
     def __init__(self):
         super(ItalianSocialRepublic, self).__init__(ItalianSocialRepublic.id, ItalianSocialRepublic.name)
@@ -12713,7 +13300,7 @@ class Algeria(Country):
         class Armor:
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            ARV_MTLB_U_BOMAN = vehicles.Armor.ARV_MTLB_U_BOMAN
+            FDDM_Grad = vehicles.Armor.FDDM_Grad
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -12729,7 +13316,6 @@ class Algeria(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -12764,6 +13350,7 @@ class Algeria(Country):
         Yak_40 = planes.Yak_40
         L_39C = planes.L_39C
         MiG_15bis = planes.MiG_15bis
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -12784,6 +13371,8 @@ class Algeria(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -12806,6 +13395,7 @@ class Algeria(Country):
         Plane.Yak_40,
         Plane.L_39C,
         Plane.MiG_15bis,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -12826,6 +13416,8 @@ class Algeria(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -12948,6 +13540,7 @@ class Kuwait(Country):
         F_A_18C = planes.F_A_18C
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -12969,6 +13562,8 @@ class Kuwait(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -12977,6 +13572,7 @@ class Kuwait(Country):
         Plane.F_A_18C,
         Plane.Hawk,
         Plane.KC130,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -12998,6 +13594,8 @@ class Kuwait(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13089,6 +13687,7 @@ class Qatar(Country):
         C_17A = planes.C_17A
         Mirage_2000_5 = planes.Mirage_2000_5
         M_2000C = planes.M_2000C
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -13111,12 +13710,15 @@ class Qatar(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.C_17A,
         Plane.Mirage_2000_5,
         Plane.M_2000C,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -13139,6 +13741,8 @@ class Qatar(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13217,6 +13821,9 @@ class Oman(Country):
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -13224,7 +13831,6 @@ class Oman(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -13244,6 +13850,7 @@ class Oman(Country):
         F_16C_bl_52d = planes.F_16C_bl_52d
         F_16C_bl_50 = planes.F_16C_bl_50
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -13266,6 +13873,8 @@ class Oman(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -13273,6 +13882,7 @@ class Oman(Country):
         Plane.F_16C_bl_52d,
         Plane.F_16C_bl_50,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -13295,6 +13905,8 @@ class Oman(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13375,6 +13987,9 @@ class UnitedArabEmirates(Country):
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             APC_Cobra = vehicles.Armor.APC_Cobra
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -13382,7 +13997,6 @@ class UnitedArabEmirates(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -13404,6 +14018,7 @@ class UnitedArabEmirates(Country):
         M_2000C = planes.M_2000C
         Hawk = planes.Hawk
         RQ_1A_Predator = planes.RQ_1A_Predator
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -13425,6 +14040,8 @@ class UnitedArabEmirates(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -13434,6 +14051,7 @@ class UnitedArabEmirates(Country):
         Plane.M_2000C,
         Plane.Hawk,
         Plane.RQ_1A_Predator,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -13455,6 +14073,8 @@ class UnitedArabEmirates(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13543,9 +14163,10 @@ class SouthAfrica(Country):
         P_51D = planes.P_51D
         C_130 = planes.C_130
         P_51D_30_NA = planes.P_51D_30_NA
-        B_17G = planes.B_17G
+        TF_51D = planes.TF_51D
         F_86F_Sabre = planes.F_86F_Sabre
         Hawk = planes.Hawk
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -13567,15 +14188,18 @@ class SouthAfrica(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
         Plane.P_51D,
         Plane.C_130,
         Plane.P_51D_30_NA,
-        Plane.B_17G,
+        Plane.TF_51D,
         Plane.F_86F_Sabre,
         Plane.Hawk,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -13597,6 +14221,8 @@ class SouthAfrica(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13693,6 +14319,9 @@ class Cuba(Country):
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
 
+        class MissilesSS:
+            SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -13700,7 +14329,6 @@ class Cuba(Country):
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
 
         class Carriage:
-            German_tank_wagon = vehicles.Carriage.German_tank_wagon
             Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
             Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
             Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
@@ -13725,11 +14353,14 @@ class Cuba(Country):
         IL_76MD = planes.IL_76MD
         P_51D = planes.P_51D
         P_51D_30_NA = planes.P_51D_30_NA
+        TF_51D = planes.TF_51D
         L_39C = planes.L_39C
         MiG_15bis = planes.MiG_15bis
         MiG_23MLD = planes.MiG_23MLD
         MiG_23MLD = planes.MiG_23MLD
         MiG_23MLD = planes.MiG_23MLD
+        MiG_19P = planes.MiG_19P
+        FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         SpitfireLFMkIX = planes.SpitfireLFMkIX
         SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
@@ -13748,8 +14379,9 @@ class Cuba(Country):
         Hawk = planes.Hawk
         I_16 = planes.I_16
         M_2000C = planes.M_2000C
-        MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
 
     planes = [
         Plane.A_10C,
@@ -13762,11 +14394,14 @@ class Cuba(Country):
         Plane.IL_76MD,
         Plane.P_51D,
         Plane.P_51D_30_NA,
+        Plane.TF_51D,
         Plane.L_39C,
         Plane.MiG_15bis,
         Plane.MiG_23MLD,
         Plane.MiG_23MLD,
         Plane.MiG_23MLD,
+        Plane.MiG_19P,
+        Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.SpitfireLFMkIX,
         Plane.SpitfireLFMkIXCW,
@@ -13785,8 +14420,9 @@ class Cuba(Country):
         Plane.Hawk,
         Plane.I_16,
         Plane.M_2000C,
-        Plane.MiG_19P,
         Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
     ]
 
     class Helicopter:
@@ -13819,6 +14455,157 @@ class Cuba(Country):
 
     def __init__(self):
         super(Cuba, self).__init__(Cuba.id, Cuba.name)
+
+
+class Portugal(Country):
+    id = 77
+    name = "Portugal"
+
+    class Vehicle:
+
+        class Artillery:
+            SPH_M109_Paladin = vehicles.Artillery.SPH_M109_Paladin
+
+        class AirDefence:
+            SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
+            Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
+            SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
+            AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            SAM_Stinger_comm_dsr = vehicles.AirDefence.SAM_Stinger_comm_dsr
+
+        class Fortification:
+            Bunker_2 = vehicles.Fortification.Bunker_2
+            Bunker_1 = vehicles.Fortification.Bunker_1
+            Barracks_armed = vehicles.Fortification.Barracks_armed
+            Watch_tower_armed = vehicles.Fortification.Watch_tower_armed
+            Road_outpost = vehicles.Fortification.Road_outpost
+            Outpost = vehicles.Fortification.Outpost
+            Armed_house = vehicles.Fortification.Armed_house
+            TACAN_Beacon__Man_Portable__TTS_3030 = vehicles.Fortification.TACAN_Beacon__Man_Portable__TTS_3030
+
+        class Unarmed:
+            Transport_M818 = vehicles.Unarmed.Transport_M818
+
+        class Armor:
+            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
+            APC_M113 = vehicles.Armor.APC_M113
+            APC_M2A1 = vehicles.Armor.APC_M2A1
+            CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+
+        class Locomotive:
+            Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
+            Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
+            ES44AH = vehicles.Locomotive.ES44AH
+            DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
+
+        class Carriage:
+            Coach_for_cargo = vehicles.Carriage.Coach_for_cargo
+            Coach_for_open_cargo = vehicles.Carriage.Coach_for_open_cargo
+            Coach_a_tank_blue = vehicles.Carriage.Coach_a_tank_blue
+            Coach_a_tank_yellow = vehicles.Carriage.Coach_a_tank_yellow
+            Coach_for_passengers = vehicles.Carriage.Coach_for_passengers
+            Coach_flatbed = vehicles.Carriage.Coach_flatbed
+            Boxcartrinity = vehicles.Carriage.Boxcartrinity
+            Tankcartrinity = vehicles.Carriage.Tankcartrinity
+            Wellcarnsc = vehicles.Carriage.Wellcarnsc
+            DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
+            German_covered_wagon_G10 = vehicles.Carriage.German_covered_wagon_G10
+            German_tank_wagon = vehicles.Carriage.German_tank_wagon
+
+    class Plane:
+        A_10C = planes.A_10C
+        C_130 = planes.C_130
+        F_16A_MLU = planes.F_16A_MLU
+        F_16A = planes.F_16A
+        F_16C_bl_50 = planes.F_16C_bl_50
+        F_86F_Sabre = planes.F_86F_Sabre
+        SpitfireLFMkIX = planes.SpitfireLFMkIX
+        SpitfireLFMkIXCW = planes.SpitfireLFMkIXCW
+        B_17G = planes.B_17G
+        C_17A = planes.C_17A
+        FW_190A8 = planes.FW_190A8
+        Bf_109K_4 = planes.Bf_109K_4
+        AJS37 = planes.AJS37
+        AV8BNA = planes.AV8BNA
+        KC130 = planes.KC130
+        KC135MPRS = planes.KC135MPRS
+        C_101EB = planes.C_101EB
+        C_101CC = planes.C_101CC
+        JF_17 = planes.JF_17
+        Christen_Eagle_II = planes.Christen_Eagle_II
+        F_5E = planes.F_5E
+        F_5E_3 = planes.F_5E_3
+        FA_18C_hornet = planes.FA_18C_hornet
+        Hawk = planes.Hawk
+        I_16 = planes.I_16
+        L_39C = planes.L_39C
+        M_2000C = planes.M_2000C
+        MiG_15bis = planes.MiG_15bis
+        MiG_19P = planes.MiG_19P
+        MiG_21Bis = planes.MiG_21Bis
+        Yak_52 = planes.Yak_52
+        A_20G = planes.A_20G
+        Ju_88A4 = planes.Ju_88A4
+
+    planes = [
+        Plane.A_10C,
+        Plane.C_130,
+        Plane.F_16A_MLU,
+        Plane.F_16A,
+        Plane.F_16C_bl_50,
+        Plane.F_86F_Sabre,
+        Plane.SpitfireLFMkIX,
+        Plane.SpitfireLFMkIXCW,
+        Plane.B_17G,
+        Plane.C_17A,
+        Plane.FW_190A8,
+        Plane.Bf_109K_4,
+        Plane.AJS37,
+        Plane.AV8BNA,
+        Plane.KC130,
+        Plane.KC135MPRS,
+        Plane.C_101EB,
+        Plane.C_101CC,
+        Plane.JF_17,
+        Plane.Christen_Eagle_II,
+        Plane.F_5E,
+        Plane.F_5E_3,
+        Plane.FA_18C_hornet,
+        Plane.Hawk,
+        Plane.I_16,
+        Plane.L_39C,
+        Plane.M_2000C,
+        Plane.MiG_15bis,
+        Plane.MiG_19P,
+        Plane.MiG_21Bis,
+        Plane.Yak_52,
+        Plane.A_20G,
+        Plane.Ju_88A4,
+    ]
+
+    class Helicopter:
+        Ka_50 = helicopters.Ka_50
+        SA342M = helicopters.SA342M
+        SA342L = helicopters.SA342L
+        SA342Mistral = helicopters.SA342Mistral
+        SA342Minigun = helicopters.SA342Minigun
+
+    helicopters = [
+        Helicopter.Ka_50,
+        Helicopter.SA342M,
+        Helicopter.SA342L,
+        Helicopter.SA342Mistral,
+        Helicopter.SA342Minigun,
+    ]
+
+    class Ship:
+        Armed_speedboat = ships.Armed_speedboat
+
+    def __init__(self):
+        super(Portugal, self).__init__(Portugal.id, Portugal.name)
 
 country_dict = {
     Russia.id: Russia,
@@ -13897,6 +14684,7 @@ country_dict = {
     UnitedArabEmirates.id: UnitedArabEmirates,
     SouthAfrica.id: SouthAfrica,
     Cuba.id: Cuba,
+    Portugal.id: Portugal,
 }
 
 

--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -93,9 +93,9 @@ class Ka_50(HelicopterType):
             ukraine_camo_1_dirt = "ukraine camo 1 dirt"
 
         class Belgium(Enum):
+            belgium_sar = "belgium sar"
             belgium_camo = "belgium camo"
             belgium_olive = "belgium olive"
-            belgium_sar = "belgium sar"
 
         class Greece(Enum):
             Greek_Army_Aviation = "Greek Army Aviation"
@@ -115,13 +115,13 @@ class Ka_50(HelicopterType):
 
         class Russia(Enum):
             Russia_Standard_Army = "Russia Standard Army"
+            Russia_DOSAAF = "Russia DOSAAF"
             Russia_Demo__024 = "Russia Demo #024"
             Russia_Demo__22__Black_Shark = "Russia Demo #22 `Black Shark`"
             Russia_Demo__Werewolf = "Russia Demo `Werewolf`"
-            Russia_DOSAAF = "Russia DOSAAF"
+            Russia_Fictional_Swedish = "Russia Fictional Swedish"
             Russia_fictional_desert_scheme = "Russia fictional desert scheme"
             Russia_Fictional_Olive_Grey = "Russia Fictional Olive Grey"
-            Russia_Fictional_Swedish = "Russia Fictional Swedish"
             Russia_Fictional_Snow_Splatter = "Russia Fictional Snow Splatter"
             Russia_Fictional_Tropic_Green = "Russia Fictional Tropic Green"
             Russia_New_Year = "Russia New Year"
@@ -152,10 +152,10 @@ class Ka_50(HelicopterType):
             Netherlands_RNAF_wooded = "Netherlands RNAF wooded"
 
         class Turkey(Enum):
-            Turkey_fictional_desert_scheme = "Turkey fictional desert scheme"
             Turkey_Fictional_Light_Gray = "Turkey Fictional Light Gray"
             Turkey_Fictional_1 = "Turkey Fictional 1"
             Turkey_Fictional = "Turkey Fictional"
+            Turkey_fictional_desert_scheme = "Turkey fictional desert scheme"
 
     class Pylon1:
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
@@ -1582,8 +1582,8 @@ class UH_1H(HelicopterType):
             id = "NetCrewControlPriority"
 
             class Values:
-                Instructor = 0
-                Pilot = 1
+                Pilot = 0
+                Copilot = 1
                 Ask_Always = -1
                 Equally_Responsible = -2
 
@@ -1982,6 +1982,7 @@ class SA342L(HelicopterType):
 
     class Pylon2:
         LAU_SNEB68G___8xSNEB68_EAP = (2, Weapons.LAU_SNEB68G___8xSNEB68_EAP)
+        LAU_SNEB68G___8xSNEB68_WP = (2, Weapons.LAU_SNEB68G___8xSNEB68_WP)
 
     class Pylon5:
         Sand_Filter = (5, Weapons.Sand_Filter)

--- a/dcs/nav_target_point.py
+++ b/dcs/nav_target_point.py
@@ -1,0 +1,51 @@
+"""
+A nav target point is special type of point handled in DCS mission editor.
+
+Two aircraft uses these special waypoints for now :
+- The JF-17 Thunder
+- The F-14B Tomcat
+
+
+--------------------------------------------------------------------------
+JF-17 :
+For the JF-17 it is possible to set up "PP" waypoint and "RP" waypoint.
+
+PP waypoints can be set by putting a comment : PP1, PP2, PP3, PP4, or PP5
+RP waypoints can be set by putting a comment : RP1, RP2, RP3, RP4, or RP5
+
+PP waypoints are preplanned target waypoints for guided bombs.
+RP waypoints are special points for the C-802AKG cruise missile.
+
+--------------------------------------------------------------------------
+F-14B Tomcat :
+
+See http://www.heatblur.se/F-14Manual/dcs.html#f-14-waypoints-in-the-mission-editor
+
+--------------------------------------------------------------------------
+
+"""
+
+from dcs import mapping
+
+
+class NavTargetPoint:
+    def __init__(self):
+        self.position = mapping.Point(0, 0)
+        self.text_comment = ""
+        self.index = 0
+
+    @classmethod
+    def create_from_dict(cls, d):
+        t = cls()
+        t.position = mapping.Point(d["x"], d["y"])
+        t.text_comment = d["text_comment"]
+        t.index = d["index"]
+        return t
+
+    def dict(self):
+        return {
+            "x": self.position.x,
+            "y": self.position.y,
+            "index": self.index,
+            "text_comment": self.text_comment,
+        }

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -651,7 +651,6 @@ class F_14A(PlaneType):
 
 class Tu_22M3(PlaneType):
     id = "Tu-22M3"
-    group_size_max = 1
     large_parking_slot = True
     height = 11.05
     width = 34.28
@@ -811,7 +810,6 @@ class F_4E(PlaneType):
 
 class B_52H(PlaneType):
     id = "B-52H"
-    group_size_max = 1
     large_parking_slot = True
     height = 12.4
     width = 56.4
@@ -868,9 +866,6 @@ class MiG_27K(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
-        class Ukraine(Enum):
-            af_standard = "af standard"
 
         class Russia(Enum):
             af_standard = "af standard"
@@ -1292,7 +1287,6 @@ class A_10A(PlaneType):
         LAU_105_2_AIM_9P5 = (1, Weapons.LAU_105_2_AIM_9P5)
         LAU_105___2_AIM_9M_Sidewinder_IR_AAM = (1, Weapons.LAU_105___2_AIM_9M_Sidewinder_IR_AAM)
         LAU_105_1_AIM_9M_L = (1, Weapons.LAU_105_1_AIM_9M_L)
-        LAU_105_1_CATM_9M_L = (1, Weapons.LAU_105_1_CATM_9M_L)
         LAU_105___2_AIM_9P_Sidewinder_IR_AAM = (1, Weapons.LAU_105___2_AIM_9P_Sidewinder_IR_AAM)
         ALQ_131 = (1, Weapons.ALQ_131)
         ALQ_184 = (1, Weapons.ALQ_184)
@@ -1344,10 +1338,6 @@ class A_10A(PlaneType):
         LAU_88_AGM_65H_2_L = (3, Weapons.LAU_88_AGM_65H_2_L)
         LAU_88_AGM_65D_3 = (3, Weapons.LAU_88_AGM_65D_3)
         LAU_88_AGM_65H_3 = (3, Weapons.LAU_88_AGM_65H_3)
-        LAU_117_CATM_65K = (3, Weapons.LAU_117_CATM_65K)
-        LAU_117_TGM_65D = (3, Weapons.LAU_117_TGM_65D)
-        LAU_117_TGM_65G = (3, Weapons.LAU_117_TGM_65G)
-        LAU_117_TGM_65H = (3, Weapons.LAU_117_TGM_65H)
         Mk_84 = (3, Weapons.Mk_84)
         Mk_82 = (3, Weapons.Mk_82)
         Mk_82AIR = (3, Weapons.Mk_82AIR)
@@ -1473,10 +1463,6 @@ class A_10A(PlaneType):
         LAU_88_AGM_65H_2_R = (9, Weapons.LAU_88_AGM_65H_2_R)
         LAU_88_AGM_65D_3 = (9, Weapons.LAU_88_AGM_65D_3)
         LAU_88_AGM_65H_3 = (9, Weapons.LAU_88_AGM_65H_3)
-        LAU_117_CATM_65K = (9, Weapons.LAU_117_CATM_65K)
-        LAU_117_TGM_65D = (9, Weapons.LAU_117_TGM_65D)
-        LAU_117_TGM_65G = (9, Weapons.LAU_117_TGM_65G)
-        LAU_117_TGM_65H = (9, Weapons.LAU_117_TGM_65H)
         Mk_84 = (9, Weapons.Mk_84)
         Mk_82 = (9, Weapons.Mk_82)
         Mk_82AIR = (9, Weapons.Mk_82AIR)
@@ -1535,7 +1521,6 @@ class A_10A(PlaneType):
         LAU_105_2_AIM_9P5 = (11, Weapons.LAU_105_2_AIM_9P5)
         LAU_105___2_AIM_9M_Sidewinder_IR_AAM = (11, Weapons.LAU_105___2_AIM_9M_Sidewinder_IR_AAM)
         LAU_105_1_AIM_9M_R = (11, Weapons.LAU_105_1_AIM_9M_R)
-        LAU_105_1_CATM_9M_R = (11, Weapons.LAU_105_1_CATM_9M_R)
         LAU_105___2_AIM_9P_Sidewinder_IR_AAM = (11, Weapons.LAU_105___2_AIM_9P_Sidewinder_IR_AAM)
         ALQ_131 = (11, Weapons.ALQ_131)
         ALQ_184 = (11, Weapons.ALQ_184)
@@ -1837,9 +1822,6 @@ class MiG_23MLD(PlaneType):
 
     class Liveries:
 
-        class Ukraine(Enum):
-            af_standard = "af standard"
-
         class Russia(Enum):
             af_standard = "af standard"
             af_standard_1 = "af standard-1"
@@ -1935,8 +1917,8 @@ class Su_25(PlaneType):
     class Liveries:
 
         class Georgia(Enum):
-            field_camo_scheme__1__native_01 = "field camo scheme #1 (native)01"
             _scorpion__demo_scheme__native = "`scorpion` demo scheme (native)"
+            field_camo_scheme__1__native_01 = "field camo scheme #1 (native)01"
 
         class Ukraine(Enum):
             broken_camo_scheme__1__native___299th_oshap = "broken camo scheme #1 (native). 299th oshap"
@@ -3056,9 +3038,6 @@ class MiG_25PD(PlaneType):
 
     class Liveries:
 
-        class Ukraine(Enum):
-            af_standard = "af standard"
-
         class Russia(Enum):
             af_standard = "af standard"
 
@@ -3095,9 +3074,6 @@ class MiG_25RBT(PlaneType):
     max_speed = 3000
 
     class Liveries:
-
-        class Ukraine(Enum):
-            af_standard = "af standard"
 
         class Russia(Enum):
             af_standard = "af standard"
@@ -3175,16 +3151,16 @@ class Su_30(PlaneType):
     class Liveries:
 
         class Russia(Enum):
+            _desert__test_paint_scheme = "`desert` test paint scheme"
+            _russian_knights__team__25 = "`russian knights` team #25"
+            _snow__test_paint_scheme = "`snow` test paint scheme"
+            _test_pilots__team__597 = "`test-pilots` team #597"
             adf_148th_ctc_savasleyka_ab = "adf 148th ctc savasleyka ab"
             af_standard = "af standard"
             af_standard_early = "af standard early"
             af_standard_early__worn_out = "af standard early (worn-out)"
             af_standard_last = "af standard last"
             af_standard_last__worn_out = "af standard last (worn-out)"
-            _desert__test_paint_scheme = "`desert` test paint scheme"
-            _russian_knights__team__25 = "`russian knights` team #25"
-            _snow__test_paint_scheme = "`snow` test paint scheme"
-            _test_pilots__team__597 = "`test-pilots` team #597"
 
     class Pylon1:
         R_73 = (1, Weapons.R_73)
@@ -3581,8 +3557,8 @@ class MiG_31(PlaneType):
 
         class Russia(Enum):
             _174_GvIAP_Boris_Safonov = "174 GvIAP_Boris Safonov"
-            af_standard = "af standard"
             _903_White = "903_White"
+            af_standard = "af standard"
 
     class Pylon1:
         R_40R = (1, Weapons.R_40R)
@@ -3614,7 +3590,6 @@ class MiG_31(PlaneType):
 
 class Tu_95MS(PlaneType):
     id = "Tu-95MS"
-    group_size_max = 1
     large_parking_slot = True
     height = 13.3
     width = 50.04
@@ -3851,9 +3826,6 @@ class Su_24MR(PlaneType):
 
     class Liveries:
 
-        class Ukraine(Enum):
-            af_standard = "af standard"
-
         class Russia(Enum):
             af_standard = "af standard"
 
@@ -3943,7 +3915,6 @@ class F_117A(PlaneType):
 
 class B_1B(PlaneType):
     id = "B-1B"
-    group_size_max = 1
     large_parking_slot = True
     height = 10.36
     width = 41.67
@@ -4000,7 +3971,6 @@ class B_1B(PlaneType):
 
 class S_3B(PlaneType):
     id = "S-3B"
-    group_size_max = 1
     large_parking_slot = True
     height = 6.93
     width = 20.93
@@ -4075,7 +4045,6 @@ class S_3B(PlaneType):
 
 class S_3B_Tanker(PlaneType):
     id = "S-3B Tanker"
-    group_size_max = 1
     large_parking_slot = True
     height = 6.93
     width = 20.93
@@ -4125,9 +4094,9 @@ class Mirage_2000_5(PlaneType):
             ec1_2__spa103__cigogne_de_fonck = "ec1_2  spa103 `cigogne de fonck`"
             ec1_2__spa12__cigogne_a_ailes_ouvertes = "ec1_2  spa12 `cigogne a ailes ouvertes`"
             ec1_2_spa3__cigogne_de_guynemer = "ec1_2 spa3 `cigogne de guynemer`"
-            ec2_2_spa94__lamort_qui_fauche = "ec2_2 spa94 `lamort qui fauche`"
             ec2_2__cote_d_or__spa57__mouette = "ec2_2 `cote d'or` spa57 `mouette`"
             ec2_2__cote_d_or__spa65__chimere = "ec2_2 `cote d'or` spa65 `chimere`"
+            ec2_2_spa94__lamort_qui_fauche = "ec2_2 spa94 `lamort qui fauche`"
 
     class Pylon1:
         R_550_Magic_2 = (1, Weapons.R_550_Magic_2)
@@ -4973,6 +4942,15 @@ class MiG_29S(PlaneType):
             _115_GvIAP_Termez = "115 GvIAP_Termez"
             _31_GvIAP_Zernograd = "31 GvIAP_Zernograd"
 
+        class Belarus(Enum):
+            Belarusian_Air_Force = "Belarusian Air Force"
+
+        class Kazakhstan(Enum):
+            KazAADF_new__fictional = "KazAADF new (fictional)"
+            KazAADF_new__fictional_digital = "KazAADF new (fictional digital)"
+            KazAADF_new_faded__fictional = "KazAADF new faded (fictional)"
+            KazAADF_old__fictional = "KazAADF old (fictional)"
+
     class Pylon1:
         R_60M = (1, Weapons.R_60M)
         R_73 = (1, Weapons.R_73)
@@ -5718,7 +5696,6 @@ class MiG_29K(PlaneType):
 
 class Tu_142(PlaneType):
     id = "Tu-142"
-    group_size_max = 1
     large_parking_slot = True
     height = 13.3
     width = 50.04
@@ -5747,7 +5724,6 @@ class Tu_142(PlaneType):
 
 class C_130(PlaneType):
     id = "C-130"
-    group_size_max = 1
     large_parking_slot = True
     height = 11.66
     width = 40.4
@@ -5810,7 +5786,6 @@ class C_130(PlaneType):
 
 class An_26B(PlaneType):
     id = "An-26B"
-    group_size_max = 1
     large_parking_slot = True
     height = 8.575
     width = 29.2
@@ -5849,7 +5824,6 @@ class An_26B(PlaneType):
 
 class An_30M(PlaneType):
     id = "An-30M"
-    group_size_max = 1
     large_parking_slot = True
     height = 8.575
     width = 29.2
@@ -5881,7 +5855,6 @@ class An_30M(PlaneType):
 
 class C_17A(PlaneType):
     id = "C-17A"
-    group_size_max = 1
     large_parking_slot = True
     height = 16.79
     width = 51.76
@@ -5907,7 +5880,6 @@ class C_17A(PlaneType):
 
 class A_50(PlaneType):
     id = "A-50"
-    group_size_max = 1
     large_parking_slot = True
     height = 14.76
     width = 50.5
@@ -5935,7 +5907,6 @@ class A_50(PlaneType):
 
 class E_3A(PlaneType):
     id = "E-3A"
-    group_size_max = 1
     large_parking_slot = True
     height = 12.93
     width = 44.4
@@ -5970,7 +5941,6 @@ class E_3A(PlaneType):
 
 class IL_78M(PlaneType):
     id = "IL-78M"
-    group_size_max = 1
     large_parking_slot = True
     height = 14.76
     width = 50.5
@@ -6002,7 +5972,6 @@ class IL_78M(PlaneType):
 
 class E_2C(PlaneType):
     id = "E-2C"
-    group_size_max = 1
     large_parking_slot = True
     height = 5.59
     width = 24.56
@@ -6031,7 +6000,6 @@ class E_2C(PlaneType):
 
 class IL_76MD(PlaneType):
     id = "IL-76MD"
-    group_size_max = 1
     large_parking_slot = True
     height = 14.76
     width = 50.5
@@ -6640,9 +6608,9 @@ class F_16A_MLU(PlaneType):
             CMD_extended_skins = "CMD extended skins"
 
         class Norway(Enum):
+            CMD_extended_skins = "CMD extended skins"
             norway_338_skvadron = "norway 338 skvadron"
             norway_skv338 = "norway skv338"
-            CMD_extended_skins = "CMD extended skins"
 
         class Romania(Enum):
             CMD_extended_skins = "CMD extended skins"
@@ -6747,9 +6715,9 @@ class F_16A_MLU(PlaneType):
             CMD_extended_skins = "CMD extended skins"
 
         class TheNetherlands(Enum):
+            CMD_extended_skins = "CMD extended skins"
             the_netherlands__313th_squadron____twenthe_ab = "the netherlands (313th squadron `` twenthe ab)"
             the_netherlands_313th__tigers__squadron = "the netherlands 313th `tigers` squadron"
-            CMD_extended_skins = "CMD extended skins"
 
         class Turkey(Enum):
             CMD_extended_skins = "CMD extended skins"
@@ -6928,7 +6896,6 @@ class RQ_1A_Predator(PlaneType):
 
 class Yak_40(PlaneType):
     id = "Yak-40"
-    group_size_max = 1
     large_parking_slot = True
     height = 6.5
     width = 25
@@ -7510,7 +7477,6 @@ class A_10C(PlaneType):
 
 class KC_135(PlaneType):
     id = "KC-135"
-    group_size_max = 1
     large_parking_slot = True
     height = 12.93
     width = 40
@@ -7648,154 +7614,423 @@ class FW_190A8(PlaneType):
 
         class Georgia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Syria(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Finland(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Australia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Germany(Enum):
             FW_190A8_2_JG_54 = "FW-190A8_2.JG 54"
             FW_190A8_2_JG_54_Hans_Dortenmann = "FW-190A8_2.JG 54_Hans Dortenmann"
+            Fw190_Alfred_Bindseil = "Fw190_Alfred_Bindseil"
+            Fw190_Ewald_Preisz = "Fw190_Ewald_Preisz"
             FW_190A8 = "FW-190A8"
+            Factory_skin = "Factory skin"
+            FW_190A8_Yellow_4 = "FW-190A8 Yellow 4"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            FW_190A8_JG26_Priller = "FW-190A8 JG26 Priller"
+            FW_190A8_JG3_Maximowitz = "FW-190A8 JG3 Maximowitz"
+            JG3_White_nose_Wulf = "JG3 White nose Wulf"
+            Inspired_by_JG2_skin_of_early_Fw_190A = "Inspired by JG2 skin of early Fw 190A"
+            Black_13_Schwarze_Katze_from_JG1 = "Black 13 Schwarze Katze from JG1"
+            Fw190_Fuselage_D_JG301 = "Fw190_Fuselage_D_JG301"
 
         class SaudiArabia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Israel(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Croatia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class CzechRepublic(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            Fw_190_A_8_Czech_Avia_S_90 = "Fw 190 A-8 Czech Avia S.90"
 
         class Norway(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Romania(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            RoAF_Grupul7 = "RoAF-Grupul7"
 
         class Spain(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Ukraine(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Belgium(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Slovakia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Greece(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class UK(Enum):
             FW_190A8 = "FW-190A8"
+            FW_190A8_RAF = "FW-190A8_RAF"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Insurgents(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Hungary(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            FW_190A8_JG26_Priller = "FW-190A8 JG26 Priller"
+            FW_190A8_JG3_Maximowitz = "FW-190A8 JG3 Maximowitz"
+            FW_190A8_RHAF = "FW-190A8 RHAF"
 
         class France(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Abkhazia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Russia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Sweden(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Austria(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Switzerland(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Italy(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class SouthOssetia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class SouthKorea(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Iran(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class China(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Pakistan(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Belarus(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class NorthKorea(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Iraq(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Kazakhstan(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Bulgaria(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Serbia(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class India(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class USAFAggressors(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            Turkish_Air_Force__5th_FR__1942 = "Turkish Air Force, 5th FR (1942)"
 
         class USA(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Denmark(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Egypt(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Canada(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class TheNetherlands(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Turkey(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
+            Turkish_Air_Force__5th_FR__1942 = "Turkish Air Force, 5th FR (1942)"
 
         class Japan(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 
         class Poland(Enum):
             FW_190A8 = "FW-190A8"
+            Fictional_IJN_256th_Kokutai_Rai_153 = "Fictional IJN 256th Kokutai Rai-153"
+            Fictional_IJN_Carrier_Akagi_AI_103 = "Fictional IJN Carrier Akagi AI-103"
+            Fictional_IJN_Carrier_Akagi_AI_151 = "Fictional IJN Carrier Akagi AI-151"
+            Fictional_IJN_Carrier_Soryu_BI_112 = "Fictional IJN Carrier Soryu BI-112"
+            Fictional_IJN_OTU_Tsukuba_Tsu_102 = "Fictional IJN OTU Tsukuba Tsu-102"
 #ERRR <CLEAN>
 
     class Pylon1:
-        SC_250 = (1, Weapons.SC_250)
+        ER_4_SC50 = (1, Weapons.ER_4_SC50)
+        SC_501_SC250 = (1, Weapons.SC_501_SC250)
+        SC_250_Type_1_L2 = (1, Weapons.SC_250_Type_1_L2)
+        SC_501_SC500 = (1, Weapons.SC_501_SC500)
+        SC_500_L2 = (1, Weapons.SC_500_L2)
+        SD_250_Stg = (1, Weapons.SD_250_Stg)
+        SD_500_A = (1, Weapons.SD_500_A)
+        AB_250_2__w__SD_2_ = (1, Weapons.AB_250_2__w__SD_2_)
+        AB_250_2__w__SD_10A_ = (1, Weapons.AB_250_2__w__SD_10A_)
+        AB_500_1__w__SD_10A_ = (1, Weapons.AB_500_1__w__SD_10A_)
+        BF109K_4_FUEL_TANK = (1, Weapons.BF109K_4_FUEL_TANK)
 
-    pylons = {1}
+    class Pylon2:
+        Werfer_Granate_21 = (2, Weapons.Werfer_Granate_21)
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    class Pylon3:
+        Werfer_Granate_21 = (3, Weapons.Werfer_Granate_21)
+
+    pylons = {1, 2, 3}
+
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -8066,8 +8301,8 @@ class Bf_109K_4(PlaneType):
             Bf_109_K4_Dogfight_RED = "Bf-109 K4 Dogfight RED"
 
         class USA(Enum):
-            Bf_109_K4_Irmgard = "Bf-109 K4 Irmgard"
             Bf_109_K4_Dogfight_BLUE = "Bf-109 K4 Dogfight BLUE"
+            Bf_109_K4_Irmgard = "Bf-109 K4 Irmgard"
             Green = "Green"
             Bf_109_K4_Dogfight_RED = "Bf-109 K4 Dogfight RED"
             Bf_109_K4_US_captured = "Bf-109 K4 US captured"
@@ -8631,9 +8866,6 @@ class P_51D_30_NA(PlaneType):
     tasks = [task.CAP, task.Escort, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAS
 
-    class Liveries:
-        pass
-
 
 class AJS37(PlaneType):
     id = "AJS37"
@@ -8643,10 +8875,10 @@ class AJS37(PlaneType):
     length = 16.3
     fuel_max = 4476
     max_speed = 2203.2
-    chaff = 105
-    flare = 36
+    chaff = 210
+    flare = 72
     charge_total = 280
-    chaff_charge_size = 4
+    chaff_charge_size = 1
     flare_charge_size = 1
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
@@ -9217,7 +9449,9 @@ class AV8BNA(PlaneType):
         "EWDispenserBL": 2,
         "EWDispenserBR": 2,
         "WpBullseye": 0,
-        "ForceINSRules": False,
+        "AAR_Zone1": 0,
+        "AAR_Zone2": 0,
+        "AAR_Zone3": 0,
     }
 
     class Properties:
@@ -9284,8 +9518,14 @@ class AV8BNA(PlaneType):
         class WpBullseye:
             id = "WpBullseye"
 
-        class ForceINSRules:
-            id = "ForceINSRules"
+        class AAR_Zone1:
+            id = "AAR_Zone1"
+
+        class AAR_Zone2:
+            id = "AAR_Zone2"
+
+        class AAR_Zone3:
+            id = "AAR_Zone3"
 
     class Liveries:
 
@@ -10173,7 +10413,7 @@ class AV8BNA(PlaneType):
         _2_GBU_12 = (2, Weapons._2_GBU_12)
         _3_GBU_12 = (2, Weapons._3_GBU_12)
         _2_MK_82_AIR = (2, Weapons._2_MK_82_AIR)
-        _3_Mk_82AIR = (2, Weapons._3_Mk_82AIR)
+        _3_Mk_82AIR_ = (2, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE = (2, Weapons._2_MK_82_SNAKEYE)
         _3_MK_82_SNAKEYE = (2, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38 = (2, Weapons._2_GBU_38)
@@ -10225,7 +10465,7 @@ class AV8BNA(PlaneType):
         _3_GBU_12 = (3, Weapons._3_GBU_12)
         _2_GBU_16 = (3, Weapons._2_GBU_16)
         _2_MK_82_AIR = (3, Weapons._2_MK_82_AIR)
-        _3_Mk_82AIR = (3, Weapons._3_Mk_82AIR)
+        _3_Mk_82AIR_ = (3, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE = (3, Weapons._2_MK_82_SNAKEYE)
         _3_MK_82_SNAKEYE = (3, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38 = (3, Weapons._2_GBU_38)
@@ -10282,7 +10522,7 @@ class AV8BNA(PlaneType):
         _3_GBU_12 = (6, Weapons._3_GBU_12)
         _2_GBU_16_ = (6, Weapons._2_GBU_16_)
         _2_MK_82_AIR_ = (6, Weapons._2_MK_82_AIR_)
-        _3_Mk_82AIR = (6, Weapons._3_Mk_82AIR)
+        _3_Mk_82AIR_ = (6, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE_ = (6, Weapons._2_MK_82_SNAKEYE_)
         _3_MK_82_SNAKEYE = (6, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38_ = (6, Weapons._2_GBU_38_)
@@ -10330,7 +10570,7 @@ class AV8BNA(PlaneType):
         _2_GBU_12_ = (7, Weapons._2_GBU_12_)
         _3_GBU_12 = (7, Weapons._3_GBU_12)
         _2_MK_82_AIR_ = (7, Weapons._2_MK_82_AIR_)
-        _3_Mk_82AIR = (7, Weapons._3_Mk_82AIR)
+        _3_Mk_82AIR_ = (7, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE_ = (7, Weapons._2_MK_82_SNAKEYE_)
         _3_MK_82_SNAKEYE = (7, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38_ = (7, Weapons._2_GBU_38_)
@@ -10483,6 +10723,8 @@ class C_101EB(PlaneType):
         "SoloFlight": False,
         "NetCrewControlPriority": 1,
         "MountIFRHood": False,
+        "NS430allow": True,
+        "SmokeOnGround": False,
     }
 
     class Properties:
@@ -10501,6 +10743,12 @@ class C_101EB(PlaneType):
 
         class MountIFRHood:
             id = "MountIFRHood"
+
+        class NS430allow:
+            id = "NS430allow"
+
+        class SmokeOnGround:
+            id = "SmokeOnGround"
 
     class Liveries:
 
@@ -10538,15 +10786,16 @@ class C_101EB(PlaneType):
             default = "default"
 
         class Spain(Enum):
+            default = "default"
             AGA__Spanish_Air_School = "AGA (Spanish Air School)"
             AGA__Spanish_Air_School__1980 = "AGA (Spanish Air School) 1980"
             AGA__Spanish_Air_School__1985 = "AGA (Spanish Air School) 1985"
-            default = "default"
             CLAEX___Centro_Logístico_de_Armamento_y_Experimentación = "CLAEX - Centro Logístico de Armamento y Experimentación"
             _74_squadron_Matacan = "74 squadron Matacan"
             Patrulla_Aguila_25_Aniversario = "Patrulla Aguila 25 Aniversario"
             Patrulla_Aguila_30_Aniversario = "Patrulla Aguila 30 Aniversario"
             Patrulla_Aguila_Spanish_AGA = "Patrulla Aguila Spanish AGA"
+            XE_25_01_Prototype = "XE-25 01 Prototype"
             XE_25_01_Prototype_1978_Farnborough_Airshow = "XE-25 01 Prototype 1978 Farnborough Airshow"
             XE25_02_Prototype = "XE25-02 Prototype"
             XE25_02_Prototype_1989_TV_Commercial = "XE25-02 Prototype 1989 TV Commercial"
@@ -10718,6 +10967,7 @@ class C_101CC(PlaneType):
         "MountIFRHood": False,
         "CameraRecorder": False,
         "SightSunFilter": False,
+        "NS430allow": True,
     }
 
     class Properties:
@@ -10742,6 +10992,9 @@ class C_101CC(PlaneType):
 
         class SightSunFilter:
             id = "SightSunFilter"
+
+        class NS430allow:
+            id = "NS430allow"
 
     class Liveries:
 
@@ -10898,7 +11151,6 @@ class C_101CC(PlaneType):
 
     class Pylon2:
         Sea_Eagle = (2, Weapons.Sea_Eagle)
-        Mk_84 = (2, Weapons.Mk_84)
         Mk_82 = (2, Weapons.Mk_82)
         LAU_61___19_2_75__rockets_MK151_HE = (2, Weapons.LAU_61___19_2_75__rockets_MK151_HE)
         LAU_68___7_2_75__rockets_M151__HE_ = (2, Weapons.LAU_68___7_2_75__rockets_M151__HE_)
@@ -10910,7 +11162,6 @@ class C_101CC(PlaneType):
         FAB_100 = (2, Weapons.FAB_100)
         Belouga = (2, Weapons.Belouga)
         BR_250 = (2, Weapons.BR_250)
-        BR_500 = (2, Weapons.BR_500)
         BIN_200 = (2, Weapons.BIN_200)
 
     class Pylon3:
@@ -10918,7 +11169,6 @@ class C_101CC(PlaneType):
         LAU_68___7_2_75__rockets_M156_WP_ = (3, Weapons.LAU_68___7_2_75__rockets_M156_WP_)
         LAU_131___7_2_75__rockets_M257__Parachute_illumination_ = (3, Weapons.LAU_131___7_2_75__rockets_M257__Parachute_illumination_)
         LAU_68___7_2_75__rockets_M274__Practice_smoke_ = (3, Weapons.LAU_68___7_2_75__rockets_M274__Practice_smoke_)
-        Mk_84 = (3, Weapons.Mk_84)
         Mk_82 = (3, Weapons.Mk_82)
         BL755 = (3, Weapons.BL755)
         FAB_250 = (3, Weapons.FAB_250)
@@ -10938,7 +11188,6 @@ class C_101CC(PlaneType):
         LAU_68___7_2_75__rockets_M156_WP_ = (5, Weapons.LAU_68___7_2_75__rockets_M156_WP_)
         LAU_131___7_2_75__rockets_M257__Parachute_illumination_ = (5, Weapons.LAU_131___7_2_75__rockets_M257__Parachute_illumination_)
         LAU_68___7_2_75__rockets_M274__Practice_smoke_ = (5, Weapons.LAU_68___7_2_75__rockets_M274__Practice_smoke_)
-        Mk_84 = (5, Weapons.Mk_84)
         Mk_82 = (5, Weapons.Mk_82)
         BL755 = (5, Weapons.BL755)
         FAB_250 = (5, Weapons.FAB_250)
@@ -10951,7 +11200,6 @@ class C_101CC(PlaneType):
 
     class Pylon6:
         Sea_Eagle = (6, Weapons.Sea_Eagle)
-        Mk_84 = (6, Weapons.Mk_84)
         Mk_82 = (6, Weapons.Mk_82)
         LAU_61___19_2_75__rockets_MK151_HE = (6, Weapons.LAU_61___19_2_75__rockets_MK151_HE)
         LAU_68___7_2_75__rockets_M151__HE_ = (6, Weapons.LAU_68___7_2_75__rockets_M151__HE_)
@@ -10963,7 +11211,6 @@ class C_101CC(PlaneType):
         FAB_100 = (6, Weapons.FAB_100)
         Belouga = (6, Weapons.Belouga)
         BR_250 = (6, Weapons.BR_250)
-        BR_500 = (6, Weapons.BR_500)
         BIN_200 = (6, Weapons.BIN_200)
 
     class Pylon7:
@@ -11249,6 +11496,27 @@ class JF_17(PlaneType):
         },
     }
 
+    property_defaults = {
+        "LaserCode100": 6,
+        "LaserCode10": 8,
+        "LaserCode1": 8,
+        "AARProbe": False,
+    }
+
+    class Properties:
+
+        class LaserCode100:
+            id = "LaserCode100"
+
+        class LaserCode10:
+            id = "LaserCode10"
+
+        class LaserCode1:
+            id = "LaserCode1"
+
+        class AARProbe:
+            id = "AARProbe"
+
     class Liveries:
 
         class Georgia(Enum):
@@ -11397,6 +11665,12 @@ class JF_17(PlaneType):
 
     class Pylon1:
         DIS_PL_5EII = (1, Weapons.DIS_PL_5EII)
+        DIS_SMOKE_GENERATOR_R = (1, Weapons.DIS_SMOKE_GENERATOR_R)
+        DIS_SMOKE_GENERATOR_G = (1, Weapons.DIS_SMOKE_GENERATOR_G)
+        DIS_SMOKE_GENERATOR_B = (1, Weapons.DIS_SMOKE_GENERATOR_B)
+        DIS_SMOKE_GENERATOR_W = (1, Weapons.DIS_SMOKE_GENERATOR_W)
+        DIS_SMOKE_GENERATOR_Y = (1, Weapons.DIS_SMOKE_GENERATOR_Y)
+        DIS_SMOKE_GENERATOR_O = (1, Weapons.DIS_SMOKE_GENERATOR_O)
 
     class Pylon2:
         DIS_PL_5EII = (2, Weapons.DIS_PL_5EII)
@@ -11412,6 +11686,8 @@ class JF_17(PlaneType):
         Mk_83 = (2, Weapons.Mk_83)
         DIS_MK_20 = (2, Weapons.DIS_MK_20)
         DIS_GBU_12 = (2, Weapons.DIS_GBU_12)
+        DIS_TYPE200 = (2, Weapons.DIS_TYPE200)
+        DIS_TYPE200_DUAL_L = (2, Weapons.DIS_TYPE200_DUAL_L)
         BRU_33___2_x_Mk_82 = (2, Weapons.BRU_33___2_x_Mk_82)
         BRU_33___2_x_Mk_82_SnakeEye = (2, Weapons.BRU_33___2_x_Mk_82_SnakeEye)
         BRU_33___2_x_Mk_20_Rockeye = (2, Weapons.BRU_33___2_x_Mk_20_Rockeye)
@@ -11421,6 +11697,12 @@ class JF_17(PlaneType):
         BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (2, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         DIS_WMD7 = (2, Weapons.DIS_WMD7)
         DIS_AKG_DLPOD = (2, Weapons.DIS_AKG_DLPOD)
+        DIS_SMOKE_GENERATOR_R = (2, Weapons.DIS_SMOKE_GENERATOR_R)
+        DIS_SMOKE_GENERATOR_G = (2, Weapons.DIS_SMOKE_GENERATOR_G)
+        DIS_SMOKE_GENERATOR_B = (2, Weapons.DIS_SMOKE_GENERATOR_B)
+        DIS_SMOKE_GENERATOR_W = (2, Weapons.DIS_SMOKE_GENERATOR_W)
+        DIS_SMOKE_GENERATOR_Y = (2, Weapons.DIS_SMOKE_GENERATOR_Y)
+        DIS_SMOKE_GENERATOR_O = (2, Weapons.DIS_SMOKE_GENERATOR_O)
 
     class Pylon3:
         DIS_C_802AK = (3, Weapons.DIS_C_802AK)
@@ -11435,9 +11717,6 @@ class JF_17(PlaneType):
         Mk_84 = (3, Weapons.Mk_84)
         DIS_GBU_10 = (3, Weapons.DIS_GBU_10)
         DIS_GBU_16 = (3, Weapons.DIS_GBU_16)
-        DIS_BRM1_90 = (3, Weapons.DIS_BRM1_90)
-        DIS_RKT_90_UG = (3, Weapons.DIS_RKT_90_UG)
-        BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (3, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
 
     class Pylon4:
         DIS_TANK800 = (4, Weapons.DIS_TANK800)
@@ -11448,6 +11727,12 @@ class JF_17(PlaneType):
         DIS_WMD7 = (4, Weapons.DIS_WMD7)
         DIS_AKG_DLPOD = (4, Weapons.DIS_AKG_DLPOD)
         DIS_SPJ_POD = (4, Weapons.DIS_SPJ_POD)
+        DIS_SMOKE_GENERATOR_R = (4, Weapons.DIS_SMOKE_GENERATOR_R)
+        DIS_SMOKE_GENERATOR_G = (4, Weapons.DIS_SMOKE_GENERATOR_G)
+        DIS_SMOKE_GENERATOR_B = (4, Weapons.DIS_SMOKE_GENERATOR_B)
+        DIS_SMOKE_GENERATOR_W = (4, Weapons.DIS_SMOKE_GENERATOR_W)
+        DIS_SMOKE_GENERATOR_Y = (4, Weapons.DIS_SMOKE_GENERATOR_Y)
+        DIS_SMOKE_GENERATOR_O = (4, Weapons.DIS_SMOKE_GENERATOR_O)
 
     class Pylon5:
         DIS_C_802AK = (5, Weapons.DIS_C_802AK)
@@ -11462,9 +11747,6 @@ class JF_17(PlaneType):
         Mk_84 = (5, Weapons.Mk_84)
         DIS_GBU_10 = (5, Weapons.DIS_GBU_10)
         DIS_GBU_16 = (5, Weapons.DIS_GBU_16)
-        DIS_BRM1_90 = (5, Weapons.DIS_BRM1_90)
-        DIS_RKT_90_UG = (5, Weapons.DIS_RKT_90_UG)
-        BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (5, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
 
     class Pylon6:
         DIS_PL_5EII = (6, Weapons.DIS_PL_5EII)
@@ -11480,6 +11762,8 @@ class JF_17(PlaneType):
         Mk_83 = (6, Weapons.Mk_83)
         DIS_MK_20 = (6, Weapons.DIS_MK_20)
         DIS_GBU_12 = (6, Weapons.DIS_GBU_12)
+        DIS_TYPE200 = (6, Weapons.DIS_TYPE200)
+        DIS_TYPE200_DUAL_R = (6, Weapons.DIS_TYPE200_DUAL_R)
         BRU_33___2_x_Mk_82 = (6, Weapons.BRU_33___2_x_Mk_82)
         BRU_33___2_x_Mk_82_SnakeEye = (6, Weapons.BRU_33___2_x_Mk_82_SnakeEye)
         BRU_33___2_x_Mk_20_Rockeye = (6, Weapons.BRU_33___2_x_Mk_20_Rockeye)
@@ -11489,9 +11773,21 @@ class JF_17(PlaneType):
         BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (6, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         DIS_WMD7 = (6, Weapons.DIS_WMD7)
         DIS_AKG_DLPOD = (6, Weapons.DIS_AKG_DLPOD)
+        DIS_SMOKE_GENERATOR_R = (6, Weapons.DIS_SMOKE_GENERATOR_R)
+        DIS_SMOKE_GENERATOR_G = (6, Weapons.DIS_SMOKE_GENERATOR_G)
+        DIS_SMOKE_GENERATOR_B = (6, Weapons.DIS_SMOKE_GENERATOR_B)
+        DIS_SMOKE_GENERATOR_W = (6, Weapons.DIS_SMOKE_GENERATOR_W)
+        DIS_SMOKE_GENERATOR_Y = (6, Weapons.DIS_SMOKE_GENERATOR_Y)
+        DIS_SMOKE_GENERATOR_O = (6, Weapons.DIS_SMOKE_GENERATOR_O)
 
     class Pylon7:
         DIS_PL_5EII = (7, Weapons.DIS_PL_5EII)
+        DIS_SMOKE_GENERATOR_R = (7, Weapons.DIS_SMOKE_GENERATOR_R)
+        DIS_SMOKE_GENERATOR_G = (7, Weapons.DIS_SMOKE_GENERATOR_G)
+        DIS_SMOKE_GENERATOR_B = (7, Weapons.DIS_SMOKE_GENERATOR_B)
+        DIS_SMOKE_GENERATOR_W = (7, Weapons.DIS_SMOKE_GENERATOR_W)
+        DIS_SMOKE_GENERATOR_Y = (7, Weapons.DIS_SMOKE_GENERATOR_Y)
+        DIS_SMOKE_GENERATOR_O = (7, Weapons.DIS_SMOKE_GENERATOR_O)
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
@@ -13047,6 +13343,17 @@ class F_16C_50(PlaneType):
 
         class USA(Enum):
             default = "default"
+            _13th_Fighter_Squadron = "13th_Fighter_Squadron"
+            _14th_Fighter_Squadron = "14th_Fighter_Squadron"
+            _179th_Fighter_Squadron = "179th_Fighter_Squadron"
+            _22nd_Fighter_Squadron = "22nd_Fighter_Squadron"
+            _23rd_Fighter_Squadron = "23rd_Fighter_Squadron"
+            _480th_Fighter_Squadron = "480th_Fighter_Squadron"
+            _522nd_Fighter_Squadron = "522nd_Fighter_Squadron"
+            _55th_Fighter_Squadron = "55th_Fighter_Squadron"
+            _77th_Fighter_Squadron = "77th_Fighter_Squadron"
+            _79th_Fighter_Squadron = "79th_Fighter_Squadron"
+            Dark_Viper = "Dark_Viper"
 
     class Pylon1:
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -13353,15 +13660,15 @@ class F_5E(PlaneType):
             USA_standard = "USA standard"
 
         class USAFAggressors(Enum):
-            aggressor__desert__scheme = "aggressor `desert` scheme"
-            aggressor__marine__scheme = "aggressor `marine` scheme"
-            aggressor__snake__scheme = "aggressor `snake` scheme"
+            Aggressor_Desert_Scheme = "Aggressor Desert Scheme"
+            Aggressor_Marine_Scheme = "Aggressor Marine Scheme"
+            Aggressor_Snake_Scheme = "Aggressor Snake Scheme"
             USA_standard = "USA standard"
 
         class USA(Enum):
-            aggressor__desert__scheme = "aggressor `desert` scheme"
-            aggressor__marine__scheme = "aggressor `marine` scheme"
-            aggressor__snake__scheme = "aggressor `snake` scheme"
+            Aggressor_Desert_Scheme = "Aggressor Desert Scheme"
+            Aggressor_Marine_Scheme = "Aggressor Marine Scheme"
+            Aggressor_Snake_Scheme = "Aggressor Snake Scheme"
             USA_standard = "USA standard"
 
         class Denmark(Enum):
@@ -13858,17 +14165,16 @@ class F_5E_3(PlaneType):
             USA_standard = "USA standard"
 
         class USAFAggressors(Enum):
+            Aggressor_Desert_Scheme = "Aggressor Desert Scheme"
+            Aggressor_Marine_Scheme = "Aggressor Marine Scheme"
+            Aggressor_Snake_Scheme = "Aggressor Snake Scheme"
             US_Aggressor_VFC_13_01 = "US Aggressor VFC-13 01"
+            Aggressor_VFC_13_11 = "Aggressor VFC-13 11"
+            Aggressor_VFC_13_21 = "Aggressor VFC-13 21"
             US_Aggressor_VFC_13_25 = "US Aggressor VFC-13 25"
             US_Aggressor_VFC_13_28_Fict_Splinter = "US Aggressor VFC-13 28 Fict Splinter"
             US_Aggressor_VFC_13_40 = "US Aggressor VFC-13 40"
             US_Aggressor_VMFT_401_02_2011 = "US Aggressor VMFT-401 02 2011"
-            aggressor_VFC_13__11 = "aggressor VFC-13 '11'"
-            aggressor_VFC_13__21 = "aggressor VFC-13 '21'"
-            aggressor__desert__scheme = "aggressor `desert` scheme"
-            aggressor__marine__scheme = "aggressor `marine` scheme"
-            aggressor__snake__scheme = "aggressor `snake` scheme"
-            black__Mig_28 = "black 'Mig-28'"
             TW_NGRC_5315 = "TW NGRC 5315"
             ROCAF_7th_Fighter_Group = "ROCAF 7th Fighter Group"
             TW_ROCAF_7thFG_M = "TW ROCAF 7thFG(M)"
@@ -13879,19 +14185,19 @@ class F_5E_3(PlaneType):
             USA_standard = "USA standard"
             USAF__Southeast_Asia = "USAF 'Southeast Asia'"
             US_USAF_Grape_31 = "US USAF Grape 31"
+            black__Mig_28 = "black 'Mig-28'"
 
         class USA(Enum):
+            Aggressor_Desert_Scheme = "Aggressor Desert Scheme"
+            Aggressor_Marine_Scheme = "Aggressor Marine Scheme"
+            Aggressor_Snake_Scheme = "Aggressor Snake Scheme"
             US_Aggressor_VFC_13_01 = "US Aggressor VFC-13 01"
+            Aggressor_VFC_13_11 = "Aggressor VFC-13 11"
+            Aggressor_VFC_13_21 = "Aggressor VFC-13 21"
             US_Aggressor_VFC_13_25 = "US Aggressor VFC-13 25"
             US_Aggressor_VFC_13_28_Fict_Splinter = "US Aggressor VFC-13 28 Fict Splinter"
             US_Aggressor_VFC_13_40 = "US Aggressor VFC-13 40"
             US_Aggressor_VMFT_401_02_2011 = "US Aggressor VMFT-401 02 2011"
-            aggressor_VFC_13__11 = "aggressor VFC-13 '11'"
-            aggressor_VFC_13__21 = "aggressor VFC-13 '21'"
-            aggressor__desert__scheme = "aggressor `desert` scheme"
-            aggressor__marine__scheme = "aggressor `marine` scheme"
-            aggressor__snake__scheme = "aggressor `snake` scheme"
-            black__Mig_28 = "black 'Mig-28'"
             TW_NGRC_5315 = "TW NGRC 5315"
             TW_ROCAF_7thFG_M = "TW ROCAF 7thFG(M)"
             US_Aggressor_VFC_111_01 = "US Aggressor VFC-111 01"
@@ -13901,6 +14207,7 @@ class F_5E_3(PlaneType):
             USA_standard = "USA standard"
             USAF__Southeast_Asia = "USAF 'Southeast Asia'"
             US_USAF_Grape_31 = "US USAF Grape 31"
+            black__Mig_28 = "black 'Mig-28'"
 
         class Denmark(Enum):
             USA_standard = "USA standard"
@@ -14267,9 +14574,9 @@ class F_86F_Sabre(PlaneType):
             US_Air_Force = "US Air Force"
             US_Air_Force__Green = "US Air Force (Green)"
             US_Air_Force__Squadron_39 = "US Air Force (Squadron 39)"
-            US_Air_Force__ex_USAF_F_86A_Sabre = "US Air Force (ex-USAF F-86A Sabre)"
             US_Air_Force__code_FU_178 = "US Air Force (code FU-178)"
             US_Air_Force__Skyblazers = "US Air Force (Skyblazers)"
+            US_Air_Force__ex_USAF_F_86A_Sabre = "US Air Force (ex-USAF F-86A Sabre)"
             default_livery = "default livery"
 
         class Denmark(Enum):
@@ -15949,144 +16256,183 @@ class FA_18C_hornet(PlaneType):
     class Liveries:
 
         class Georgia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Syria(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Finland(Enum):
-            Finland_31 = "Finland 31"
+            F_18_IRIAF = "F-18 IRIAF"
             Finland_21 = "Finland 21"
+            Finland_31 = "Finland 31"
             default_livery = "default livery"
 
         class Australia(Enum):
             Australian_75th_Squadron = "Australian 75th Squadron"
             Australian_77th_Squadron = "Australian 77th Squadron"
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Germany(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class SaudiArabia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Israel(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Fictional_Israel_Air_Force = "Fictional Israel Air Force"
             default_livery = "default livery"
 
         class Croatia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class CzechRepublic(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Norway(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Romania(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Spain(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
+            Spain_462th_Escuadron_C_15_79 = "Spain 462th Escuadron C.15-79"
             Spain_111th_Escuadron_C_15_73 = "Spain 111th Escuadron C.15-73"
             Spain_111th_Escuadron_C_15_88 = "Spain 111th Escuadron C.15-88"
             Spain_121th_Escuadron_C_15_45 = "Spain 121th Escuadron C.15-45"
             Spain_121th_Escuadron_C_15_50 = "Spain 121th Escuadron C.15-50"
             Spain_121th_Escuadron_C_15_60 = "Spain 121th Escuadron C.15-60"
             Spain_121th_Escuadron_C_15_34_50th_Anniversary = "Spain 121th Escuadron C.15-34 50th Anniversary"
-            Spain_151th_Escuadron_C_15_14_Tiger_Meet = "Spain 151th Escuadron C.15-14 Tiger Meet"
             Spain_151th_Escuadron_C_15_14 = "Spain 151th Escuadron C.15-14"
             Spain_151th_Escuadron_C_15_18 = "Spain 151th Escuadron C.15-18"
             Spain_151th_Escuadron_C_15_23 = "Spain 151th Escuadron C.15-23"
             Spain_151th_Escuadron_C_15_24 = "Spain 151th Escuadron C.15-24"
+            Spain_151th_Escuadron_C_15_14_Tiger_Meet = "Spain 151th Escuadron C.15-14 Tiger Meet"
             Spain_211th_Escuadron_C_15_76 = "Spain 211th Escuadron C.15-76"
             Spain_211th_Escuadron_C_15_77 = "Spain 211th Escuadron C.15-77"
             Spain_462th_Escuadron_C_15_90 = "Spain 462th Escuadron C.15-90"
-            Spain_462th_Escuadron_C_15_79 = "Spain 462th Escuadron C.15-79"
             default_livery = "default livery"
 
         class Ukraine(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Fictional_Ukraine_Air_Force = "Fictional Ukraine Air Force"
             default_livery = "default livery"
 
         class Belgium(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Slovakia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Greece(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class UK(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Fictional_UK_Air_Force = "Fictional UK Air Force"
             default_livery = "default livery"
 
         class Insurgents(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Hungary(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class France(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Abkhazia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Russia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Fictional_Russia_Air_Force = "Fictional Russia Air Force"
             default_livery = "default livery"
 
         class Sweden(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Austria(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Switzerland(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Switzerland = "Switzerland"
             default_livery = "default livery"
 
         class Italy(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class SouthOssetia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class SouthKorea(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Iran(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class China(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Pakistan(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Belarus(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class NorthKorea(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Iraq(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Kazakhstan(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Bulgaria(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Serbia(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class India(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class USAFAggressors(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             Fictional_Russia_Air_Force = "Fictional Russia Air Force"
             VFC_12 = "VFC-12"
             NAWDC_blue = "NAWDC blue"
@@ -16098,6 +16444,7 @@ class FA_18C_hornet(PlaneType):
 
         class USA(Enum):
             VFA_37 = "VFA-37"
+            F_18_IRIAF = "F-18 IRIAF"
             VFA_106 = "VFA-106"
             VFA_106_high_visibility = "VFA-106 high visibility"
             VFA_113 = "VFA-113"
@@ -16137,9 +16484,11 @@ class FA_18C_hornet(PlaneType):
             Blue_Angels_Jet_Team = "Blue Angels Jet Team"
 
         class Denmark(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Egypt(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Canada(Enum):
@@ -16147,19 +16496,24 @@ class FA_18C_hornet(PlaneType):
             Canada_409th_Squadron = "Canada 409th Squadron"
             Canada_425th_Squadron = "Canada 425th Squadron"
             Canada_NORAD_60_Demo_Jet = "Canada NORAD 60 Demo Jet"
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class TheNetherlands(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Turkey(Enum):
             Fictional_Turkey_162nd_Sq = "Fictional Turkey 162nd Sq"
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Japan(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
         class Poland(Enum):
+            F_18_IRIAF = "F-18 IRIAF"
             default_livery = "default livery"
 
     class Pylon1:
@@ -16194,8 +16548,8 @@ class FA_18C_hornet(PlaneType):
         BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (2, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         BRU_33_LAU_10___4_ZUNI_MK_71 = (2, Weapons.BRU_33_LAU_10___4_ZUNI_MK_71)
         BRU_33___2_LAU_10___4_ZUNI_MK_71 = (2, Weapons.BRU_33___2_LAU_10___4_ZUNI_MK_71)
-        BRU_33_LAU_61___19_2_75__rockets_MK151_HE = (2, Weapons.BRU_33_LAU_61___19_2_75__rockets_MK151_HE)
-        BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE = (2, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE)
+        BRU_33_LAU_61___19_2_75__rockets_M151__HE_ = (2, Weapons.BRU_33_LAU_61___19_2_75__rockets_M151__HE_)
+        BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_ = (2, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_)
         Mk_82 = (2, Weapons.Mk_82)
         Mk_82_SnakeEye = (2, Weapons.Mk_82_SnakeEye)
         Mk_82Y = (2, Weapons.Mk_82Y)
@@ -16240,10 +16594,12 @@ class FA_18C_hornet(PlaneType):
         AGM_88C_ = (3, Weapons.AGM_88C_)
         BRU_33_LAU_68___7_2_75__rockets_M151__HE_ = (3, Weapons.BRU_33_LAU_68___7_2_75__rockets_M151__HE_)
         BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_ = (3, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_)
+        BRU_33_LAU_68___7_2_75__rockets_MK5__HE_ = (3, Weapons.BRU_33_LAU_68___7_2_75__rockets_MK5__HE_)
+        BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (3, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         BRU_33_LAU_10___4_ZUNI_MK_71 = (3, Weapons.BRU_33_LAU_10___4_ZUNI_MK_71)
         BRU_33___2_LAU_10___4_ZUNI_MK_71 = (3, Weapons.BRU_33___2_LAU_10___4_ZUNI_MK_71)
-        BRU_33_LAU_61___19_2_75__rockets_MK151_HE = (3, Weapons.BRU_33_LAU_61___19_2_75__rockets_MK151_HE)
-        BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE = (3, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE)
+        BRU_33_LAU_61___19_2_75__rockets_M151__HE_ = (3, Weapons.BRU_33_LAU_61___19_2_75__rockets_M151__HE_)
+        BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_ = (3, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_)
         Mk_82 = (3, Weapons.Mk_82)
         Mk_82_SnakeEye = (3, Weapons.Mk_82_SnakeEye)
         Mk_82Y = (3, Weapons.Mk_82Y)
@@ -16281,6 +16637,7 @@ class FA_18C_hornet(PlaneType):
         AIM_7MH = (4, Weapons.AIM_7MH)
         AIM_120B = (4, Weapons.AIM_120B)
         AIM_120C = (4, Weapons.AIM_120C)
+        AN_AAQ_28_LITENING_ = (4, Weapons.AN_AAQ_28_LITENING_)
 
     class Pylon5:
         FPU_8A_Fuel_Tank_330_gallons = (5, Weapons.FPU_8A_Fuel_Tank_330_gallons)
@@ -16320,10 +16677,12 @@ class FA_18C_hornet(PlaneType):
         AGM_88C_ = (7, Weapons.AGM_88C_)
         BRU_33_LAU_68___7_2_75__rockets_M151__HE_ = (7, Weapons.BRU_33_LAU_68___7_2_75__rockets_M151__HE_)
         BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_ = (7, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_)
+        BRU_33_LAU_68___7_2_75__rockets_MK5__HE_ = (7, Weapons.BRU_33_LAU_68___7_2_75__rockets_MK5__HE_)
+        BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (7, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         BRU_33_LAU_10___4_ZUNI_MK_71 = (7, Weapons.BRU_33_LAU_10___4_ZUNI_MK_71)
         BRU_33___2_LAU_10___4_ZUNI_MK_71 = (7, Weapons.BRU_33___2_LAU_10___4_ZUNI_MK_71)
-        BRU_33_LAU_61___19_2_75__rockets_MK151_HE = (7, Weapons.BRU_33_LAU_61___19_2_75__rockets_MK151_HE)
-        BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE = (7, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE)
+        BRU_33_LAU_61___19_2_75__rockets_M151__HE_ = (7, Weapons.BRU_33_LAU_61___19_2_75__rockets_M151__HE_)
+        BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_ = (7, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_)
         Mk_82 = (7, Weapons.Mk_82)
         Mk_82_SnakeEye = (7, Weapons.Mk_82_SnakeEye)
         Mk_82Y = (7, Weapons.Mk_82Y)
@@ -16380,8 +16739,8 @@ class FA_18C_hornet(PlaneType):
         BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = (8, Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_)
         BRU_33_LAU_10___4_ZUNI_MK_71 = (8, Weapons.BRU_33_LAU_10___4_ZUNI_MK_71)
         BRU_33___2_LAU_10___4_ZUNI_MK_71 = (8, Weapons.BRU_33___2_LAU_10___4_ZUNI_MK_71)
-        BRU_33_LAU_61___19_2_75__rockets_MK151_HE = (8, Weapons.BRU_33_LAU_61___19_2_75__rockets_MK151_HE)
-        BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE = (8, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE)
+        BRU_33_LAU_61___19_2_75__rockets_M151__HE_ = (8, Weapons.BRU_33_LAU_61___19_2_75__rockets_M151__HE_)
+        BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_ = (8, Weapons.BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_)
         Mk_82 = (8, Weapons.Mk_82)
         Mk_82_SnakeEye = (8, Weapons.Mk_82_SnakeEye)
         Mk_82Y = (8, Weapons.Mk_82Y)
@@ -18017,7 +18376,6 @@ class MiG_15bis(PlaneType):
     class Liveries:
 
         class Georgia(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class Syria(Enum):
@@ -18056,7 +18414,6 @@ class MiG_15bis(PlaneType):
             default_livery = "default livery"
 
         class Ukraine(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class Belgium(Enum):
@@ -18082,7 +18439,6 @@ class MiG_15bis(PlaneType):
             default_livery = "default livery"
 
         class Abkhazia(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class Russia(Enum):
@@ -18106,7 +18462,6 @@ class MiG_15bis(PlaneType):
             default_livery = "default livery"
 
         class SouthOssetia(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class SouthKorea(Enum):
@@ -18124,7 +18479,6 @@ class MiG_15bis(PlaneType):
             default_livery = "default livery"
 
         class Belarus(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class NorthKorea(Enum):
@@ -18137,7 +18491,6 @@ class MiG_15bis(PlaneType):
             default_livery = "default livery"
 
         class Kazakhstan(Enum):
-            USSR_Air_Forces = "USSR_Air Forces"
             default_livery = "default livery"
 
         class Bulgaria(Enum):
@@ -18257,292 +18610,292 @@ class MiG_19P(PlaneType):
     class Liveries:
 
         class Georgia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Syria(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Finland(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Australia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Germany(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class SaudiArabia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Israel(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Croatia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class CzechRepublic(Enum):
+            default = "default"
             IAP = "IAP"
             CZechoslovakia = "CZechoslovakia"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Norway(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Romania(Enum):
+            default = "default"
             IAP = "IAP"
             Romania___66th_Fighter_Division = "Romania - 66th Fighter Division"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Spain(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Ukraine(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Belgium(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Slovakia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Greece(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class UK(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Insurgents(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Hungary(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class France(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Abkhazia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Russia(Enum):
+            default = "default"
             IAP = "IAP"
             USSR_2 = "USSR_2"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Sweden(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Austria(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Switzerland(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Italy(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class SouthOssetia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class SouthKorea(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Iran(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class China(Enum):
+            default = "default"
             PLAAF = "PLAAF"
             IAP = "IAP"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             PLAAF_CAMO = "PLAAF CAMO"
             Snow___Fictional = "Snow - Fictional"
 
         class Pakistan(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Belarus(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class NorthKorea(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Iraq(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Kazakhstan(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Bulgaria(Enum):
+            default = "default"
             Bulgaria = "Bulgaria"
             IAP = "IAP"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Serbia(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class India(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class USAFAggressors(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class USA(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Denmark(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Egypt(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Canada(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class TheNetherlands(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Turkey(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Japan(Enum):
-            IAP = "IAP"
             default = "default"
+            IAP = "IAP"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
         class Poland(Enum):
+            default = "default"
             IAP = "IAP"
             Poland_39_PLM = "Poland 39 PLM"
             Poland_62_PLM = "Poland 62 PLM"
-            default = "default"
             DDR___Fictional = "DDR - Fictional"
             Snow___Fictional = "Snow - Fictional"
 
@@ -18649,9 +19002,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18680,9 +19033,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18711,9 +19064,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18742,9 +19095,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18773,9 +19126,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18804,9 +19157,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18835,9 +19188,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18866,9 +19219,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18897,9 +19250,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18928,9 +19281,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18959,9 +19312,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -18990,9 +19343,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19021,9 +19374,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19052,9 +19405,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19083,9 +19436,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19114,9 +19467,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19145,9 +19498,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19176,9 +19529,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19207,9 +19560,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19238,9 +19591,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19269,9 +19622,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19300,9 +19653,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19331,9 +19684,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19362,9 +19715,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19393,9 +19746,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19424,9 +19777,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19455,9 +19808,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19486,9 +19839,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19517,9 +19870,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19548,9 +19901,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19579,9 +19932,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19610,9 +19963,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19641,9 +19994,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19672,9 +20025,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19703,9 +20056,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19734,9 +20087,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19765,9 +20118,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19796,9 +20149,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19827,9 +20180,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19858,9 +20211,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19889,9 +20242,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19920,9 +20273,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19951,9 +20304,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -19982,9 +20335,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -20013,9 +20366,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -20044,9 +20397,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -20075,9 +20428,9 @@ class MiG_21Bis(PlaneType):
             Egypt_Tan = "Egypt Tan"
             Finland___HavLLv_31 = "Finland - HavLLv 31"
             HunAF_Griff_Sqn___47th_AB = "HunAF Griff Sqn. (47th AB)"
-            India___15_Sqn = "India - 15 Sqn"
             IRIAF___51st_SQN = "IRIAF - 51st SQN"
             IRIAF___Standard = "IRIAF - Standard"
+            India___15_Sqn = "India - 15 Sqn"
             Iraq_AF___17th_SQN__1 = "Iraq AF - 17th SQN (1)"
             Iraq_AF___17th_SQN__2 = "Iraq AF - 17th SQN (2)"
             Northeria___32_FS = "Northeria - 32 FS"
@@ -20492,7 +20845,6 @@ class Yak_52(PlaneType):
     length = 7.745
     fuel_max = 87.84
     max_speed = 270
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 132
 
     panel_radio = {
@@ -20716,6 +21068,58 @@ class B_17G(PlaneType):
     pylons = {1}
 
     tasks = [task.GroundAttack, task.RunwayAttack]
+    task_default = task.GroundAttack
+
+
+class A_20G(PlaneType):
+    id = "A-20G"
+    height = 4.83
+    width = 18.69
+    length = 14.63
+    fuel_max = 1500
+    max_speed = 619.2
+
+    property_defaults = {
+    }
+
+    class Liveries:
+
+        class UK(Enum):
+            _107_Sqn = "107 Sqn"
+
+        class Russia(Enum):
+            USSR_1st_GMTAP = "USSR 1st GMTAP"
+            USSR_27_APE_DD = "USSR 27 APE DD"
+
+        class USA(Enum):
+            USAF_645th_BS = "USAF 645th BS"
+            USAF_668th_BS = "USAF 668th BS"
+
+    class Pylon1:
+        _4___AN_M64 = (1, Weapons._4___AN_M64)
+
+    pylons = {1}
+
+    tasks = [task.GroundAttack, task.RunwayAttack, task.CAS]
+    task_default = task.CAS
+
+
+class Ju_88A4(PlaneType):
+    id = "Ju-88A4"
+    height = 5.07
+    width = 20.08
+    length = 14.35
+    fuel_max = 2120
+    max_speed = 540
+
+    property_defaults = {
+    }
+#ERRR {LTF_5B}
+#ERRR {LTF_5B}
+
+    pylons = {1, 3}
+
+    tasks = [task.GroundAttack, task.RunwayAttack, task.AntishipStrike]
     task_default = task.GroundAttack
 
 
@@ -20986,5 +21390,7 @@ plane_map = {
     "Su-34": Su_34,
     "Yak-52": Yak_52,
     "B-17G": B_17G,
+    "A-20G": A_20G,
+    "Ju-88A4": Ju_88A4,
     "TF-51D": TF_51D,
 }

--- a/dcs/ships.py
+++ b/dcs/ships.py
@@ -155,6 +155,17 @@ class SSK_641B(unittype.ShipType):
     air_weapon_dist = 0
 
 
+class CV_1143_5_Admiral_Kuznetsov_2017(unittype.ShipType):
+    id = "CV_1143_5"
+    name = "CV 1143.5 Admiral Kuznetsov(2017)"
+    plane_num = 24
+    helicopter_num = 12
+    parking = 3
+    detection_range = 25000
+    threat_range = 12000
+    air_weapon_dist = 12000
+
+
 class CVN_74_John_C__Stennis(unittype.ShipType):
     id = "Stennis"
     name = "CVN-74 John C. Stennis"
@@ -164,6 +175,49 @@ class CVN_74_John_C__Stennis(unittype.ShipType):
     detection_range = 30000
     threat_range = 15000
     air_weapon_dist = 15000
+
+
+class CVN_71_Theodore_Roosevelt(unittype.ShipType):
+    id = "CVN_71"
+    name = "CVN-71 Theodore Roosevelt"
+    plane_num = 72
+    helicopter_num = 6
+    parking = 4
+    detection_range = 30000
+    threat_range = 15000
+    air_weapon_dist = 15000
+
+
+class CVN_72_Abraham_Lincoln(unittype.ShipType):
+    id = "CVN_72"
+    name = "CVN-72 Abraham Lincoln"
+    plane_num = 72
+    helicopter_num = 6
+    parking = 4
+    detection_range = 30000
+    threat_range = 15000
+    air_weapon_dist = 15000
+
+
+class CVN_73_George_Washington(unittype.ShipType):
+    id = "CVN_73"
+    name = "CVN-73 George Washington"
+    plane_num = 72
+    helicopter_num = 6
+    parking = 4
+    detection_range = 30000
+    threat_range = 15000
+    air_weapon_dist = 15000
+
+
+class USS_Arleigh_Burke_IIa(unittype.ShipType):
+    id = "USS_Arleigh_Burke_IIa"
+    name = "USS Arleigh Burke IIa"
+    helicopter_num = 2
+    parking = 1
+    detection_range = 150000
+    threat_range = 100000
+    air_weapon_dist = 100000
 
 
 class LHA_1_Tarawa(unittype.ShipType):
@@ -210,6 +264,14 @@ class Type_052C_Destroyer(unittype.ShipType):
     air_weapon_dist = 100000
 
 
+class Type_093(unittype.ShipType):
+    id = "Type 093"
+    name = "Type 093"
+    detection_range = 40000
+    threat_range = 40000
+    air_weapon_dist = 30000
+
+
 class LST_Mk_II(unittype.ShipType):
     id = "LST_Mk2"
     name = "LST Mk.II"
@@ -233,6 +295,22 @@ class LCVP__Higgins_boat(unittype.ShipType):
     threat_range = 1000
     air_weapon_dist = 1000
 
+
+class Uboat_VIIC_U_flak(unittype.ShipType):
+    id = "Uboat_VIIC"
+    name = "Uboat VIIC U-flak"
+    detection_range = 12000
+    threat_range = 4000
+    air_weapon_dist = 4000
+
+
+class Schnellboot_type_S130(unittype.ShipType):
+    id = "Schnellboot_type_S130"
+    name = "Schnellboot type S130"
+    detection_range = 12000
+    threat_range = 7000
+    air_weapon_dist = 7000
+
 ship_map = {
     "speedboat": Armed_speedboat,
     "VINSON": CVN_70_Carl_Vinson,
@@ -251,12 +329,20 @@ ship_map = {
     "ZWEZDNY": Civil_boat_Zvezdny,
     "KILO": SSK_877,
     "SOM": SSK_641B,
+    "CV_1143_5": CV_1143_5_Admiral_Kuznetsov_2017,
     "Stennis": CVN_74_John_C__Stennis,
+    "CVN_71": CVN_71_Theodore_Roosevelt,
+    "CVN_72": CVN_72_Abraham_Lincoln,
+    "CVN_73": CVN_73_George_Washington,
+    "USS_Arleigh_Burke_IIa": USS_Arleigh_Burke_IIa,
     "LHA_Tarawa": LHA_1_Tarawa,
     "052B": Type_052B_Destroyer,
     "054A": Type_054A_Frigate,
     "052C": Type_052C_Destroyer,
+    "Type 093": Type_093,
     "LST_Mk2": LST_Mk_II,
     "USS_Samuel_Chase": LS_Samuel_Chase,
     "Higgins_boat": LCVP__Higgins_boat,
+    "Uboat_VIIC": Uboat_VIIC_U_flak,
+    "Schnellboot_type_S130": Schnellboot_type_S130,
 }

--- a/dcs/vehicles.py
+++ b/dcs/vehicles.py
@@ -644,9 +644,9 @@ class AirDefence:
         threat_range = 0
         air_weapon_dist = 0
 
-    class AAA_Flak_18(unittype.VehicleType):
+    class AAA_8_8cm_Flak_18(unittype.VehicleType):
         id = "flak18"
-        name = "AAA Flak 18"
+        name = "AAA 8,8cm Flak 18"
         detection_range = 0
         threat_range = 15000
         air_weapon_dist = 15000
@@ -658,16 +658,16 @@ class AirDefence:
         threat_range = 2500
         air_weapon_dist = 2500
 
-    class AAA_Flak_36(unittype.VehicleType):
+    class AAA_8_8cm_Flak_36(unittype.VehicleType):
         id = "flak36"
-        name = "AAA Flak 36"
+        name = "AAA 8,8cm Flak 36"
         detection_range = 0
         threat_range = 15000
         air_weapon_dist = 15000
 
-    class AAA_Flak_37(unittype.VehicleType):
+    class AAA_8_8cm_Flak_37(unittype.VehicleType):
         id = "flak37"
-        name = "AAA Flak 37"
+        name = "AAA 8,8cm Flak 37"
         detection_range = 0
         threat_range = 15000
         air_weapon_dist = 15000
@@ -685,6 +685,27 @@ class AirDefence:
         detection_range = 30000
         threat_range = 0
         air_weapon_dist = 0
+
+    class Flak_Searchlight_37(unittype.VehicleType):
+        id = "Flakscheinwerfer_37"
+        name = "Flak Searchlight 37"
+        detection_range = 8000
+        threat_range = 6000
+        air_weapon_dist = 0
+
+    class Maschinensatz_33(unittype.VehicleType):
+        id = "Maschinensatz_33"
+        name = "Maschinensatz_33"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class AAA_8_8cm_Flak_41(unittype.VehicleType):
+        id = "flak41"
+        name = "AAA 8,8cm Flak 41"
+        detection_range = 0
+        threat_range = 20000
+        air_weapon_dist = 20000
 
     class AAA_Bofors_40mm(unittype.VehicleType):
         id = "bofors40"
@@ -1213,9 +1234,9 @@ class Armor:
         threat_range = 1000
         air_weapon_dist = 1000
 
-    class ARV_MTLB_U_BOMAN(unittype.VehicleType):
-        id = "Boman"
-        name = "ARV MTLB-U BOMAN"
+    class FDDM_Grad(unittype.VehicleType):
+        id = "Grad_FDDM"
+        name = "FDDM Grad"
         detection_range = 0
         threat_range = 1000
         air_weapon_dist = 1000
@@ -1333,7 +1354,7 @@ class Armor:
         id = "Tiger_II_H"
         name = "HT Pz.Kpfw.VI Ausf. B 'Tiger II'"
         detection_range = 0
-        threat_range = 5000
+        threat_range = 6000
         air_weapon_dist = 0
 
     class MT_Pz_Kpfw_V_Panther_Ausf_G(unittype.VehicleType):
@@ -1350,16 +1371,16 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 0
 
-    class Jagdpanther_G1(unittype.VehicleType):
+    class TD_Jagdpanther_G1(unittype.VehicleType):
         id = "Jagdpanther_G1"
-        name = "Jagdpanther G1"
+        name = "TD Jagdpanther G1"
         detection_range = 0
         threat_range = 5000
         air_weapon_dist = 0
 
-    class Jagdpanzer_IV(unittype.VehicleType):
+    class TD_Jagdpanzer_IV(unittype.VehicleType):
         id = "JagdPz_IV"
-        name = "Jagdpanzer IV"
+        name = "TD Jagdpanzer IV"
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
@@ -1385,6 +1406,20 @@ class Armor:
         threat_range = 1100
         air_weapon_dist = 0
 
+    class StuG_III_Ausf__G(unittype.VehicleType):
+        id = "Stug_III"
+        name = "StuG III Ausf. G"
+        detection_range = 0
+        threat_range = 3000
+        air_weapon_dist = 0
+
+    class Sd_Kfz_184_Elefant(unittype.VehicleType):
+        id = "Elefant_SdKfz_184"
+        name = "Sd.Kfz.184 Elefant"
+        detection_range = 0
+        threat_range = 6000
+        air_weapon_dist = 0
+
     class CT_Cromwell_IV(unittype.VehicleType):
         id = "Cromwell_IV"
         name = "CT Cromwell IV"
@@ -1395,6 +1430,20 @@ class Armor:
     class MT_M4A4_Sherman_Firefly(unittype.VehicleType):
         id = "M4A4_Sherman_FF"
         name = "MT M4A4 Sherman Firefly"
+        detection_range = 0
+        threat_range = 3000
+        air_weapon_dist = 0
+
+    class ST_Centaur_IV(unittype.VehicleType):
+        id = "Centaur_IV"
+        name = "ST Centaur IV"
+        detection_range = 0
+        threat_range = 6000
+        air_weapon_dist = 0
+
+    class HIT_Churchill_VII(unittype.VehicleType):
+        id = "Churchill_VII"
+        name = "HIT Churchill_VII"
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
@@ -1420,8 +1469,29 @@ class Armor:
         threat_range = 1200
         air_weapon_dist = 0
 
+    class TD_M10_GMC(unittype.VehicleType):
+        id = "M10_GMC"
+        name = "TD M10 GMC"
+        detection_range = 0
+        threat_range = 6000
+        air_weapon_dist = 0
+
+    class LAC_M8_Greyhound(unittype.VehicleType):
+        id = "M8_Greyhound"
+        name = "LAC M8 Greyhound"
+        detection_range = 0
+        threat_range = 2000
+        air_weapon_dist = 0
+
 
 class MissilesSS:
+
+    class SRBM_SS_1C_Scud_B_9K72_LN_9P117M(unittype.VehicleType):
+        id = "Scud_B"
+        name = "SRBM SS-1C Scud-B 9K72 LN 9P117M"
+        detection_range = 0
+        threat_range = 460000
+        air_weapon_dist = 460000
 
     class SS_N_2_Silkworm(unittype.VehicleType):
         id = "hy_launcher"
@@ -1434,6 +1504,13 @@ class MissilesSS:
         id = "Silkworm_SR"
         name = "Silkworm Radar"
         detection_range = 200000
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class V_1_ramp(unittype.VehicleType):
+        id = "v1_launcher"
+        name = "V-1 ramp"
+        detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
 
@@ -1583,7 +1660,7 @@ vehicle_map = {
     "MTLB": Armor.APC_MTLB,
     "Marder": Armor.IFV_Marder,
     "TPZ": Armor.TPz_Fuchs,
-    "Boman": Armor.ARV_MTLB_U_BOMAN,
+    "Grad_FDDM": Armor.FDDM_Grad,
     "Bunker": Fortification.Bunker_2,
     "Paratrooper RPG-16": Infantry.Paratrooper_RPG_16,
     "Paratrooper AKS-74": Infantry.Paratrooper_AKS,
@@ -1713,6 +1790,7 @@ vehicle_map = {
     "Coach a tank yellow": Carriage.Coach_a_tank_yellow,
     "Coach a passenger": Carriage.Coach_for_passengers,
     "Coach a platform": Carriage.Coach_flatbed,
+    "Scud_B": MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M,
     "S_75M_Volhov": AirDefence.SAM_SA_2_LN_SM_90,
     "SNR_75V": AirDefence.SAM_SA_2_TR_SNR_75_Fan_Song,
     "rapier_fsa_launcher": AirDefence.Rapier_FSA_Launcher,
@@ -1740,26 +1818,34 @@ vehicle_map = {
     "Tiger_II_H": Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II,
     "Pz_V_Panther_G": Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,
     "Pz_IV_H": Armor.MT_Pz_Kpfw_IV_Ausf_H,
-    "Jagdpanther_G1": Armor.Jagdpanther_G1,
-    "JagdPz_IV": Armor.Jagdpanzer_IV,
+    "Jagdpanther_G1": Armor.TD_Jagdpanther_G1,
+    "JagdPz_IV": Armor.TD_Jagdpanzer_IV,
     "Stug_IV": Armor.StuG_IV,
     "SturmPzIV": Artillery.Sturmpanzer_IV_Brummbär,
     "Sd_Kfz_234_2_Puma": Armor.IFV_Sd_Kfz_234_2_Puma,
     "Sd_Kfz_251": Armor.APC_Sd_Kfz_251,
-    "flak18": AirDefence.AAA_Flak_18,
+    "flak18": AirDefence.AAA_8_8cm_Flak_18,
     "flak30": AirDefence.AAA_Flak_38,
-    "flak36": AirDefence.AAA_Flak_36,
-    "flak37": AirDefence.AAA_Flak_37,
+    "flak36": AirDefence.AAA_8_8cm_Flak_36,
+    "flak37": AirDefence.AAA_8_8cm_Flak_37,
     "flak38": AirDefence.AAA_Flak_Vierling_38,
     "KDO_Mod40": AirDefence.AAA_Kdo_G_40,
+    "Flakscheinwerfer_37": AirDefence.Flak_Searchlight_37,
+    "Maschinensatz_33": AirDefence.Maschinensatz_33,
     "soldier_mauser98": Infantry.Infantry_Mauser_98,
     "SK_C_28_naval_gun": Fortification.Bunker_with_SK_C_28_15cm_naval_gun,
     "fire_control": Fortification.Fire_control_bunker,
+    "Stug_III": Armor.StuG_III_Ausf__G,
+    "Elefant_SdKfz_184": Armor.Sd_Kfz_184_Elefant,
+    "flak41": AirDefence.AAA_8_8cm_Flak_41,
+    "v1_launcher": MissilesSS.V_1_ramp,
     "Bedford_MWD": Unarmed.Bedford_MWD,
     "Cromwell_IV": Armor.CT_Cromwell_IV,
     "M4A4_Sherman_FF": Armor.MT_M4A4_Sherman_Firefly,
     "bofors40": AirDefence.AAA_Bofors_40mm,
     "soldier_wwii_br_01": Infantry.Infantry_SMLE_No_4_Mk_1,
+    "Centaur_IV": Armor.ST_Centaur_IV,
+    "Churchill_VII": Armor.HIT_Churchill_VII,
     "CCKW_353": Unarmed.CCKW_353,
     "Willys_MB": Unarmed.Willys_MB,
     "M4_Sherman": Armor.MT_M4_Sherman,
@@ -1767,6 +1853,8 @@ vehicle_map = {
     "M30_CC": Armor.M30_Cargo_Carrier,
     "M2A1_halftrack": Armor.APC_M2A1,
     "soldier_wwii_us": Infantry.Infantry_M1_Garand,
+    "M10_GMC": Armor.TD_M10_GMC,
+    "M8_Greyhound": Armor.LAC_M8_Greyhound,
     "DR_50Ton_Flat_Wagon": Carriage.DR_50_ton_flat_wagon,
     "DRG_Class_86": Locomotive.DRG_Class_86,
     "German_covered_wagon_G10": Carriage.German_covered_wagon_G10,

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -2,6 +2,9 @@
 
 
 class Weapons:
+    AB_250_2__w__SD_10A_ = {"clsid": "{AB_250_2_SD_10A}", "name": "AB 250-2 (w/ SD 10A)", "weight": 253}
+    AB_250_2__w__SD_2_ = {"clsid": "{AB_250_2_SD_2}", "name": "AB 250-2 (w/ SD 2)", "weight": 290}
+    AB_500_1__w__SD_10A_ = {"clsid": "{AB_500_1_SD_10A}", "name": "AB 500-1 (w/ SD 10A)", "weight": 500}
     ADEN_GUNPOD = {"clsid": "{ADEN_GUNPOD}", "name": "ADEN GUNPOD", "weight": 87}
     ADM_141A = {"clsid": "{ADM_141A}", "name": "ADM-141A", "weight": 180}
     ADM_141A_ = {"clsid": "{BRU42_ADM141}", "name": "ADM_141A", "weight": 308}
@@ -73,6 +76,7 @@ class Weapons:
     ALQ_131 = {"clsid": "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}", "name": "ALQ-131", "weight": 305}
     ALQ_184 = {"clsid": "ALQ_184", "name": "ALQ-184", "weight": 215}
     AN_AAQ_28_LITENING = {"clsid": "{A111396E-D3E8-4b9c-8AC9-2432489304D5}", "name": "AN/AAQ-28 LITENING", "weight": 300}
+    AN_AAQ_28_LITENING_ = {"clsid": "{AAQ-28_LEFT}", "name": "AN/AAQ-28 LITENING", "weight": 300}
     AN_AAS_38_FLIR = {"clsid": "{6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}", "name": "AN/AAS-38 FLIR", "weight": 200}
     AN_ALQ_164_DECM_Pod = {"clsid": "{ALQ_164_RF_Jammer}", "name": "AN/ALQ-164 DECM Pod", "weight": 143.789}
     AN_ASQ_173_LST_SCAM = {"clsid": "{1C2B16EB-8EB0-43de-8788-8EBB2D70B8BC}", "name": "AN/ASQ-173 LST/SCAM", "weight": 250}
@@ -118,11 +122,11 @@ class Weapons:
     BL_755_2 = {"clsid": "{C535596E-F7D2-4301-8BB4-B1658BB87ED7}", "name": "BL-755*2", "weight": 200}
     BOZ_107 = {"clsid": "{8C3F26A1-FA0F-11d5-9190-00A0249B6F00}", "name": "BOZ-107", "weight": 200}
     BRU_33_LAU_10___4_ZUNI_MK_71 = {"clsid": "{BRU33_LAU10}", "name": "BRU-33 LAU-10 - 4 ZUNI MK 71", "weight": 519}
-    BRU_33_LAU_61___19_2_75__rockets_MK151_HE = {"clsid": "{BRU33_LAU61}", "name": "BRU-33 LAU-61 - 19 2.75' rockets MK151 HE", "weight": 369.59}
+    BRU_33_LAU_61___19_2_75__rockets_M151__HE_ = {"clsid": "{BRU33_LAU61}", "name": "BRU-33 LAU-61 - 19 2.75' rockets M151 (HE)", "weight": 369.59}
     BRU_33_LAU_68___7_2_75__rockets_M151__HE_ = {"clsid": "{BRU33_LAU68}", "name": "BRU-33 LAU-68 - 7 2.75' rockets M151 (HE)", "weight": 193.53}
     BRU_33_LAU_68___7_2_75__rockets_MK5__HE_ = {"clsid": "{BRU33_LAU68_MK5}", "name": "BRU-33 LAU-68 - 7 2.75' rockets MK5 (HE)", "weight": 182.2}
     BRU_33___2_LAU_10___4_ZUNI_MK_71 = {"clsid": "{BRU33_2*LAU10}", "name": "BRU-33 - 2 LAU-10 - 4 ZUNI MK 71", "weight": 959}
-    BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE = {"clsid": "{BRU33_2*LAU61}", "name": "BRU-33 - 2 LAU-61 - 19 2.75' rockets MK151 HE", "weight": 660.18}
+    BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_ = {"clsid": "{BRU33_2*LAU61}", "name": "BRU-33 - 2 LAU-61 - 19 2.75' rockets M151 (HE)", "weight": 660.18}
     BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_ = {"clsid": "{BRU33_2*LAU68}", "name": "BRU-33 - 2 LAU-68 - 7 2.75' rockets M151 (HE)", "weight": 308.06}
     BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_ = {"clsid": "{BRU33_2*LAU68_MK5}", "name": "BRU-33 - 2 LAU-68 - 7 2.75' rockets MK5 (HE)", "weight": 285.4}
     BRU_33___2_x_CBU_99 = {"clsid": "{BRU33_2X_CBU-99}", "name": "BRU-33 - 2 x CBU-99", "weight": 523}
@@ -147,9 +151,9 @@ class Weapons:
     BRU_57___2_x_GBU_38 = {"clsid": "{BRU57_2*GBU-38}", "name": "BRU-57 - 2 x GBU-38", "weight": 561}
     BR_250 = {"clsid": "BR_250", "name": "BR-250", "weight": 250}
     BR_500 = {"clsid": "BR_500", "name": "BR-500", "weight": 500}
-    British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = {"clsid": "British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier", "name": "GB-GP-250LBS-MK4-BOMB", "weight": 108.326}
-    British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = {"clsid": "British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier", "name": "GB-GP-250LBS-MK4-BOMB", "weight": 108.326}
-    British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = {"clsid": "British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3", "name": "GB-GP-500LBS-MK4-BOMB", "weight": 225.188}
+    British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = {"clsid": "British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier", "name": "250 lbs. Bomb Mk. IV", "weight": 108.326}
+    British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = {"clsid": "British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier", "name": "250 lbs. Bomb Mk. IV", "weight": 108.326}
+    British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = {"clsid": "British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3", "name": "500 lbs. Bomb Mk. IV", "weight": 225.188}
     B_13L___5_S_13_OF = {"clsid": "{FC56DF80-9B09-44C5-8976-DCFAFF219062}", "name": "B-13L - 5 S-13 OF", "weight": 510}
     B_1B_Mk_84_8 = {"clsid": "B-1B_Mk-84*8", "name": "Mk-84*8", "weight": 7152}
     B_8M1___20_S_8KOM = {"clsid": "{F72F47E5-C83A-4B85-96ED-D3E46671EE9A}", "name": "B-8M1 - 20 S-8KOM", "weight": 363.5}
@@ -171,7 +175,7 @@ class Weapons:
     CBU_99 = {"clsid": "{CBU_99}", "name": "CBU-99", "weight": 222}
     DEFA_553 = {"clsid": "{C-101-DEFA553}", "name": "DEFA-553", "weight": 218}
     DIS_AKG_DLPOD = {"clsid": "DIS_AKG_DLPOD", "name": "DATA-LINK POD", "weight": 295}
-    DIS_BRM1_90 = {"clsid": "DIS_BRM1_90", "name": "BRM-1 90MM", "weight": 462.5}
+    DIS_BRM1_90 = {"clsid": "DIS_BRM1_90", "name": "BRM-1_90MM", "weight": 462.5}
     DIS_CM_802AKG = {"clsid": "DIS_CM-802AKG", "name": "CM-802AKG", "weight": 765}
     DIS_C_701IR = {"clsid": "DIS_C-701IR", "name": "C-701IR", "weight": 170}
     DIS_C_701T = {"clsid": "DIS_C-701T", "name": "C-701T", "weight": 170}
@@ -193,21 +197,29 @@ class Weapons:
     DIS_PL_5EII_TIP = {"clsid": "DIS_PL-5EII_TIP", "name": "PL-5EII", "weight": 83}
     DIS_PL_8A = {"clsid": "DIS_PL-8A", "name": "PL-8A", "weight": 115}
     DIS_PL_8B = {"clsid": "DIS_PL-8B", "name": "PL-8B", "weight": 115}
-    DIS_RKT_90_UG = {"clsid": "DIS_RKT_90_UG", "name": "Unguided Rocket 90mm", "weight": 382.5}
+    DIS_RKT_90_UG = {"clsid": "DIS_RKT_90_UG", "name": "UG_90MM", "weight": 382.5}
     DIS_SD_10 = {"clsid": "DIS_SD-10", "name": "SD-10", "weight": 289}
     DIS_SD_10_DUAL_L = {"clsid": "DIS_SD-10_DUAL_L", "name": "SD-10 x 2", "weight": 558}
     DIS_SD_10_DUAL_R = {"clsid": "DIS_SD-10_DUAL_R", "name": "SD-10 x 2", "weight": 558}
+    DIS_SMOKE_GENERATOR_B = {"clsid": "DIS_SMOKE_GENERATOR_B", "name": "Smoke Generator - blue", "weight": 0}
+    DIS_SMOKE_GENERATOR_G = {"clsid": "DIS_SMOKE_GENERATOR_G", "name": "Smoke Generator - green", "weight": 0}
+    DIS_SMOKE_GENERATOR_O = {"clsid": "DIS_SMOKE_GENERATOR_O", "name": "Smoke Generator - orange", "weight": 0}
+    DIS_SMOKE_GENERATOR_R = {"clsid": "DIS_SMOKE_GENERATOR_R", "name": "Smoke Generator - red", "weight": 0}
+    DIS_SMOKE_GENERATOR_W = {"clsid": "DIS_SMOKE_GENERATOR_W", "name": "Smoke Generator - white", "weight": 0}
+    DIS_SMOKE_GENERATOR_Y = {"clsid": "DIS_SMOKE_GENERATOR_Y", "name": "Smoke Generator - yellow", "weight": 0}
     DIS_SPJ_POD = {"clsid": "DIS_SPJ_POD", "name": "SPJ POD", "weight": 270}
     DIS_TANK1100 = {"clsid": "DIS_TANK1100", "name": "1100L Tank", "weight": 1064}
     DIS_TANK800 = {"clsid": "DIS_TANK800", "name": "800L Tank", "weight": 730}
-    DIS_Type200 = {"clsid": "DIS_Type200", "name": "Type 200", "weight": 200}
+    DIS_TYPE200 = {"clsid": "DIS_TYPE200", "name": "TYPE-200A", "weight": 200}
+    DIS_TYPE200_DUAL_L = {"clsid": "DIS_TYPE200_DUAL_L", "name": "TYPE-200A Dual", "weight": 400}
+    DIS_TYPE200_DUAL_R = {"clsid": "DIS_TYPE200_DUAL_R", "name": "TYPE-200A Dual", "weight": 400}
     DIS_WMD7 = {"clsid": "DIS_WMD7", "name": "WMD7 POD", "weight": 295}
     Drop_Tank_75Gal = {"clsid": "{DT75GAL}", "name": "Drop Tank 75Gal", "weight": 227.048087675}
     DWS39_MJ1 = {"clsid": "{DWS39_MJ1}", "name": "DWS39 MJ1", "weight": 605}
     DWS39_MJ1_MJ2 = {"clsid": "{DWS39_MJ1_MJ2}", "name": "DWS39 MJ1-MJ2", "weight": 605}
     DWS39_MJ2 = {"clsid": "{DWS39_MJ2}", "name": "DWS39 MJ2", "weight": 605}
     Eclair = {"clsid": "{Eclair}", "name": "Eclair", "weight": 20}
-    ER_4_SC50 = {"clsid": "ER_4_SC50", "name": "4 * SC50", "weight": 220}
+    ER_4_SC50 = {"clsid": "ER_4_SC50", "name": "4 * SC 50", "weight": 220}
     ETHER = {"clsid": "{0519A261-0AB6-11d6-9193-00A0249B6F00}", "name": "ETHER", "weight": 200}
     FAB_100 = {"clsid": "{FB3CE165-BF07-4979-887C-92B87F13276B}", "name": "FAB-100", "weight": 100}
     FAB_100M = {"clsid": "FAB_100M", "name": "FAB-100M", "weight": 100}
@@ -246,15 +258,15 @@ class Weapons:
     Fuel_tank_1400L = {"clsid": "{2BEC576B-CDF5-4B7F-961F-B0FA4312B841}", "name": "Fuel tank 1400L", "weight": 1262.5}
     Fuel_tank_2000L = {"clsid": "{16602053-4A12-40A2-B214-AB60D481B20E}", "name": "Fuel tank 2000L", "weight": 1700}
     Fuel_tank_3000L = {"clsid": "{7D7EC917-05F6-49D4-8045-61FC587DD019}", "name": "Fuel tank 3000L", "weight": 2550}
-    Fuel_tank_300_gal = {"clsid": "{8A0BE8AE-58D4-4572-9263-3144C0D06364}", "name": "Fuel tank 300 gal", "weight": 958.4}
+    Fuel_tank_300_gal = {"clsid": "{8A0BE8AE-58D4-4572-9263-3144C0D06364}", "name": "Fuel tank 300 gal", "weight": 1083.5076415}
     Fuel_tank_300_gal_ = {"clsid": "{F14-300gal}", "name": "Fuel tank 300 gal", "weight": 958.4}
     Fuel_tank_300_gal__empty_ = {"clsid": "{F14-300gal-empty}", "name": "Fuel tank 300 gal (empty)", "weight": 70}
-    Fuel_tank_330_gal = {"clsid": "{EFEC8200-B922-11d7-9897-000476191836}", "name": "Fuel tank 330 gal", "weight": 1049.24}
-    Fuel_tank_330_gal_ = {"clsid": "{EFEC8201-B922-11d7-9897-000476191836}", "name": "Fuel tank 330 gal", "weight": 1049.24}
-    Fuel_tank_367_gal = {"clsid": "{82364E69-5564-4043-A866-E13032926C3E}", "name": "Fuel tank 367 gal", "weight": 1161.276}
-    Fuel_tank_370_gal = {"clsid": "{F376DBEE-4CAE-41BA-ADD9-B2910AC95DEC}", "name": "Fuel tank 370 gal", "weight": 1170.36}
+    Fuel_tank_330_gal = {"clsid": "{EFEC8200-B922-11d7-9897-000476191836}", "name": "Fuel tank 330 gal", "weight": 1067.750921}
+    Fuel_tank_330_gal_ = {"clsid": "{EFEC8201-B922-11d7-9897-000476191836}", "name": "Fuel tank 330 gal", "weight": 1067.750921}
+    Fuel_tank_367_gal = {"clsid": "{82364E69-5564-4043-A866-E13032926C3E}", "name": "Fuel tank 367 gal", "weight": 1181.8623879}
+    Fuel_tank_370_gal = {"clsid": "{F376DBEE-4CAE-41BA-ADD9-B2910AC95DEC}", "name": "Fuel tank 370 gal", "weight": 1338.1101068}
     Fuel_tank_5000L = {"clsid": "{0855A3A1-FA50-4C89-BDBB-5D5360ABA071}", "name": "Fuel tank 5000L", "weight": 4420}
-    Fuel_tank_610_gal = {"clsid": "{E1F29B21-F291-4589-9FD8-3272EEC69506}", "name": "Fuel tank 610 gal", "weight": 1897.08}
+    Fuel_tank_610_gal = {"clsid": "{E1F29B21-F291-4589-9FD8-3272EEC69506}", "name": "Fuel tank 610 gal", "weight": 2010.8766885}
     Fuel_tank_800L = {"clsid": "{A5BAEAB7-6FAF-4236-AF72-0FD900F493F9}", "name": "Fuel tank 800L", "weight": 680}
     Fuel_tank_800L_Wing = {"clsid": "{E8D4652F-FD48-45B7-BA5B-2AE05BB5A9CF}", "name": "Fuel tank 800L Wing", "weight": 760}
     Fuel_tank_Ka_50 = {"clsid": "{B99EE8A8-99BC-4a8d-89AC-A26831920DCE}", "name": "Fuel tank Ka-50", "weight": 550}
@@ -265,7 +277,7 @@ class Weapons:
     F_5_150Gal_Fuel_tank = {"clsid": "{PTB-150GAL}", "name": "F-5 150Gal Fuel tank", "weight": 509}
     F_5_275Gal_Fuel_tank = {"clsid": "{0395076D-2F77-4420-9D33-087A4398130B}", "name": "F-5 275Gal Fuel tank", "weight": 909}
     GAR_8_Sidewinder_IR_AAM = {"clsid": "{AIM-9B}", "name": "GAR-8 Sidewinder IR AAM", "weight": 85.5}
-    GAU_12_Gunpod = {"clsid": "{GAU_12_Equalizer}", "name": "GAU 12 Gunpod", "weight": 595.9426}
+    GAU_12_Gunpod = {"clsid": "{GAU_12_Equalizer}", "name": "GAU 12 Gunpod", "weight": 283.9}
     GBU_10 = {"clsid": "{51F9AAE5-964F-4D21-83FB-502E3BFE5F8A}", "name": "GBU-10", "weight": 1162}
     GBU_10_ = {"clsid": "{BRU-32 GBU-10}", "name": "GBU-10", "weight": 997.38}
     GBU_10_2 = {"clsid": "{62BE78B1-9258-48AE-B882-279534C0D278}", "name": "GBU-10*2", "weight": 1800}
@@ -380,10 +392,10 @@ class Weapons:
     LAU_115C_AIM_7MH = {"clsid": "{LAU-115 - AIM-7H}", "name": "LAU-115C AIM-7MH", "weight": 284.4}
     LAU_115_2_LAU_127_AIM_120B = {"clsid": "LAU-115_2*LAU-127_AIM-120B", "name": "LAU-115 - 2 AIM-120B", "weight": 460.6}
     LAU_115_2_LAU_127_AIM_120C = {"clsid": "LAU-115_2*LAU-127_AIM-120C", "name": "LAU-115 - 2 AIM-120C", "weight": 468}
-    LAU_115_2_LAU_127_AIM_9L = {"clsid": "LAU-115_2*LAU-127_AIM-9L", "name": "LAU-115 - 2 AIM-9L Sidewinder IR AAM", "weight": 316}
-    LAU_115_2_LAU_127_AIM_9M = {"clsid": "LAU-115_2*LAU-127_AIM-9M", "name": "LAU-115 - 2 AIM-9M Sidewinder IR AAM", "weight": 318.28}
-    LAU_115_2_LAU_127_AIM_9X = {"clsid": "LAU-115_2*LAU-127_AIM-9X", "name": "LAU-115 - 2 AIM-9X Sidewinder IR AAM", "weight": 313.92}
-    LAU_115_2_LAU_127_CATM_9M = {"clsid": "LAU-115_2*LAU-127_CATM-9M", "name": "LAU-115 - 2 CAP-9M", "weight": 316}
+    LAU_115_2_LAU_127_AIM_9L = {"clsid": "LAU-115_2*LAU-127_AIM-9L", "name": "LAU-115 - 2 LAU-127 AIM-9L Sidewinder IR AAM", "weight": 316}
+    LAU_115_2_LAU_127_AIM_9M = {"clsid": "LAU-115_2*LAU-127_AIM-9M", "name": "LAU-115 - 2 LAU-127 AIM-9M Sidewinder IR AAM", "weight": 318.28}
+    LAU_115_2_LAU_127_AIM_9X = {"clsid": "LAU-115_2*LAU-127_AIM-9X", "name": "LAU-115 - 2 LAU-127 AIM-9X Sidewinder IR AAM", "weight": 313.92}
+    LAU_115_2_LAU_127_CATM_9M = {"clsid": "LAU-115_2*LAU-127_CATM-9M", "name": "LAU-115 - 2 LAU-127 CAP-9M", "weight": 316}
     LAU_115_LAU_127_AIM_9L = {"clsid": "LAU-115_LAU-127_AIM-9L", "name": "LAU-115C LAU-127 AIM-9L Sidewinder IR AAM", "weight": 185.2}
     LAU_115_LAU_127_AIM_9M = {"clsid": "LAU-115_LAU-127_AIM-9M", "name": "LAU-115C LAU-127 AIM-9M Sidewinder IR AAM", "weight": 186.34}
     LAU_115_LAU_127_AIM_9X = {"clsid": "LAU-115_LAU-127_AIM-9X", "name": "LAU-115C LAU-127 AIM-9X Sidewinder IR AAM", "weight": 184.16}
@@ -477,6 +489,7 @@ class Weapons:
     LAU_88_AGM_65K_2_ = {"clsid": "{D7670BC7-881B-4094-906C-73879CF7EB27}", "name": "LAU-88,AGM-65K*2", "weight": 931}
     LAU_88_AGM_65K_3 = {"clsid": "{907D835F-E650-4154-BAFD-C656882555C0}", "name": "LAU-88,AGM-65K*3", "weight": 1291}
     LAU_SNEB68G___8xSNEB68_EAP = {"clsid": "{LAU_SNEB68G}", "name": "LAU_SNEB68G - 8xSNEB68_EAP", "weight": 50.08}
+    LAU_SNEB68G___8xSNEB68_WP = {"clsid": "{LAU_SNEB68_WP}", "name": "LAU_SNEB68G - 8xSNEB68_WP", "weight": 50.08}
     Lantirn_F_16 = {"clsid": "{CAAC1CFD-6745-416B-AFA4-CB57414856D0}", "name": "Lantirn F-16", "weight": 445}
     Lantirn_Target_Pod = {"clsid": "{D1744B93-2A8A-4C4D-B004-7A09CD8C8F3F}", "name": "Lantirn Target Pod", "weight": 200}
     LYSBOMB_Illumination_bomb = {"clsid": "{LYSBOMB}", "name": "LYSBOMB Illumination bomb", "weight": 220}
@@ -679,9 +692,14 @@ class Weapons:
     R_77_ = {"clsid": "{B4C01D60-A8A3-4237-BD72-CA7655BC0FEC}", "name": "R-77", "weight": 250}
     SAB_100 = {"clsid": "{0511E528-EA28-4caf-A212-00D1408DF10A}", "name": "SAB-100", "weight": 100}
     Sand_Filter = {"clsid": "{FAS}", "name": "Sand Filter", "weight": 15}
-    SC_250 = {"clsid": "{SC_250}", "name": "SC-250", "weight": 250}
-    SC_501_SC250 = {"clsid": "SC_501_SC250", "name": "SC-250", "weight": 250}
-    SC_501_SC500 = {"clsid": "SC_501_SC500", "name": "SC-500", "weight": 500}
+    SC_250_Type_1_L2 = {"clsid": "{SC_250_T1_L2}", "name": "SC 250 Type 1 L2", "weight": 250}
+    SC_250_Type_3_J = {"clsid": "{Schloss500XIIC1_SC_250_T3_J}", "name": "SC 250 Type 3 J", "weight": 270}
+    SC_50 = {"clsid": "{SC_50}", "name": "SC 50", "weight": 50}
+    SC_500_L2 = {"clsid": "{SC_500_L2}", "name": "SC 500 L2", "weight": 500}
+    SC_501_SC250 = {"clsid": "SC_501_SC250", "name": "SC 250 Type 3 J", "weight": 250}
+    SC_501_SC500 = {"clsid": "SC_501_SC500", "name": "SC 500 J", "weight": 500}
+    SD_250_Stg = {"clsid": "{SD_250_Stg}", "name": "SD 250 Stg", "weight": 250}
+    SD_500_A = {"clsid": "{SD_500_A}", "name": "SD 500 A", "weight": 500}
     SEASPARROW = {"clsid": "SEASPARROW", "name": "SEASPARROW", "weight": None}
     Sea_Eagle = {"clsid": "{1461CD18-429A-42A9-A21F-4C621ECD4573}", "name": "Sea Eagle", "weight": 600}
     Shpil_2M_Laser_Intelligence_Pod = {"clsid": "{0519A263-0AB6-11d6-9193-00A0249B6F00}", "name": "Shpil-2M Laser Intelligence Pod", "weight": 200}
@@ -871,7 +889,7 @@ class Weapons:
     _3_GBU_16 = {"clsid": "{88D49E04-78DF-4F08-B47E-B81247A9E3C5}", "name": "3 GBU-16", "weight": 666}
     _3_GBU_16_ = {"clsid": "{BRU-42A_3*GBU-16}", "name": "3 GBU-16", "weight": 1545}
     _3_GBU_38 = {"clsid": "{BRU-42_3*GBU-38}", "name": "3 GBU-38", "weight": 885}
-    _3_MK_20_Rockeye = {"clsid": "{BRU-42_3*MK-20}", "name": "3 MK-20 Rockeye", "weight": 504}
+    _3_MK_20_Rockeye = {"clsid": "{BRU-42_3*MK-20}", "name": "3 MK-20 Rockeye", "weight": 726}
     _3_MK_81_LD = {"clsid": "{BRU-42_3*Mk-81LD}", "name": "3 MK-81 LD", "weight": 414}
     _3_MK_82_LD = {"clsid": "{BRU-42_3*Mk-82LD}", "name": "3 MK-82 LD", "weight": 783}
     _3_MK_82_SNAKEYE = {"clsid": "{BRU-42_3*Mk-82SNAKEYE}", "name": "3 MK-82 SNAKEYE", "weight": 783}
@@ -879,11 +897,13 @@ class Weapons:
     _3_Mk_20_Rockeye = {"clsid": "{B83CB620-5BBE-4BEA-910C-EB605A327EF9}", "name": "3 Mk-20 Rockeye", "weight": 726}
     _3_Mk_82 = {"clsid": "{60CC734F-0AFA-4E2E-82B8-93B941AB11CF}", "name": "3 Mk-82", "weight": 783}
     _3_Mk_82AIR = {"clsid": "{BRU-42_3*Mk-82AIR}", "name": "3 Mk-82AIR", "weight": 783}
+    _3_Mk_82AIR_ = {"clsid": "{BRU-42_3_MK82AIR}", "name": "3 Mk-82AIR", "weight": 783}
     _3_SUU_25___8_LUU_2 = {"clsid": "{BRU-42_LS_3*SUU-25_8*LUU-2}", "name": "3 SUU-25 * 8 LUU-2", "weight": 490}
     _48N6E2 = {"clsid": "48N6E2", "name": "48N6E2 S-300F (SA-N-6 Grumble)", "weight": None}
     _4M80 = {"clsid": "_4M80", "name": "SS-N-12 SANDBOX", "weight": None}
     _4_M_71_HE_Bomb = {"clsid": "{M71BOMB}", "name": "4 M/71 HE-Bomb", "weight": 609}
     _4_M_71_HE_Bomb_w_chute = {"clsid": "{M71BOMBD}", "name": "4 M/71 HE-Bomb w chute", "weight": 609}
+    _4___AN_M64 = {"clsid": "{4xAN-M64_on_InvCountedAttachmentPoints}", "name": "4 * AN-M64", "weight": 908}
     _51_Mk_82 = {"clsid": "{B84DFE16-6AC7-4854-8F6D-34137892E166}", "name": "51 Mk-82", "weight": 12291}
     _5V55 = {"clsid": "5V55", "name": "5V55 S-300PS (SA-10B Grumble)", "weight": None}
     _5_Mk_82 = {"clsid": "{MER-5E_MK82x5}", "name": "5 Mk-82", "weight": 1295.7}
@@ -904,6 +924,9 @@ class Weapons:
     _9M39 = {"clsid": "_9M39", "name": "SA-18 GROUSE", "weight": None}
 
 weapon_ids = {
+    "{AB_250_2_SD_10A}": Weapons.AB_250_2__w__SD_10A_,
+    "{AB_250_2_SD_2}": Weapons.AB_250_2__w__SD_2_,
+    "{AB_500_1_SD_10A}": Weapons.AB_500_1__w__SD_10A_,
     "{ADEN_GUNPOD}": Weapons.ADEN_GUNPOD,
     "{ADM_141A}": Weapons.ADM_141A,
     "{BRU42_ADM141}": Weapons.ADM_141A_,
@@ -975,6 +998,7 @@ weapon_ids = {
     "{6D21ECEA-F85B-4E8D-9D51-31DC9B8AA4EF}": Weapons.ALQ_131,
     "ALQ_184": Weapons.ALQ_184,
     "{A111396E-D3E8-4b9c-8AC9-2432489304D5}": Weapons.AN_AAQ_28_LITENING,
+    "{AAQ-28_LEFT}": Weapons.AN_AAQ_28_LITENING_,
     "{6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}": Weapons.AN_AAS_38_FLIR,
     "{ALQ_164_RF_Jammer}": Weapons.AN_ALQ_164_DECM_Pod,
     "{1C2B16EB-8EB0-43de-8788-8EBB2D70B8BC}": Weapons.AN_ASQ_173_LST_SCAM,
@@ -1020,11 +1044,11 @@ weapon_ids = {
     "{C535596E-F7D2-4301-8BB4-B1658BB87ED7}": Weapons.BL_755_2,
     "{8C3F26A1-FA0F-11d5-9190-00A0249B6F00}": Weapons.BOZ_107,
     "{BRU33_LAU10}": Weapons.BRU_33_LAU_10___4_ZUNI_MK_71,
-    "{BRU33_LAU61}": Weapons.BRU_33_LAU_61___19_2_75__rockets_MK151_HE,
+    "{BRU33_LAU61}": Weapons.BRU_33_LAU_61___19_2_75__rockets_M151__HE_,
     "{BRU33_LAU68}": Weapons.BRU_33_LAU_68___7_2_75__rockets_M151__HE_,
     "{BRU33_LAU68_MK5}": Weapons.BRU_33_LAU_68___7_2_75__rockets_MK5__HE_,
     "{BRU33_2*LAU10}": Weapons.BRU_33___2_LAU_10___4_ZUNI_MK_71,
-    "{BRU33_2*LAU61}": Weapons.BRU_33___2_LAU_61___19_2_75__rockets_MK151_HE,
+    "{BRU33_2*LAU61}": Weapons.BRU_33___2_LAU_61___19_2_75__rockets_M151__HE_,
     "{BRU33_2*LAU68}": Weapons.BRU_33___2_LAU_68___7_2_75__rockets_M151__HE_,
     "{BRU33_2*LAU68_MK5}": Weapons.BRU_33___2_LAU_68___7_2_75__rockets_MK5__HE_,
     "{BRU33_2X_CBU-99}": Weapons.BRU_33___2_x_CBU_99,
@@ -1099,10 +1123,18 @@ weapon_ids = {
     "DIS_SD-10": Weapons.DIS_SD_10,
     "DIS_SD-10_DUAL_L": Weapons.DIS_SD_10_DUAL_L,
     "DIS_SD-10_DUAL_R": Weapons.DIS_SD_10_DUAL_R,
+    "DIS_SMOKE_GENERATOR_B": Weapons.DIS_SMOKE_GENERATOR_B,
+    "DIS_SMOKE_GENERATOR_G": Weapons.DIS_SMOKE_GENERATOR_G,
+    "DIS_SMOKE_GENERATOR_O": Weapons.DIS_SMOKE_GENERATOR_O,
+    "DIS_SMOKE_GENERATOR_R": Weapons.DIS_SMOKE_GENERATOR_R,
+    "DIS_SMOKE_GENERATOR_W": Weapons.DIS_SMOKE_GENERATOR_W,
+    "DIS_SMOKE_GENERATOR_Y": Weapons.DIS_SMOKE_GENERATOR_Y,
     "DIS_SPJ_POD": Weapons.DIS_SPJ_POD,
     "DIS_TANK1100": Weapons.DIS_TANK1100,
     "DIS_TANK800": Weapons.DIS_TANK800,
-    "DIS_Type200": Weapons.DIS_Type200,
+    "DIS_TYPE200": Weapons.DIS_TYPE200,
+    "DIS_TYPE200_DUAL_L": Weapons.DIS_TYPE200_DUAL_L,
+    "DIS_TYPE200_DUAL_R": Weapons.DIS_TYPE200_DUAL_R,
     "DIS_WMD7": Weapons.DIS_WMD7,
     "{DT75GAL}": Weapons.Drop_Tank_75Gal,
     "{DWS39_MJ1}": Weapons.DWS39_MJ1,
@@ -1379,6 +1411,7 @@ weapon_ids = {
     "{D7670BC7-881B-4094-906C-73879CF7EB27}": Weapons.LAU_88_AGM_65K_2_,
     "{907D835F-E650-4154-BAFD-C656882555C0}": Weapons.LAU_88_AGM_65K_3,
     "{LAU_SNEB68G}": Weapons.LAU_SNEB68G___8xSNEB68_EAP,
+    "{LAU_SNEB68_WP}": Weapons.LAU_SNEB68G___8xSNEB68_WP,
     "{CAAC1CFD-6745-416B-AFA4-CB57414856D0}": Weapons.Lantirn_F_16,
     "{D1744B93-2A8A-4C4D-B004-7A09CD8C8F3F}": Weapons.Lantirn_Target_Pod,
     "{LYSBOMB}": Weapons.LYSBOMB_Illumination_bomb,
@@ -1581,9 +1614,14 @@ weapon_ids = {
     "{B4C01D60-A8A3-4237-BD72-CA7655BC0FEC}": Weapons.R_77_,
     "{0511E528-EA28-4caf-A212-00D1408DF10A}": Weapons.SAB_100,
     "{FAS}": Weapons.Sand_Filter,
-    "{SC_250}": Weapons.SC_250,
+    "{SC_250_T1_L2}": Weapons.SC_250_Type_1_L2,
+    "{Schloss500XIIC1_SC_250_T3_J}": Weapons.SC_250_Type_3_J,
+    "{SC_50}": Weapons.SC_50,
+    "{SC_500_L2}": Weapons.SC_500_L2,
     "SC_501_SC250": Weapons.SC_501_SC250,
     "SC_501_SC500": Weapons.SC_501_SC500,
+    "{SD_250_Stg}": Weapons.SD_250_Stg,
+    "{SD_500_A}": Weapons.SD_500_A,
     "SEASPARROW": Weapons.SEASPARROW,
     "{1461CD18-429A-42A9-A21F-4C621ECD4573}": Weapons.Sea_Eagle,
     "{0519A263-0AB6-11d6-9193-00A0249B6F00}": Weapons.Shpil_2M_Laser_Intelligence_Pod,
@@ -1781,11 +1819,13 @@ weapon_ids = {
     "{B83CB620-5BBE-4BEA-910C-EB605A327EF9}": Weapons._3_Mk_20_Rockeye,
     "{60CC734F-0AFA-4E2E-82B8-93B941AB11CF}": Weapons._3_Mk_82,
     "{BRU-42_3*Mk-82AIR}": Weapons._3_Mk_82AIR,
+    "{BRU-42_3_MK82AIR}": Weapons._3_Mk_82AIR_,
     "{BRU-42_LS_3*SUU-25_8*LUU-2}": Weapons._3_SUU_25___8_LUU_2,
     "48N6E2": Weapons._48N6E2,
     "_4M80": Weapons._4M80,
     "{M71BOMB}": Weapons._4_M_71_HE_Bomb,
     "{M71BOMBD}": Weapons._4_M_71_HE_Bomb_w_chute,
+    "{4xAN-M64_on_InvCountedAttachmentPoints}": Weapons._4___AN_M64,
     "{B84DFE16-6AC7-4854-8F6D-34137892E166}": Weapons._51_Mk_82,
     "5V55": Weapons._5V55,
     "{MER-5E_MK82x5}": Weapons._5_Mk_82,

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -166,6 +166,52 @@ class BasicTests(unittest.TestCase):
 
         m.save('missions/basic_mission.miz')
 
+    def test_nav_target_points(self):
+
+        m = dcs.Mission()
+        batumi = m.terrain.batumi()
+        batumi.set_blue()
+        usa = m.country("USA")
+
+        jeff = m.flight_group_from_airport(usa, "JF17", dcs.planes.JF_17, group_size=2, airport=m.terrain.batumi())
+        jeff.set_client()
+        jeff.add_waypoint(m.terrain.batumi().position.point_from_heading(-90, 10000), 600)
+
+        pp1_pos = batumi.position.point_from_heading(-90, 12000)
+        jeff.add_nav_target_point(batumi.position.point_from_heading(-90, 12000), "PP1")
+        jeff.add_nav_target_point(batumi.position.point_from_heading(-90, 14000), "PP2")
+        jeff.add_nav_target_point(batumi.position.point_from_heading(-90, 16000), "PP3")
+        jeff.add_nav_target_point(batumi.position.point_from_heading(-90, 18000), "PP4")
+
+        # Test pydcs model
+        self.assertEqual(len(jeff.nav_target_points), 4)
+        self.assertEqual(jeff.nav_target_points[0].text_comment, "PP1")
+        self.assertEqual(jeff.nav_target_points[0].position.x, pp1_pos.x)
+        self.assertEqual(jeff.nav_target_points[0].position.y, pp1_pos.y)
+        self.assertEqual(jeff.nav_target_points[0].index, 1)
+
+        # Test dict representation
+        self.assertTrue("NavTargetPoints" in jeff.dict().keys())
+        self.assertTrue(jeff.dict()["NavTargetPoints"][0]["text_comment"] == "PP1")
+        self.assertTrue(jeff.dict()["NavTargetPoints"][0]["x"] == pp1_pos.x)
+        self.assertTrue(jeff.dict()["NavTargetPoints"][0]["y"] == pp1_pos.y)
+        self.assertTrue(jeff.dict()["NavTargetPoints"][0]["index"] == 1)
+
+        m.save("missions/mission_with_nav_target_points.miz")
+
+        # load the mission back
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file("missions/mission_with_nav_target_points.miz"))
+        jeff_miz = usa.find_group("JF17")
+
+        # Test pydcs model from loaded mission
+        self.assertEqual(len(jeff_miz.nav_target_points), 4)
+        self.assertEqual(jeff_miz.nav_target_points[0].text_comment, "PP1")
+        self.assertEqual(jeff_miz.nav_target_points[0].position.x, pp1_pos.x)
+        self.assertEqual(jeff_miz.nav_target_points[0].position.y, pp1_pos.y)
+        self.assertEqual(jeff_miz.nav_target_points[0].index, 1)
+
+
     def test_loadmission(self):
         m = dcs.mission.Mission()
         self.assertTrue(m.load_file('tests/loadtest.miz'))


### PR DESCRIPTION
Hello, 

I ran a data export for my own usage, for the new Supercarrier module support.
I have been using it for a day, and it's working fine.

**Note:** After running the export, I had to manually remove a "planes.F_4E_new" reference that was being added in countries.py, while this plane did not exist in planes.py. Looks like a new F_4E model is coming in the game, but might be currently disabled.
 
Thanks, 

Khopa