### PR TITLE
Add manual heading

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1416,7 +1416,7 @@ class OptRadarUsing(Option):
         UseForContinuousSearch = 3
 
     def __init__(self, value: Values = Values.UseForContinuousSearch):
-        super(OptRadarUsing, self).__init__(value)
+        super(OptRadarUsing, self).__init__(value.value)
 
 
 class OptChaffFlareUsing(Option):
@@ -1507,7 +1507,7 @@ class OptRTBOnOutOfAmmo(Option):
         LR_AAM = 16777216
 
     def __init__(self, value: Values=Values.All):
-        super(OptRTBOnOutOfAmmo, self).__init__(value)
+        super(OptRTBOnOutOfAmmo, self).__init__(value.value)
 
 
 class OptECMUsing(Option):

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1409,7 +1409,13 @@ class OptReactOnThreat(Option):
 class OptRadarUsing(Option):
     Key = 3
 
-    def __init__(self, value=None):
+    class Values(IntEnum):
+        NeverUse = 0
+        UseForAttackOnly = 1
+        UseForSearchIfRequired = 2
+        UseForContinuousSearch = 3
+
+    def __init__(self, value: Values = Values.UseForContinuousSearch):
         super(OptRadarUsing, self).__init__(value)
 
 
@@ -1472,9 +1478,6 @@ class OptAlarmState(Option):
 class OptRTBOnOutOfAmmo(Option):
     Key = 10
 
-    def __init__(self, value=None):
-        super(OptRTBOnOutOfAmmo, self).__init__(value)
-
     class Values(IntEnum):
         NoWeapon = 0
         All = 4294967295
@@ -1502,6 +1505,9 @@ class OptRTBOnOutOfAmmo(Option):
         SR_AAM = 4194304
         MR_AAM = 8388608
         LR_AAM = 16777216
+
+    def __init__(self, value: Values=Values.All):
+        super(OptRTBOnOutOfAmmo, self).__init__(value)
 
 
 class OptECMUsing(Option):

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -156,6 +156,32 @@ class ControlledTask(Task):
 
 class WeaponType(Enum):
     Auto = 1073741822
+    NoWeapon = 0
+    All = 4294967295
+    Unguided = 805339120
+    Cannon = 805306368
+    Rockets = 30720
+    SmokeRockets = 4096
+    LightRockets = 2048
+    CandleRockets = 8192
+    HeavyRockets = 16384
+    Bombs = 2032
+    IronBombs = 240
+    ClusterBombs = 768
+    CandleBombs = 1024
+    Guided = 268402702
+    GuidedBombs = 14
+    Missiles = 268402688
+    ASM = 4161536
+    ATGM = 131072
+    StandardASM = 1835008
+    ARM = 32768
+    Antiship = 65536
+    CruiseMissile = 2097152
+    AAM = 264241152
+    SR_AAM = 4194304
+    MR_AAM = 8388608
+    LR_AAM = 16777216
 
 
 class TargetType(type):
@@ -531,7 +557,7 @@ class EngageGroup(Task):
             "visible": visible,
             "groupId": group_id,
             "priority": 1,
-            "weaponType": 1073741822
+            "weaponType": WeaponType.Auto.value
         }
 
 
@@ -546,7 +572,7 @@ class EngageUnit(Task):
             "groupAttack": False,
             "unitId": unit_id,
             "priority": 1,
-            "weaponType": 1073741822,
+            "weaponType": WeaponType.Auto.value,
             "directionEnabled": False,
             "direction": 0,
             "altitudeEnabled": False,

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1444,14 +1444,14 @@ class OptFormation(Option):
 class OptRTBOnBingoFuel(Option):
     Key = 6
 
-    def __init__(self, value=None):
+    def __init__(self, value: bool=True):
         super(OptRTBOnBingoFuel, self).__init__(value)
 
 
 class OptRadioSilence(Option):
     Key = 7
 
-    def __init__(self, value=None):
+    def __init__(self, value: bool=True):
         super(OptRadioSilence, self).__init__(value)
 
 
@@ -1474,6 +1474,34 @@ class OptRTBOnOutOfAmmo(Option):
 
     def __init__(self, value=None):
         super(OptRTBOnOutOfAmmo, self).__init__(value)
+
+    class Values(IntEnum):
+        NoWeapon = 0
+        All = 4294967295
+        Unguided = 805339120
+        Cannon = 805306368
+        Rockets = 30720
+        SmokeRockets = 4096
+        LightRockets = 2048
+        CandleRockets = 8192
+        HeavyRockets = 16384
+        Bombs = 2032
+        IronBombs = 240
+        ClusterBombs = 768
+        CandleBombs = 1024
+        Guided = 268402702
+        GuidedBombs = 14
+        Missiles = 268402688
+        ASM = 4161536
+        ATGM = 131072
+        StandardASM = 1835008
+        ARM = 32768
+        Antiship = 65536
+        CruiseMissile = 2097152
+        AAM = 264241152
+        SR_AAM = 4194304
+        MR_AAM = 8388608
+        LR_AAM = 16777216
 
 
 class OptECMUsing(Option):

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -263,12 +263,14 @@ class VehicleGroup(MovingGroup):
         self.frequency = None
         self.visible = False  # visible before start flag
         self.spans = []
+        self.manualHeading = False
 
     def load_from_dict(self, d):
         super(VehicleGroup, self).load_from_dict(d)
         self.modulation = d.get("modulation")
         self.communication = d.get("communication", False)
         self.visible = d.get("visible", False)
+        self.manualHeading = d.get("manualHeading", False)
 
     def add_span(self, position: mapping.Point):
         self.spans.append({"x": position.x, "y": position.y})
@@ -292,6 +294,7 @@ class VehicleGroup(MovingGroup):
             d["communication"] = self.communication
             d["frequency"] = self.frequency
         d["visible"] = self.visible
+        d["manualHeading"] = self.manualHeading
         if self.spans is not None:
             # spans
             d["route"]["spans"] = {}

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -190,7 +190,11 @@ class Group:
                 d["units"][i] = unit.dict()
                 dunit = d["units"][i]
                 if len(self.points) > 1:
-                    hdg = self.points[0].position.heading_between_point(self.points[1].position)
+                    use_manual_heading = getattr(self, "manualHeading", False)
+                    if not use_manual_heading:
+                        hdg = self.points[0].position.heading_between_point(self.points[1].position)
+                    else:
+                        hdg = unit.heading
                     rhdg = math.radians(hdg)
                     dunit["heading"] = round(rhdg, 13)
                     if "psi" in dunit:


### PR DESCRIPTION
Hello @rp- 

I made this branch to add the "manualHeading" parameter. This is this parameter in DCS mission editor, that is only available for ground units : 

![image](https://user-images.githubusercontent.com/2546901/89794259-16be5000-db27-11ea-8ec2-46239bd95aad.png)

This allow forcing the heading of a unit regardless of its waypoints.

I also made some small changes to some "Option" tasks, and completed some Enums.

Thanks,

Khopa

