### PR TITLE
Add support for setting preset radio channels.

### DIFF
--- a/dcs/flyingunit.py
+++ b/dcs/flyingunit.py
@@ -95,13 +95,44 @@ class FlyingUnit(Unit):
     def reset_loadout(self):
         self.pylons = {}
 
-    def set_default_preset_channel(self, freq):
-        if self.radio:
-            self.radio[1]["channels"][1] = freq
+    def set_default_preset_channel(self, freq: float) -> None:
+        """Sets the frequency for channel 1 of the main radio."""
+        self.set_radio_channel_preset(1, 1, freq)
 
     def set_radio_preset(self):
+        """Resets the radio channel configuration to the airframe's default."""
         if self.unit_type.panel_radio:
             self.radio = self.unit_type.panel_radio
+
+    def num_radio_channels(self, radio_id: int) -> int:
+        """Returns the number of channels available for the given radio."""
+        return len(self.radio[radio_id]["channels"])
+
+    def set_radio_channel_preset(self, radio_id: int, channel: int,
+                                 frequency: float) -> None:
+        """Sets a preset radio channel to the given frequency.
+
+        Note that DCS will clobber the first compatible channel for the flight's
+        frequency. For example, if a flight of F-16s is assigned 118 MHz, COM2
+        channel 1 will be set to 118 MHz regardless of what this function sets
+        it to.
+
+        Args:
+             radio_id: The index of the radio to set the channel for.
+             channel: The channel number to set.
+             frequency: The frequency to set the channel to, in megahertz.
+
+        Raises:
+            KeyError: No such radio or channel number.
+        """
+        if self.radio is None:
+            # Not all aircraft have configurable radio channels.
+            return
+
+        radio = self.radio[radio_id]
+        if channel not in radio["channels"]:
+            raise KeyError
+        radio["channels"][channel] = frequency
 
     def set_player(self):
         if not self.unit_type.flyable:

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -477,17 +477,32 @@ class FlyingGroup(MovingGroup):
         for u in self.units:
             u.reset_loadout()
 
-    def set_frequency(self, frequency):
+    def set_frequency(self, frequency: float, radio_id: int = 1) -> None:
+        """Sets the intra-flight frequency.
+
+        This is equivalent to setting the frequency field of the aircraft group
+        in the mission editor. The primary use is in determining which frequency
+        an AI pilot will listen/transmit on for intra-flight communication.
+
+        The first channel of the first compatible radio will automatically be
+        set to this value by DCS. Any calls to
+        FlyingUnit.set_radio_channel_preset for that radio will have no effect.
+
+        Args:
+            frequency: The intra-flight frequency to assign to the group.
+            radio_id: The index of the radio that should be used for
+                intra-flight communications. Typically it is okay to use the
+                default value of 1, but for some cases (such as a VHF
+                intra-flight channel for the F-16), another radio should be
+                used.
+        """
         self.frequency = frequency
         self.radio_set = True
-
-    def dict(self):
-        # if a player/client is in the group
-        # make sure his 1. preset channel is at frequency
         for u in self.units:
             if u.skill in [Skill.Client, Skill.Player]:
-                u.set_default_preset_channel(self.frequency)
+                u.set_radio_channel_preset(radio_id, 1, self.frequency)
 
+    def dict(self):
         d = super(FlyingGroup, self).dict()
         d["modulation"] = self.modulation
         d["communication"] = self.communication


### PR DESCRIPTION
One behavioral change here that is present even without using the new
API: channel 1 of radio 1 will no longer be forcibly set during
serialization. It will still be set when set_frequency() is called,
but this allows callers to set their own channel 1 for radio 1 as
desired. DCS (the mission editor, at least) will automatically set
channel 1 of the first compatible radio to the flight's frequency, but
that is not necessarily the first radio (such as for an F-16 with a
VHF flight channel).