### PR TITLE
Reduce differences between DCS and pydcs mission files.

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -1575,6 +1575,7 @@ class AITaskPush(Action):
         super(AITaskPush, self).__init__(AITaskPush.predicate)
         self.groupid = groupid
         self.task_index = task_index
+        self.params.extend([self.groupid, self.task_index])
 
     @classmethod
     def create_from_dict(cls, d, mission):
@@ -1594,6 +1595,7 @@ class AITaskSet(Action):
         super(AITaskSet, self).__init__(AITaskSet.predicate)
         self.groupid = groupid
         self.task_index = task_index
+        self.params.extend([self.groupid, self.task_index])
 
     @classmethod
     def create_from_dict(cls, d, mission):


### PR DESCRIPTION
DCS Liberation currently has an issue where generated missions need to be opened in the mission editor and saved before delayed flights behave properly. I'm not completely sure that either of these changes fixes that issue (I can't reproduce it myself), but these seem to be the only two behavioral differences in the mission file before and after saving with the mission editor. They do seem to be incorrect, although it's possible these are working due to some default behavior for each function.