### PR TITLE
Added functions to handle multiple DCS installations (to installation.py)

### DIFF
--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -37,10 +37,13 @@ def is_using_dcs_steam_edition():
     except FileNotFoundError as fnfe:
         return False
 
+
 def is_using_dcs_standalone_edition_stable():
     """
     Check if dcs standalone stable version is installed
     """
+    if not is_windows_os:
+        return False
     try:
         dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
         winreg.CloseKey(dcs_path_key)
@@ -48,10 +51,13 @@ def is_using_dcs_standalone_edition_stable():
     except FileNotFoundError as fnfe:
         return False
 
+
 def get_dcs_install_directory_standalone_stable():
     """
         Get dcs stable install dir if avail
     """
+    if not is_windows_os:
+        return False
     try:
         dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World")
         path = winreg.QueryValueEx(dcs_path_key, "Path")
@@ -62,16 +68,20 @@ def get_dcs_install_directory_standalone_stable():
         print("Couldn't detect DCS World stable installation folder")
         return ""
 
+
 def is_using_dcs_standalone_edition_openbeta():
     """
         Check if dcs standalone openbeta version is installed
     """
+    if not is_windows_os:
+        return False
     try:
         dcs_path_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Eagle Dynamics\\DCS World OpenBeta")
         winreg.CloseKey(dcs_path_key)
         return True
     except FileNotFoundError:
         return False
+
 
 def get_dcs_install_directory_standalone_openbeta():
     """
@@ -86,6 +96,7 @@ def get_dcs_install_directory_standalone_openbeta():
     except FileNotFoundError:
         print("Couldn't detect DCS World openbeta installation folder")
         return ""
+
 
 def is_using_dcs_standalone_edition():
     """
@@ -102,6 +113,7 @@ def is_using_dcs_standalone_edition():
 
     else:
         return False
+
 
 def get_dcs_install_directory(target="any"):
     """

--- a/dcs/installation.py
+++ b/dcs/installation.py
@@ -244,6 +244,7 @@ def _find_steam_dcs_directory():
     return ""
 
 
+
 if __name__ == "__main__":
     print("Using Windows : " + str(is_windows_os))
     print("Using STEAM Edition : " + str(is_using_dcs_steam_edition()))


### PR DESCRIPTION
Added functions to independently check stable, openbeta, steam installations,
while maintaining compatibility with previous functions.

Tested with my system which installed both stable and openbeta (but not steam),
by adding scripts to if __name__ == "__main__": 

- may need test steam version, which I don't have