### PR TITLE
Added support for scenery destruction zone, and remove scene objects actions

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 from dcs.lua.serialize import dumps
 from dcs.translation import String, ResourceKey
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 class Action:
@@ -1678,6 +1678,63 @@ class UnitEmissionOn(Action):
         d["unit"] = self.unit
         return d
 
+
+class RemoveSceneObjectsMask(IntEnum):
+    ALL = 0
+    TREES_ONLY = 1
+    OBJECTS_ONLY = 2
+
+
+class RemoveSceneObjects(Action):
+    predicate = "a_remove_scene_objects"
+
+    def __init__(self, objects_mask: RemoveSceneObjectsMask=RemoveSceneObjectsMask.ALL, zone="", meters=1000):
+        super(RemoveSceneObjects, self).__init__(RemoveSceneObjects.predicate)
+        self.objects_mask = objects_mask
+        self.params.append(self.objects_mask)
+        self.zone = zone
+        self.params.append(self.zone)
+        # Note : the parameter meters is in the DCS save file, but seems unused, and not editable from ME
+        self.meters = meters
+        self.params.append(self.meters)
+
+    @classmethod
+    def create_from_dict(cls, d, mission):
+        return cls(RemoveSceneObjectsMask(d["objects_mask"]), d["zone"], d["meters"])
+
+    def dict(self):
+        d = super(RemoveSceneObjects, self).dict()
+        d["objects_mask"] = self.objects_mask.value
+        d["zone"] = self.zone
+        d["meters"] = self.meters
+        return d
+
+
+class SceneryDestructionZone(Action):
+    predicate = "a_scenery_destruction_zone"
+
+    def __init__(self, destruction_level=100, zone="", meters=1000):
+        super(SceneryDestructionZone, self).__init__(SceneryDestructionZone.predicate)
+        self.destruction_level = destruction_level
+        self.params.append(self.destruction_level)
+        self.zone = zone
+        self.params.append(self.zone)
+        # Note : the parameter meters is in the DCS save file, but seems unused, and not editable from ME
+        self.meters = meters
+        self.params.append(self.meters)
+
+    @classmethod
+    def create_from_dict(cls, d, mission):
+        return cls(d["destruction_level"], d["zone"], d["meters"])
+
+    def dict(self):
+        d = super(SceneryDestructionZone, self).dict()
+        d["destruction_level"] = self.destruction_level
+        d["zone"] = self.zone
+        d["meters"] = self.meters
+        return d
+
+
 actions_map = {
     "a_activate_group": ActivateGroup,
     "a_add_radio_item": AddRadioItem,
@@ -1752,5 +1809,7 @@ actions_map = {
     "a_unit_emission_off": UnitEmissionOff,
     "a_unit_emission_on": UnitEmissionOn,
     "a_ai_task": AITaskPush,
-    "a_set_ai_task": AITaskSet
+    "a_set_ai_task": AITaskSet,
+    "a_remove_scene_objects": RemoveSceneObjects,
+    "a_scenery_destruction_zone": SceneryDestructionZone,
 }

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -536,3 +536,111 @@ class BasicTests(unittest.TestCase):
         unit = group.units[0]
         self.assertIsInstance(unit, dcs.unit.Ship)
         self.assertEqual(unit.frequency, frequency)
+
+    def test_create_scenery_destruction_zone(self):
+
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        usa = m.country("USA")
+        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
+
+        # Create trigger zone
+        destruction_zone = m.triggers.add_triggerzone(point, 1000, False, "destruction zone")
+
+        # Add destruction zone trigger
+        t = dcs.triggers.TriggerOnce(comment='Destruction')
+        t.actions.append(dcs.action.SceneryDestructionZone(95, destruction_zone.id))
+        m.triggerrules.triggers.append(t)
+
+        m.save('missions/test_mission_scenery_destruction.miz')
+
+        # Test reload the mission
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file('missions/test_mission_scenery_destruction.miz'))
+        self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
+        self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.SceneryDestructionZone)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].destruction_level, 95)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, destruction_zone.id)
+
+    def test_remove_trees_in_zone(self):
+
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        usa = m.country("USA")
+        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
+
+        # Create trigger zone
+        removal_zone = m.triggers.add_triggerzone(point, 1000, False, "removal zone")
+
+        # Add destruction zone trigger
+        t = dcs.triggers.TriggerOnce(comment='Remove Trees')
+        t.actions.append(dcs.action.RemoveSceneObjects(dcs.action.RemoveSceneObjectsMask.TREES_ONLY, removal_zone.id))
+        m.triggerrules.triggers.append(t)
+
+        m.save('missions/test_mission_remove_trees.miz')
+
+        # Test reload the mission
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file('missions/test_mission_remove_trees.miz'))
+        self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
+        self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.TREES_ONLY)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
+
+    def test_remove_objects_in_zone(self):
+
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        usa = m.country("USA")
+        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
+
+        # Create trigger zone
+        removal_zone = m.triggers.add_triggerzone(point, 1000, False, "removal zone")
+
+        # Add destruction zone trigger
+        t = dcs.triggers.TriggerOnce(comment='Remove Trees')
+        t.actions.append(dcs.action.RemoveSceneObjects(dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY, removal_zone.id))
+        m.triggerrules.triggers.append(t)
+
+        m.save('missions/test_mission_remove_objects.miz')
+
+        # Test reload the mission
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file('missions/test_mission_remove_objects.miz'))
+        self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
+        self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
+
+    def test_remove_trees_and_objects_in_zone(self):
+
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        usa = m.country("USA")
+        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
+
+        # Create trigger zone
+        removal_zone = m.triggers.add_triggerzone(point, 1000, False, "removal zone")
+
+        # Add destruction zone trigger
+        t = dcs.triggers.TriggerOnce(comment='Remove Trees')
+        t.actions.append(dcs.action.RemoveSceneObjects(dcs.action.RemoveSceneObjectsMask.ALL, removal_zone.id))
+        m.triggerrules.triggers.append(t)
+
+        m.save('missions/test_mission_remove_all.miz')
+
+        # Test reload the mission
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file('missions/test_mission_remove_all.miz'))
+        self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
+        self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.ALL)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)


### PR DESCRIPTION
Hello

I added support for two missing mission editor actions : 

* Scenery Destruction Zone
* Scenery Remove Objects Zone

![image](https://user-images.githubusercontent.com/2546901/96119800-cb8d3880-0eed-11eb-9cae-09310933f203.png)

Regards,


Khopa
