### PR TITLE
data-export: 2.5.6.57264

### DIFF
--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -179,7 +179,9 @@ class Russia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -198,7 +200,6 @@ class Russia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -244,7 +245,9 @@ class Russia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -263,7 +266,6 @@ class Russia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -600,7 +602,9 @@ class Ukraine(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -619,7 +623,6 @@ class Ukraine(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -657,7 +660,9 @@ class Ukraine(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -676,7 +681,6 @@ class Ukraine(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -799,6 +803,9 @@ class USA(Country):
             Rapier_FSA_Launcher = vehicles.AirDefence.Rapier_FSA_Launcher
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -841,9 +848,12 @@ class USA(Country):
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
 
         class Locomotive:
             ES44AH = vehicles.Locomotive.ES44AH
@@ -915,25 +925,25 @@ class USA(Country):
         AV8BNA = planes.AV8BNA
         Hawk = planes.Hawk
         KC130 = planes.KC130
+        A_10C_2 = planes.A_10C_2
+        F_14B = planes.F_14B
         FW_190D9 = planes.FW_190D9
         FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
-        A_10C_2 = planes.A_10C_2
+        A_20G = planes.A_20G
         AJS37 = planes.AJS37
         C_101EB = planes.C_101EB
         C_101CC = planes.C_101CC
         JF_17 = planes.JF_17
-        F_14B = planes.F_14B
         I_16 = planes.I_16
         M_2000C = planes.M_2000C
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -979,25 +989,25 @@ class USA(Country):
         Plane.AV8BNA,
         Plane.Hawk,
         Plane.KC130,
+        Plane.A_10C_2,
+        Plane.F_14B,
         Plane.FW_190D9,
         Plane.FW_190A8,
         Plane.Bf_109K_4,
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
-        Plane.A_10C_2,
+        Plane.A_20G,
         Plane.AJS37,
         Plane.C_101EB,
         Plane.C_101CC,
         Plane.JF_17,
-        Plane.F_14B,
         Plane.I_16,
         Plane.M_2000C,
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -1047,10 +1057,10 @@ class USA(Country):
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         LHA_1_Tarawa = ships.LHA_1_Tarawa
         USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
         CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
         CVN_73_George_Washington = ships.CVN_73_George_Washington
-        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -1232,6 +1242,7 @@ class Turkey(Country):
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -1274,7 +1285,9 @@ class Turkey(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -1294,7 +1307,6 @@ class Turkey(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -1319,7 +1331,9 @@ class Turkey(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -1339,7 +1353,6 @@ class Turkey(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -1517,7 +1530,10 @@ class UK(Country):
             Rapier_FSA_Launcher = vehicles.AirDefence.Rapier_FSA_Launcher
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -1546,13 +1562,16 @@ class UK(Country):
             TPz_Fuchs = vehicles.Armor.TPz_Fuchs
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            M4_Tractor = vehicles.Armor.M4_Tractor
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
@@ -1597,7 +1616,9 @@ class UK(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         KC130 = planes.KC130
         KC135MPRS = planes.KC135MPRS
@@ -1617,7 +1638,6 @@ class UK(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         B_17G = planes.B_17G
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -1640,7 +1660,9 @@ class UK(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.KC130,
         Plane.KC135MPRS,
@@ -1660,7 +1682,6 @@ class UK(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.B_17G,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -1835,6 +1856,9 @@ class France(Country):
             Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
             SAM_Stinger_comm_dsr = vehicles.AirDefence.SAM_Stinger_comm_dsr
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -1862,10 +1886,13 @@ class France(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            M4_Tractor = vehicles.Armor.M4_Tractor
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
@@ -1911,7 +1938,9 @@ class France(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         C_101EB = planes.C_101EB
@@ -1928,7 +1957,6 @@ class France(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -1954,7 +1982,9 @@ class France(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.C_101EB,
@@ -1971,7 +2001,6 @@ class France(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -2186,6 +2215,7 @@ class Germany(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -2233,15 +2263,15 @@ class Germany(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -2283,6 +2313,7 @@ class Germany(Country):
         Su_17M4 = planes.Su_17M4
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
+        MiG_29A = planes.MiG_29A
         FW_190D9 = planes.FW_190D9
         FW_190A8 = planes.FW_190A8
         Bf_109K_4 = planes.Bf_109K_4
@@ -2292,7 +2323,9 @@ class Germany(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -2310,7 +2343,6 @@ class Germany(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -2328,6 +2360,7 @@ class Germany(Country):
         Plane.Su_17M4,
         Plane.Yak_40,
         Plane.Yak_52,
+        Plane.MiG_29A,
         Plane.FW_190D9,
         Plane.FW_190A8,
         Plane.Bf_109K_4,
@@ -2337,7 +2370,9 @@ class Germany(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -2355,7 +2390,6 @@ class Germany(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.MiG_19P,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -2554,6 +2588,7 @@ class USAFAggressors(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
             EWR_1L13 = vehicles.AirDefence.EWR_1L13
             SAM_SA_19_Tunguska_2S6 = vehicles.AirDefence.SAM_SA_19_Tunguska_2S6
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
@@ -2585,6 +2620,9 @@ class USAFAggressors(Country):
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
             AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
             SAM_Hawk_TR_AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR_AN_MPQ_46
             SAM_Hawk_SR_AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR_AN_MPQ_50
@@ -2631,8 +2669,8 @@ class USAFAggressors(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -2673,15 +2711,15 @@ class USAFAggressors(Country):
             APC_Tigr_233036 = vehicles.Unarmed.APC_Tigr_233036
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
@@ -2698,13 +2736,16 @@ class USAFAggressors(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
@@ -2773,7 +2814,9 @@ class USAFAggressors(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -2795,7 +2838,6 @@ class USAFAggressors(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         A_50 = planes.A_50
         An_26B = planes.An_26B
@@ -2857,7 +2899,6 @@ class USAFAggressors(Country):
         F_14A = planes.F_14A
         S_3B_Tanker = planes.S_3B_Tanker
         S_3B = planes.S_3B
-        A_10C_2 = planes.A_10C_2
         F_14B = planes.F_14B
         Tornado_GR4 = planes.Tornado_GR4
 
@@ -2870,7 +2911,9 @@ class USAFAggressors(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -2892,7 +2935,6 @@ class USAFAggressors(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.A_50,
         Plane.An_26B,
@@ -2954,7 +2996,6 @@ class USAFAggressors(Country):
         Plane.F_14A,
         Plane.S_3B_Tanker,
         Plane.S_3B,
-        Plane.A_10C_2,
         Plane.F_14B,
         Plane.Tornado_GR4,
     ]
@@ -3034,10 +3075,10 @@ class USAFAggressors(Country):
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LHA_1_Tarawa = ships.LHA_1_Tarawa
         USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
         CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
         CVN_73_George_Washington = ships.CVN_73_George_Washington
-        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -3176,6 +3217,9 @@ class Canada(Country):
             Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -3205,11 +3249,14 @@ class Canada(Country):
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
-            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
-            M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            M4_Tractor = vehicles.Armor.M4_Tractor
             APC_M2A1 = vehicles.Armor.APC_M2A1
+            CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
+            HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
 
@@ -3252,7 +3299,9 @@ class Canada(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -3270,7 +3319,6 @@ class Canada(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -3292,7 +3340,9 @@ class Canada(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -3310,7 +3360,6 @@ class Canada(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -3517,6 +3566,7 @@ class Spain(Country):
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -3561,7 +3611,9 @@ class Spain(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         KC135MPRS = planes.KC135MPRS
         JF_17 = planes.JF_17
@@ -3576,7 +3628,6 @@ class Spain(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -3603,7 +3654,9 @@ class Spain(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.KC135MPRS,
         Plane.JF_17,
@@ -3618,7 +3671,6 @@ class Spain(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -3802,6 +3854,9 @@ class TheNetherlands(Country):
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -3834,9 +3889,12 @@ class TheNetherlands(Country):
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
+            M4_Tractor = vehicles.Armor.M4_Tractor
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
@@ -3880,7 +3938,9 @@ class TheNetherlands(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -3901,7 +3961,6 @@ class TheNetherlands(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -3923,7 +3982,9 @@ class TheNetherlands(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -3944,7 +4005,6 @@ class TheNetherlands(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -4122,6 +4182,9 @@ class Belgium(Country):
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -4148,9 +4211,12 @@ class Belgium(Country):
             APC_M2A1 = vehicles.Armor.APC_M2A1
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            M4_Tractor = vehicles.Armor.M4_Tractor
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
@@ -4191,7 +4257,9 @@ class Belgium(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -4212,7 +4280,6 @@ class Belgium(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -4232,7 +4299,9 @@ class Belgium(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -4253,7 +4322,6 @@ class Belgium(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -4448,6 +4516,7 @@ class Norway(Country):
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             TPz_Fuchs = vehicles.Armor.TPz_Fuchs
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -4486,7 +4555,9 @@ class Norway(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -4506,7 +4577,6 @@ class Norway(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -4527,7 +4597,9 @@ class Norway(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -4547,7 +4619,6 @@ class Norway(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -4741,6 +4812,7 @@ class Denmark(Country):
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             ATGM_M1045_HMMWV_TOW = vehicles.Armor.ATGM_M1045_HMMWV_TOW
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -4779,7 +4851,9 @@ class Denmark(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -4799,7 +4873,6 @@ class Denmark(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -4820,7 +4893,9 @@ class Denmark(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -4840,7 +4915,6 @@ class Denmark(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -5022,6 +5096,7 @@ class Israel(Country):
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -5048,10 +5123,11 @@ class Israel(Country):
             APC_M2A1 = vehicles.Armor.APC_M2A1
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -5096,7 +5172,9 @@ class Israel(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -5115,7 +5193,6 @@ class Israel(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -5141,7 +5218,9 @@ class Israel(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -5160,7 +5239,6 @@ class Israel(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -5447,7 +5525,9 @@ class Georgia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -5466,7 +5546,6 @@ class Georgia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         TF_51D = planes.TF_51D
 
@@ -5488,7 +5567,9 @@ class Georgia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -5507,7 +5588,6 @@ class Georgia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.TF_51D,
     ]
@@ -5761,8 +5841,10 @@ class Insurgents(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
         A_10C = planes.A_10C
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -5783,7 +5865,6 @@ class Insurgents(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -5795,8 +5876,10 @@ class Insurgents(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
         Plane.A_10C,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -5817,7 +5900,6 @@ class Insurgents(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -6001,8 +6083,10 @@ class Abkhazia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
         A_10C = planes.A_10C
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -6021,7 +6105,6 @@ class Abkhazia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -6040,8 +6123,10 @@ class Abkhazia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
         Plane.A_10C,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -6060,7 +6145,6 @@ class Abkhazia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -6233,8 +6317,10 @@ class SouthOssetia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
         A_10C = planes.A_10C
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -6255,7 +6341,6 @@ class SouthOssetia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -6266,8 +6351,10 @@ class SouthOssetia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
         Plane.A_10C,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -6288,7 +6375,6 @@ class SouthOssetia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -6399,6 +6485,7 @@ class Italy(Country):
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -6443,7 +6530,9 @@ class Italy(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         KC135MPRS = planes.KC135MPRS
         C_101EB = planes.C_101EB
@@ -6462,7 +6551,6 @@ class Italy(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -6488,7 +6576,9 @@ class Italy(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.KC135MPRS,
         Plane.C_101EB,
@@ -6507,7 +6597,6 @@ class Italy(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -6672,6 +6761,9 @@ class Australia(Country):
             Rapier_FSA_Launcher = vehicles.AirDefence.Rapier_FSA_Launcher
             Rapier_FSA_Optical_Tracker = vehicles.AirDefence.Rapier_FSA_Optical_Tracker
             Rapier_FSA_Blindfire_Tracker = vehicles.AirDefence.Rapier_FSA_Blindfire_Tracker
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -6699,15 +6791,18 @@ class Australia(Country):
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
             APC_M113 = vehicles.Armor.APC_M113
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
-            APC_M2A1 = vehicles.Armor.APC_M2A1
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             ES44AH = vehicles.Locomotive.ES44AH
@@ -6748,7 +6843,9 @@ class Australia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -6768,7 +6865,6 @@ class Australia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -6790,7 +6886,9 @@ class Australia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -6810,7 +6908,6 @@ class Australia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -7036,7 +7133,9 @@ class Switzerland(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -7055,7 +7154,6 @@ class Switzerland(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -7073,7 +7171,9 @@ class Switzerland(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -7092,7 +7192,6 @@ class Switzerland(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -7261,9 +7360,10 @@ class Austria(Country):
 
         class Armor:
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             DRG_Class_86 = vehicles.Locomotive.DRG_Class_86
@@ -7297,7 +7397,9 @@ class Austria(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -7316,7 +7418,6 @@ class Austria(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -7331,7 +7432,9 @@ class Austria(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -7350,7 +7453,6 @@ class Austria(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -7643,7 +7745,9 @@ class Belarus(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -7662,7 +7766,6 @@ class Belarus(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -7688,7 +7791,9 @@ class Belarus(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -7707,7 +7812,6 @@ class Belarus(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -7818,6 +7922,7 @@ class Bulgaria(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -7840,8 +7945,8 @@ class Bulgaria(Country):
             Transport_UAZ_469 = vehicles.Unarmed.Transport_UAZ_469
             Transport_ZIU_9 = vehicles.Unarmed.Transport_ZIU_9
             Transport_VAZ_2109 = vehicles.Unarmed.Transport_VAZ_2109
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -7855,14 +7960,14 @@ class Bulgaria(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -7912,7 +8017,9 @@ class Bulgaria(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -7929,7 +8036,6 @@ class Bulgaria(Country):
         I_16 = planes.I_16
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -7954,7 +8060,9 @@ class Bulgaria(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -7971,7 +8079,6 @@ class Bulgaria(Country):
         Plane.I_16,
         Plane.L_39C,
         Plane.M_2000C,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -8143,6 +8250,9 @@ class CzechRepublic(Country):
             SAM_SA_8_Osa_9A33 = vehicles.AirDefence.SAM_SA_8_Osa_9A33
             SAM_SA_2_LN_SM_90 = vehicles.AirDefence.SAM_SA_2_LN_SM_90
             SAM_SA_2_TR_SNR_75_Fan_Song = vehicles.AirDefence.SAM_SA_2_TR_SNR_75_Fan_Song
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -8172,15 +8282,18 @@ class CzechRepublic(Country):
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
+            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
-            APC_M2A1 = vehicles.Armor.APC_M2A1
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class MissilesSS:
             SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
@@ -8221,7 +8334,9 @@ class CzechRepublic(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -8241,7 +8356,6 @@ class CzechRepublic(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -8260,7 +8374,9 @@ class CzechRepublic(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -8280,7 +8396,6 @@ class CzechRepublic(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -8528,7 +8643,9 @@ class China(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -8547,7 +8664,6 @@ class China(Country):
         M_2000C = planes.M_2000C
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -8573,7 +8689,9 @@ class China(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -8592,7 +8710,6 @@ class China(Country):
         Plane.M_2000C,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -8696,6 +8813,7 @@ class Croatia(Country):
             APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -8728,7 +8846,9 @@ class Croatia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -8748,7 +8868,6 @@ class Croatia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -8762,7 +8881,9 @@ class Croatia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -8782,7 +8903,6 @@ class Croatia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -9056,7 +9176,9 @@ class Egypt(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -9076,7 +9198,6 @@ class Egypt(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -9094,7 +9215,9 @@ class Egypt(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -9114,7 +9237,6 @@ class Egypt(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -9308,6 +9430,7 @@ class Finland(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -9329,8 +9452,8 @@ class Finland(Country):
             Transport_UAZ_469 = vehicles.Unarmed.Transport_UAZ_469
             Transport_ZIU_9 = vehicles.Unarmed.Transport_ZIU_9
             Transport_VAZ_2109 = vehicles.Unarmed.Transport_VAZ_2109
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -9342,15 +9465,15 @@ class Finland(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -9390,7 +9513,9 @@ class Finland(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -9408,7 +9533,6 @@ class Finland(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -9424,7 +9548,9 @@ class Finland(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -9442,7 +9568,6 @@ class Finland(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -9659,9 +9784,10 @@ class Greece(Country):
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -9701,7 +9827,9 @@ class Greece(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -9721,7 +9849,6 @@ class Greece(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -9742,7 +9869,9 @@ class Greece(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -9762,7 +9891,6 @@ class Greece(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -9959,6 +10087,7 @@ class Hungary(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -9979,8 +10108,8 @@ class Hungary(Country):
             Transport_MAZ_6303 = vehicles.Unarmed.Transport_MAZ_6303
             Transport_ZIU_9 = vehicles.Unarmed.Transport_ZIU_9
             Transport_VAZ_2109 = vehicles.Unarmed.Transport_VAZ_2109
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -9996,12 +10125,12 @@ class Hungary(Country):
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -10036,7 +10165,7 @@ class Hungary(Country):
         C_17A = planes.C_17A
         MiG_15bis = planes.MiG_15bis
         MiG_21Bis = planes.MiG_21Bis
-        MiG_29S = planes.MiG_29S
+        MiG_29A = planes.MiG_29A
         Yak_40 = planes.Yak_40
         Yak_52 = planes.Yak_52
         FW_190A8 = planes.FW_190A8
@@ -10046,7 +10175,9 @@ class Hungary(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -10064,7 +10195,6 @@ class Hungary(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -10074,7 +10204,7 @@ class Hungary(Country):
         Plane.C_17A,
         Plane.MiG_15bis,
         Plane.MiG_21Bis,
-        Plane.MiG_29S,
+        Plane.MiG_29A,
         Plane.Yak_40,
         Plane.Yak_52,
         Plane.FW_190A8,
@@ -10084,7 +10214,9 @@ class Hungary(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -10102,13 +10234,13 @@ class Hungary(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.MiG_19P,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         Mi_24V = helicopters.Mi_24V
+        Mi_8MT = helicopters.Mi_8MT
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -10117,6 +10249,7 @@ class Hungary(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.Mi_24V,
+        Helicopter.Mi_8MT,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -10282,6 +10415,7 @@ class India(Country):
             SAM_SA_18_Igla_S_MANPADS = vehicles.AirDefence.SAM_SA_18_Igla_S_MANPADS
             SAM_SA_18_Igla_S_comm = vehicles.AirDefence.SAM_SA_18_Igla_S_comm
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -10307,6 +10441,7 @@ class India(Country):
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -10349,7 +10484,9 @@ class India(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -10367,7 +10504,6 @@ class India(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -10391,7 +10527,9 @@ class India(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -10409,7 +10547,6 @@ class India(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -10685,7 +10822,9 @@ class Iran(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -10703,7 +10842,6 @@ class Iran(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -10728,7 +10866,9 @@ class Iran(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -10746,7 +10886,6 @@ class Iran(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -11019,7 +11158,9 @@ class Iraq(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -11037,7 +11178,6 @@ class Iraq(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -11060,7 +11200,9 @@ class Iraq(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -11078,7 +11220,6 @@ class Iraq(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -11263,6 +11404,7 @@ class Japan(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -11279,23 +11421,23 @@ class Japan(Country):
         class Unarmed:
             Transport_M818 = vehicles.Unarmed.Transport_M818
             APC_M1025_HMMWV = vehicles.Unarmed.APC_M1025_HMMWV
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
 
         class Armor:
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -11336,7 +11478,9 @@ class Japan(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -11355,7 +11499,6 @@ class Japan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -11372,7 +11515,9 @@ class Japan(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -11391,7 +11536,6 @@ class Japan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -11699,7 +11843,9 @@ class Kazakhstan(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -11720,7 +11866,6 @@ class Kazakhstan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -11745,7 +11890,9 @@ class Kazakhstan(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -11766,7 +11913,6 @@ class Kazakhstan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -11955,7 +12101,7 @@ class NorthKorea(Country):
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
@@ -11998,7 +12144,9 @@ class NorthKorea(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -12017,7 +12165,6 @@ class NorthKorea(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -12034,7 +12181,9 @@ class NorthKorea(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -12053,7 +12202,6 @@ class NorthKorea(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -12222,6 +12370,7 @@ class Pakistan(Country):
             Stinger_MANPADS = vehicles.AirDefence.Stinger_MANPADS
             SAM_Stinger_comm = vehicles.AirDefence.SAM_Stinger_comm
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
             HQ_7_Self_Propelled_LN = vehicles.AirDefence.HQ_7_Self_Propelled_LN
             HQ_7_Self_Propelled_STR = vehicles.AirDefence.HQ_7_Self_Propelled_STR
 
@@ -12285,7 +12434,9 @@ class Pakistan(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -12306,7 +12457,6 @@ class Pakistan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -12326,7 +12476,9 @@ class Pakistan(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -12347,7 +12499,6 @@ class Pakistan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -12521,6 +12672,9 @@ class Poland(Country):
             SAM_SA_8_Osa_9A33 = vehicles.AirDefence.SAM_SA_8_Osa_9A33
             SAM_SA_9_Strela_1_9P31 = vehicles.AirDefence.SAM_SA_9_Strela_1_9P31
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -12553,17 +12707,20 @@ class Poland(Country):
             APC_MTLB = vehicles.Armor.APC_MTLB
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class MissilesSS:
             SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
@@ -12613,7 +12770,9 @@ class Poland(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -12630,7 +12789,6 @@ class Poland(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -12658,7 +12816,9 @@ class Poland(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -12675,7 +12835,6 @@ class Poland(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -12861,6 +13020,7 @@ class Romania(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -12883,8 +13043,8 @@ class Romania(Country):
             Transport_UAZ_469 = vehicles.Unarmed.Transport_UAZ_469
             Transport_ZIU_9 = vehicles.Unarmed.Transport_ZIU_9
             Transport_VAZ_2109 = vehicles.Unarmed.Transport_VAZ_2109
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -12896,14 +13056,14 @@ class Romania(Country):
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -12950,7 +13110,9 @@ class Romania(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -12967,7 +13129,6 @@ class Romania(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         MiG_21Bis = planes.MiG_21Bis
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -12989,7 +13150,9 @@ class Romania(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -13006,7 +13169,6 @@ class Romania(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.MiG_21Bis,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -13254,7 +13416,9 @@ class SaudiArabia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -13271,7 +13435,6 @@ class SaudiArabia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -13294,7 +13457,9 @@ class SaudiArabia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -13311,7 +13476,6 @@ class SaudiArabia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -13577,7 +13741,9 @@ class Serbia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -13598,7 +13764,6 @@ class Serbia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -13615,7 +13780,9 @@ class Serbia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -13636,7 +13803,6 @@ class Serbia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -13877,7 +14043,9 @@ class Slovakia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -13897,7 +14065,6 @@ class Slovakia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -13915,7 +14082,9 @@ class Slovakia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -13935,7 +14104,6 @@ class Slovakia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -14132,6 +14300,7 @@ class SouthKorea(Country):
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -14174,7 +14343,9 @@ class SouthKorea(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -14191,7 +14362,6 @@ class SouthKorea(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -14215,7 +14385,9 @@ class SouthKorea(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -14232,7 +14404,6 @@ class SouthKorea(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -14450,7 +14621,9 @@ class Sweden(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
         C_101EB = planes.C_101EB
@@ -14469,7 +14642,6 @@ class Sweden(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -14488,7 +14660,9 @@ class Sweden(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AV8BNA,
         Plane.KC135MPRS,
         Plane.C_101EB,
@@ -14507,7 +14681,6 @@ class Sweden(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -14755,7 +14928,9 @@ class Syria(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -14774,7 +14949,6 @@ class Syria(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -14794,7 +14968,9 @@ class Syria(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -14813,7 +14989,6 @@ class Syria(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -15050,7 +15225,9 @@ class Yemen(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -15068,7 +15245,6 @@ class Yemen(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -15087,7 +15263,9 @@ class Yemen(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -15105,7 +15283,6 @@ class Yemen(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -15356,7 +15533,9 @@ class Vietnam(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -15372,7 +15551,6 @@ class Vietnam(Country):
         M_2000C = planes.M_2000C
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -15395,7 +15573,9 @@ class Vietnam(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -15411,7 +15591,6 @@ class Vietnam(Country):
         Plane.M_2000C,
         Plane.MiG_15bis,
         Plane.MiG_19P,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -15647,7 +15826,9 @@ class Venezuela(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -15667,7 +15848,6 @@ class Venezuela(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -15683,7 +15863,9 @@ class Venezuela(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -15703,7 +15885,6 @@ class Venezuela(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -15913,7 +16094,9 @@ class Tunisia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -15931,7 +16114,6 @@ class Tunisia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -15947,7 +16129,9 @@ class Tunisia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -15965,7 +16149,6 @@ class Tunisia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -16181,7 +16364,9 @@ class Thailand(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -16199,7 +16384,6 @@ class Thailand(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -16218,7 +16402,9 @@ class Thailand(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -16236,7 +16422,6 @@ class Thailand(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -16465,7 +16650,9 @@ class Sudan(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -16484,7 +16671,6 @@ class Sudan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -16503,7 +16689,9 @@ class Sudan(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -16522,7 +16710,6 @@ class Sudan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -16735,7 +16922,9 @@ class Philippines(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -16753,7 +16942,6 @@ class Philippines(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -16772,7 +16960,9 @@ class Philippines(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -16790,7 +16980,6 @@ class Philippines(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -17024,7 +17213,9 @@ class Morocco(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -17042,7 +17233,6 @@ class Morocco(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -17060,7 +17250,9 @@ class Morocco(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -17078,7 +17270,6 @@ class Morocco(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -17291,7 +17482,9 @@ class Mexico(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -17310,7 +17503,6 @@ class Mexico(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -17326,7 +17518,9 @@ class Mexico(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -17345,7 +17539,6 @@ class Mexico(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -17525,6 +17718,9 @@ class Malaysia(Country):
             Land_Rover_101_FC = vehicles.Unarmed.Land_Rover_101_FC
             Land_Rover_109_S3 = vehicles.Unarmed.Land_Rover_109_S3
 
+        class Armor:
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
             Locomotive_CHME3T = vehicles.Locomotive.Locomotive_CHME3T
@@ -17560,7 +17756,9 @@ class Malaysia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -17577,7 +17775,6 @@ class Malaysia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -17595,7 +17792,9 @@ class Malaysia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -17612,7 +17811,6 @@ class Malaysia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -17849,7 +18047,9 @@ class Libya(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -17868,7 +18068,6 @@ class Libya(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -17885,7 +18084,9 @@ class Libya(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -17904,7 +18105,6 @@ class Libya(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -18132,7 +18332,9 @@ class Jordan(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -18148,7 +18350,6 @@ class Jordan(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -18168,7 +18369,9 @@ class Jordan(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -18184,7 +18387,6 @@ class Jordan(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -18423,7 +18625,9 @@ class Indonesia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -18440,7 +18644,6 @@ class Indonesia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -18465,7 +18668,9 @@ class Indonesia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -18482,7 +18687,6 @@ class Indonesia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -18685,7 +18889,9 @@ class Honduras(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -18702,7 +18908,6 @@ class Honduras(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -18719,7 +18924,9 @@ class Honduras(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -18736,7 +18943,6 @@ class Honduras(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -18972,7 +19178,9 @@ class Ethiopia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -18988,7 +19196,6 @@ class Ethiopia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -19009,7 +19216,9 @@ class Ethiopia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -19025,7 +19234,6 @@ class Ethiopia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -19254,7 +19462,9 @@ class Chile(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -19270,7 +19480,6 @@ class Chile(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -19294,7 +19503,9 @@ class Chile(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -19310,7 +19521,6 @@ class Chile(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -19544,7 +19754,9 @@ class Brazil(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -19561,7 +19773,6 @@ class Brazil(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -19579,7 +19790,9 @@ class Brazil(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -19596,7 +19809,6 @@ class Brazil(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -19824,7 +20036,9 @@ class Bahrain(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -19842,7 +20056,6 @@ class Bahrain(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -19857,7 +20070,9 @@ class Bahrain(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -19875,7 +20090,6 @@ class Bahrain(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -20045,6 +20259,7 @@ class ThirdReich(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -20059,22 +20274,22 @@ class ThirdReich(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -20111,7 +20326,9 @@ class ThirdReich(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -20132,7 +20349,6 @@ class ThirdReich(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -20145,7 +20361,9 @@ class ThirdReich(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -20166,7 +20384,6 @@ class ThirdReich(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -20334,6 +20551,9 @@ class Yugoslavia(Country):
             SAM_SA_9_Strela_1_9P31 = vehicles.AirDefence.SAM_SA_9_Strela_1_9P31
             SPAAA_ZSU_23_4_Shilka = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -20356,14 +20576,17 @@ class Yugoslavia(Country):
             ARV_BRDM_2 = vehicles.Armor.ARV_BRDM_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
-            APC_M2A1 = vehicles.Armor.APC_M2A1
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class MissilesSS:
             SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
@@ -20401,7 +20624,9 @@ class Yugoslavia(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -20421,7 +20646,6 @@ class Yugoslavia(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -20437,7 +20661,9 @@ class Yugoslavia(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -20457,7 +20683,6 @@ class Yugoslavia(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -20580,6 +20805,9 @@ class USSR(Country):
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -20631,14 +20859,17 @@ class USSR(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class MissilesSS:
             SRBM_SS_1C_Scud_B_9K72_LN_9P117M = vehicles.MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M
@@ -20704,7 +20935,9 @@ class USSR(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -20719,7 +20952,6 @@ class USSR(Country):
         FA_18C_hornet = planes.FA_18C_hornet
         Hawk = planes.Hawk
         M_2000C = planes.M_2000C
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -20763,7 +20995,9 @@ class USSR(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -20778,7 +21012,6 @@ class USSR(Country):
         Plane.FA_18C_hornet,
         Plane.Hawk,
         Plane.M_2000C,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -20884,6 +21117,7 @@ class ItalianSocialRepublic(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -20898,22 +21132,22 @@ class ItalianSocialRepublic(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
 
@@ -20949,7 +21183,9 @@ class ItalianSocialRepublic(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -20970,7 +21206,6 @@ class ItalianSocialRepublic(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -20982,7 +21217,9 @@ class ItalianSocialRepublic(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -21003,7 +21240,6 @@ class ItalianSocialRepublic(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -21298,7 +21534,9 @@ class Algeria(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -21317,7 +21555,6 @@ class Algeria(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -21348,7 +21585,9 @@ class Algeria(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -21367,7 +21606,6 @@ class Algeria(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -21618,7 +21856,9 @@ class Kuwait(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC135MPRS = planes.KC135MPRS
@@ -21637,7 +21877,6 @@ class Kuwait(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -21654,7 +21893,9 @@ class Kuwait(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC135MPRS,
@@ -21673,7 +21914,6 @@ class Kuwait(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -21859,6 +22099,7 @@ class Qatar(Country):
 
         class Armor:
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -21892,7 +22133,9 @@ class Qatar(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -21912,7 +22155,6 @@ class Qatar(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -21927,7 +22169,9 @@ class Qatar(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -21947,7 +22191,6 @@ class Qatar(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -22182,7 +22425,9 @@ class Oman(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -22202,7 +22447,6 @@ class Oman(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -22218,7 +22462,9 @@ class Oman(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -22238,7 +22484,6 @@ class Oman(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -22478,7 +22723,9 @@ class UnitedArabEmirates(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -22498,7 +22745,6 @@ class UnitedArabEmirates(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -22516,7 +22762,9 @@ class UnitedArabEmirates(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -22536,7 +22784,6 @@ class UnitedArabEmirates(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -22755,7 +23002,9 @@ class SouthAfrica(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -22774,7 +23023,6 @@ class SouthAfrica(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -22792,7 +23040,9 @@ class SouthAfrica(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -22811,7 +23061,6 @@ class SouthAfrica(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -23076,7 +23325,9 @@ class Cuba(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -23093,7 +23344,6 @@ class Cuba(Country):
         I_16 = planes.I_16
         M_2000C = planes.M_2000C
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -23121,7 +23371,9 @@ class Cuba(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -23138,7 +23390,6 @@ class Cuba(Country):
         Plane.I_16,
         Plane.M_2000C,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -23329,7 +23580,8 @@ class Portugal(Country):
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
+            M4_Tractor = vehicles.Armor.M4_Tractor
 
         class Locomotive:
             Electric_locomotive_VL80 = vehicles.Locomotive.Electric_locomotive_VL80
@@ -23367,7 +23619,9 @@ class Portugal(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -23387,7 +23641,6 @@ class Portugal(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -23406,7 +23659,9 @@ class Portugal(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -23426,7 +23681,6 @@ class Portugal(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -23668,7 +23922,7 @@ class GDR(Country):
         An_26B = planes.An_26B
         MiG_15bis = planes.MiG_15bis
         MiG_21Bis = planes.MiG_21Bis
-        MiG_29G = planes.MiG_29G
+        MiG_29A = planes.MiG_29A
         Su_17M4 = planes.Su_17M4
         Yak_40 = planes.Yak_40
         FW_190A8 = planes.FW_190A8
@@ -23678,7 +23932,9 @@ class GDR(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -23697,7 +23953,6 @@ class GDR(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -23705,7 +23960,7 @@ class GDR(Country):
         Plane.An_26B,
         Plane.MiG_15bis,
         Plane.MiG_21Bis,
-        Plane.MiG_29G,
+        Plane.MiG_29A,
         Plane.Su_17M4,
         Plane.Yak_40,
         Plane.FW_190A8,
@@ -23715,7 +23970,9 @@ class GDR(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -23734,7 +23991,6 @@ class GDR(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -23966,7 +24222,9 @@ class Lebanon(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -23986,7 +24244,6 @@ class Lebanon(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
 
     planes = [
@@ -24001,7 +24258,9 @@ class Lebanon(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -24021,7 +24280,6 @@ class Lebanon(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
     ]
 
@@ -24215,6 +24473,7 @@ class CombinedJointTaskForcesBlue(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
             EWR_1L13 = vehicles.AirDefence.EWR_1L13
             SAM_SA_19_Tunguska_2S6 = vehicles.AirDefence.SAM_SA_19_Tunguska_2S6
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
@@ -24246,6 +24505,9 @@ class CombinedJointTaskForcesBlue(Country):
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
             AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
             SAM_Hawk_TR_AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR_AN_MPQ_46
             SAM_Hawk_SR_AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR_AN_MPQ_50
@@ -24292,8 +24554,8 @@ class CombinedJointTaskForcesBlue(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -24334,15 +24596,15 @@ class CombinedJointTaskForcesBlue(Country):
             APC_Tigr_233036 = vehicles.Unarmed.APC_Tigr_233036
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
@@ -24359,13 +24621,16 @@ class CombinedJointTaskForcesBlue(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
@@ -24434,7 +24699,9 @@ class CombinedJointTaskForcesBlue(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -24455,7 +24722,6 @@ class CombinedJointTaskForcesBlue(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         A_50 = planes.A_50
         An_26B = planes.An_26B
@@ -24518,7 +24784,6 @@ class CombinedJointTaskForcesBlue(Country):
         F_14A = planes.F_14A
         S_3B_Tanker = planes.S_3B_Tanker
         S_3B = planes.S_3B
-        A_10C_2 = planes.A_10C_2
         F_14B = planes.F_14B
         Tornado_GR4 = planes.Tornado_GR4
 
@@ -24531,7 +24796,9 @@ class CombinedJointTaskForcesBlue(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -24552,7 +24819,6 @@ class CombinedJointTaskForcesBlue(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.A_50,
         Plane.An_26B,
@@ -24615,7 +24881,6 @@ class CombinedJointTaskForcesBlue(Country):
         Plane.F_14A,
         Plane.S_3B_Tanker,
         Plane.S_3B,
-        Plane.A_10C_2,
         Plane.F_14B,
         Plane.Tornado_GR4,
     ]
@@ -24695,10 +24960,10 @@ class CombinedJointTaskForcesBlue(Country):
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LHA_1_Tarawa = ships.LHA_1_Tarawa
         USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
         CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
         CVN_73_George_Washington = ships.CVN_73_George_Washington
-        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -24870,6 +25135,7 @@ class CombinedJointTaskForcesRed(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
             EWR_1L13 = vehicles.AirDefence.EWR_1L13
             SAM_SA_19_Tunguska_2S6 = vehicles.AirDefence.SAM_SA_19_Tunguska_2S6
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
@@ -24901,6 +25167,9 @@ class CombinedJointTaskForcesRed(Country):
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
             AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
             SAM_Hawk_TR_AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR_AN_MPQ_46
             SAM_Hawk_SR_AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR_AN_MPQ_50
@@ -24947,8 +25216,8 @@ class CombinedJointTaskForcesRed(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -24989,15 +25258,15 @@ class CombinedJointTaskForcesRed(Country):
             APC_Tigr_233036 = vehicles.Unarmed.APC_Tigr_233036
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
@@ -25014,13 +25283,16 @@ class CombinedJointTaskForcesRed(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
@@ -25089,7 +25361,9 @@ class CombinedJointTaskForcesRed(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -25110,7 +25384,6 @@ class CombinedJointTaskForcesRed(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         A_50 = planes.A_50
         An_26B = planes.An_26B
@@ -25173,7 +25446,6 @@ class CombinedJointTaskForcesRed(Country):
         F_14A = planes.F_14A
         S_3B_Tanker = planes.S_3B_Tanker
         S_3B = planes.S_3B
-        A_10C_2 = planes.A_10C_2
         F_14B = planes.F_14B
         Tornado_GR4 = planes.Tornado_GR4
 
@@ -25186,7 +25458,9 @@ class CombinedJointTaskForcesRed(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -25207,7 +25481,6 @@ class CombinedJointTaskForcesRed(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.A_50,
         Plane.An_26B,
@@ -25270,7 +25543,6 @@ class CombinedJointTaskForcesRed(Country):
         Plane.F_14A,
         Plane.S_3B_Tanker,
         Plane.S_3B,
-        Plane.A_10C_2,
         Plane.F_14B,
         Plane.Tornado_GR4,
     ]
@@ -25350,10 +25622,10 @@ class CombinedJointTaskForcesRed(Country):
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LHA_1_Tarawa = ships.LHA_1_Tarawa
         USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
         CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
         CVN_73_George_Washington = ships.CVN_73_George_Washington
-        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -25525,6 +25797,7 @@ class UnitedNationsPeacekeepers(Country):
             Flak_Searchlight_37 = vehicles.AirDefence.Flak_Searchlight_37
             Maschinensatz_33 = vehicles.AirDefence.Maschinensatz_33
             AAA_8_8cm_Flak_41 = vehicles.AirDefence.AAA_8_8cm_Flak_41
+            EWR_FuMG_401_Freya_LZ = vehicles.AirDefence.EWR_FuMG_401_Freya_LZ
             EWR_1L13 = vehicles.AirDefence.EWR_1L13
             SAM_SA_19_Tunguska_2S6 = vehicles.AirDefence.SAM_SA_19_Tunguska_2S6
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
@@ -25556,6 +25829,9 @@ class UnitedNationsPeacekeepers(Country):
             AAA_ZU_23_Closed = vehicles.AirDefence.AAA_ZU_23_Closed
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AA_gun_QF_3_7 = vehicles.AirDefence.AA_gun_QF_3_7
+            AAA_M45_Quadmount = vehicles.AirDefence.AAA_M45_Quadmount
+            AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
             AAA_Vulcan_M163 = vehicles.AirDefence.AAA_Vulcan_M163
             SAM_Hawk_TR_AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR_AN_MPQ_46
             SAM_Hawk_SR_AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR_AN_MPQ_50
@@ -25602,8 +25878,8 @@ class UnitedNationsPeacekeepers(Country):
             Fire_control_bunker = vehicles.Fortification.Fire_control_bunker
 
         class Unarmed:
-            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Blitz_3_6_6700A = vehicles.Unarmed.Blitz_3_6_6700A
+            Kübelwagen_82 = vehicles.Unarmed.Kübelwagen_82
             Sd_Kfz_2 = vehicles.Unarmed.Sd_Kfz_2
             Sd_Kfz_7 = vehicles.Unarmed.Sd_Kfz_7
             Horch_901_typ_40 = vehicles.Unarmed.Horch_901_typ_40
@@ -25644,15 +25920,15 @@ class UnitedNationsPeacekeepers(Country):
             APC_Tigr_233036 = vehicles.Unarmed.APC_Tigr_233036
 
         class Armor:
-            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
-            HT_Pz_Kpfw_VI_Ausf__B__Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II
-            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             MT_Pz_Kpfw_IV_Ausf_H = vehicles.Armor.MT_Pz_Kpfw_IV_Ausf_H
+            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
+            HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
+            MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             TD_Jagdpanther_G1 = vehicles.Armor.TD_Jagdpanther_G1
             TD_Jagdpanzer_IV = vehicles.Armor.TD_Jagdpanzer_IV
             StuG_IV = vehicles.Armor.StuG_IV
-            IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
-            APC_Sd_Kfz_251 = vehicles.Armor.APC_Sd_Kfz_251
+            AC_Sd_Kfz_234_2_Puma = vehicles.Armor.AC_Sd_Kfz_234_2_Puma
             StuG_III_Ausf__G = vehicles.Armor.StuG_III_Ausf__G
             Sd_Kfz_184_Elefant = vehicles.Armor.Sd_Kfz_184_Elefant
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
@@ -25669,13 +25945,16 @@ class UnitedNationsPeacekeepers(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             APC_M2A1 = vehicles.Armor.APC_M2A1
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
-            ST_Centaur_IV = vehicles.Armor.ST_Centaur_IV
+            CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
             TD_M10_GMC = vehicles.Armor.TD_M10_GMC
+            LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
+            Daimler_Armoured_Car = vehicles.Armor.Daimler_Armoured_Car
             M30_Cargo_Carrier = vehicles.Armor.M30_Cargo_Carrier
             LAC_M8_Greyhound = vehicles.Armor.LAC_M8_Greyhound
+            M4_Tractor = vehicles.Armor.M4_Tractor
             APC_M1043_HMMWV_Armament = vehicles.Armor.APC_M1043_HMMWV_Armament
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
@@ -25744,7 +26023,9 @@ class UnitedNationsPeacekeepers(Country):
         P_47D_30 = planes.P_47D_30
         P_47D_30bl1 = planes.P_47D_30bl1
         P_47D_40 = planes.P_47D_40
+        A_20G = planes.A_20G
         A_10A = planes.A_10A
+        A_10C_2 = planes.A_10C_2
         AJS37 = planes.AJS37
         AV8BNA = planes.AV8BNA
         KC130 = planes.KC130
@@ -25765,7 +26046,6 @@ class UnitedNationsPeacekeepers(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
-        A_20G = planes.A_20G
         Ju_88A4 = planes.Ju_88A4
         A_50 = planes.A_50
         An_26B = planes.An_26B
@@ -25828,7 +26108,6 @@ class UnitedNationsPeacekeepers(Country):
         F_14A = planes.F_14A
         S_3B_Tanker = planes.S_3B_Tanker
         S_3B = planes.S_3B
-        A_10C_2 = planes.A_10C_2
         F_14B = planes.F_14B
         Tornado_GR4 = planes.Tornado_GR4
 
@@ -25841,7 +26120,9 @@ class UnitedNationsPeacekeepers(Country):
         Plane.P_47D_30,
         Plane.P_47D_30bl1,
         Plane.P_47D_40,
+        Plane.A_20G,
         Plane.A_10A,
+        Plane.A_10C_2,
         Plane.AJS37,
         Plane.AV8BNA,
         Plane.KC130,
@@ -25862,7 +26143,6 @@ class UnitedNationsPeacekeepers(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Yak_52,
-        Plane.A_20G,
         Plane.Ju_88A4,
         Plane.A_50,
         Plane.An_26B,
@@ -25925,7 +26205,6 @@ class UnitedNationsPeacekeepers(Country):
         Plane.F_14A,
         Plane.S_3B_Tanker,
         Plane.S_3B,
-        Plane.A_10C_2,
         Plane.F_14B,
         Plane.Tornado_GR4,
     ]
@@ -26005,10 +26284,10 @@ class UnitedNationsPeacekeepers(Country):
         CVN_74_John_C__Stennis = ships.CVN_74_John_C__Stennis
         LHA_1_Tarawa = ships.LHA_1_Tarawa
         USS_Arleigh_Burke_IIa = ships.USS_Arleigh_Burke_IIa
+        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         CVN_71_Theodore_Roosevelt = ships.CVN_71_Theodore_Roosevelt
         CVN_72_Abraham_Lincoln = ships.CVN_72_Abraham_Lincoln
         CVN_73_George_Washington = ships.CVN_73_George_Washington
-        CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
 
     class CallsignAWACS:
         Overlord = "Overlord"

--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -1909,6 +1909,7 @@ class UH_1H(HelicopterType):
         "ExhaustScreen": True,
         "GunnersAISkill": 90,
         "EngineResource": 90,
+        "SoloFlight": False,
         "NetCrewControlPriority": 1,
     }
 
@@ -1922,6 +1923,9 @@ class UH_1H(HelicopterType):
 
         class EngineResource:
             id = "EngineResource"
+
+        class SoloFlight:
+            id = "SoloFlight"
 
         class NetCrewControlPriority:
             id = "NetCrewControlPriority"

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -9642,6 +9642,19 @@ class P_47D_30(PlaneType):
         },
     }
 
+    property_defaults = {
+        "WaterTankContents": 1,
+    }
+
+    class Properties:
+
+        class WaterTankContents:
+            id = "WaterTankContents"
+
+            class Values:
+                Empty = 0
+                Water = 1
+
     class Liveries:
 
         class USA(Enum):
@@ -9720,6 +9733,19 @@ class P_47D_30bl1(PlaneType):
         },
     }
 
+    property_defaults = {
+        "WaterTankContents": 1,
+    }
+
+    class Properties:
+
+        class WaterTankContents:
+            id = "WaterTankContents"
+
+            class Values:
+                Empty = 0
+                Water = 1
+
     class Pylon1:
         AN_M30A1 = (1, Weapons.AN_M30A1)
         AN_M57 = (1, Weapons.AN_M57)
@@ -9785,6 +9811,19 @@ class P_47D_40(PlaneType):
         },
     }
 
+    property_defaults = {
+        "WaterTankContents": 1,
+    }
+
+    class Properties:
+
+        class WaterTankContents:
+            id = "WaterTankContents"
+
+            class Values:
+                Empty = 0
+                Water = 1
+
     class Pylon1:
         AN_M30A1 = (1, Weapons.AN_M30A1)
         AN_M57 = (1, Weapons.AN_M57)
@@ -9836,6 +9875,39 @@ class P_47D_40(PlaneType):
 
     tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
+
+
+class A_20G(PlaneType):
+    id = "A-20G"
+    height = 4.83
+    width = 18.69
+    length = 14.63
+    fuel_max = 1500
+    max_speed = 619.2
+
+    property_defaults = {
+    }
+
+    class Liveries:
+
+        class UK(Enum):
+            _107_sqn = "107 sqn"
+
+        class USA(Enum):
+            usaf_645th_bs = "usaf 645th bs"
+            usaf_668th_bs = "usaf 668th bs"
+
+        class Russia(Enum):
+            ussr_1st_gmtap = "ussr 1st gmtap"
+            ussr_27_ape_dd = "ussr 27 ape dd"
+
+    class Pylon1:
+        _4___AN_M64 = (1, Weapons._4___AN_M64)
+
+    pylons = {1}
+
+    tasks = [task.GroundAttack, task.RunwayAttack, task.CAS]
+    task_default = task.CAS
 
 
 class A_10A(PlaneType):
@@ -10780,10 +10852,10 @@ class A_10C_2(PlaneType):
     fuel_max = 5029
     max_speed = 720
     chaff = 240
-    flare = 120
+    flare = 240
     charge_total = 480
     chaff_charge_size = 1
-    flare_charge_size = 2
+    flare_charge_size = 1
     eplrs = True
 
     callnames = {
@@ -10796,17 +10868,7 @@ class A_10C_2(PlaneType):
     }
 
     property_defaults = {
-        "DefaultGunMode": 0,
     }
-
-    class Properties:
-
-        class DefaultGunMode:
-            id = "DefaultGunMode"
-
-            class Values:
-                CCIP_Gun_Reticle = 0
-                CCIP_Gun_Cross = 1
 
     class Pylon1:
         LAU_105___2_AIM_9M_Sidewinder_IR_AAM = (1, Weapons.LAU_105___2_AIM_9M_Sidewinder_IR_AAM)
@@ -13665,18 +13727,20 @@ class AV8BNA(PlaneType):
         GBU_38 = (2, Weapons.GBU_38)
         GBU_32_V_2_B = (2, Weapons.GBU_32_V_2_B)
         GBU_54_V_1_B = (2, Weapons.GBU_54_V_1_B)
-        _3_MK_81_LD = (2, Weapons._3_MK_81_LD)
         _2_MK_82 = (2, Weapons._2_MK_82)
-        _3_MK_82_LD = (2, Weapons._3_MK_82_LD)
         _2_Mk_20_Rockeye_ = (2, Weapons._2_Mk_20_Rockeye_)
         _2_GBU_12 = (2, Weapons._2_GBU_12)
-        _3_GBU_12 = (2, Weapons._3_GBU_12)
         _2_MK_82_AIR = (2, Weapons._2_MK_82_AIR)
-        _3_Mk_82AIR_ = (2, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE = (2, Weapons._2_MK_82_SNAKEYE)
-        _3_MK_82_SNAKEYE = (2, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38 = (2, Weapons._2_GBU_38)
+        _2_GBU_54_V_1_B = (2, Weapons._2_GBU_54_V_1_B)
+        _3_MK_81_LD = (2, Weapons._3_MK_81_LD)
+        _3_MK_82_LD = (2, Weapons._3_MK_82_LD)
+        _3_Mk_82AIR_ = (2, Weapons._3_Mk_82AIR_)
+        _3_MK_82_SNAKEYE = (2, Weapons._3_MK_82_SNAKEYE)
+        _3_GBU_12 = (2, Weapons._3_GBU_12)
         _3_GBU_38 = (2, Weapons._3_GBU_38)
+        _3_GBU_54_V_1_B = (2, Weapons._3_GBU_54_V_1_B)
         BDU_33 = (2, Weapons.BDU_33)
         BRU_42_3_BDU_33 = (2, Weapons.BRU_42_3_BDU_33)
         LAU_117_AGM_65E = (2, Weapons.LAU_117_AGM_65E)
@@ -13716,19 +13780,14 @@ class AV8BNA(PlaneType):
         GBU_54_V_1_B = (3, Weapons.GBU_54_V_1_B)
         _3_MK_81_LD = (3, Weapons._3_MK_81_LD)
         _2_MK_82 = (3, Weapons._2_MK_82)
-        _3_MK_82_LD = (3, Weapons._3_MK_82_LD)
         _2_MK_83 = (3, Weapons._2_MK_83)
-        _3_MK_83 = (3, Weapons._3_MK_83)
         _2_Mk_20_Rockeye_ = (3, Weapons._2_Mk_20_Rockeye_)
-        _3_MK_20_Rockeye = (3, Weapons._3_MK_20_Rockeye)
         _2_GBU_12 = (3, Weapons._2_GBU_12)
-        _3_GBU_12 = (3, Weapons._3_GBU_12)
         _2_GBU_16 = (3, Weapons._2_GBU_16)
         _2_MK_82_AIR = (3, Weapons._2_MK_82_AIR)
-        _3_Mk_82AIR_ = (3, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE = (3, Weapons._2_MK_82_SNAKEYE)
-        _3_MK_82_SNAKEYE = (3, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38 = (3, Weapons._2_GBU_38)
+        _2_GBU_54_V_1_B = (3, Weapons._2_GBU_54_V_1_B)
         BDU_33 = (3, Weapons.BDU_33)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
         LAU_117_AGM_65E = (3, Weapons.LAU_117_AGM_65E)
@@ -13774,19 +13833,14 @@ class AV8BNA(PlaneType):
         GBU_54_V_1_B = (6, Weapons.GBU_54_V_1_B)
         _3_MK_81_LD = (6, Weapons._3_MK_81_LD)
         _2_MK_82_ = (6, Weapons._2_MK_82_)
-        _3_MK_82_LD = (6, Weapons._3_MK_82_LD)
         _2_MK_83_ = (6, Weapons._2_MK_83_)
-        _3_MK_83 = (6, Weapons._3_MK_83)
         _2_Mk_20_Rockeye__ = (6, Weapons._2_Mk_20_Rockeye__)
-        _3_MK_20_Rockeye = (6, Weapons._3_MK_20_Rockeye)
         _2_GBU_12_ = (6, Weapons._2_GBU_12_)
-        _3_GBU_12 = (6, Weapons._3_GBU_12)
         _2_GBU_16_ = (6, Weapons._2_GBU_16_)
         _2_MK_82_AIR_ = (6, Weapons._2_MK_82_AIR_)
-        _3_Mk_82AIR_ = (6, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE_ = (6, Weapons._2_MK_82_SNAKEYE_)
-        _3_MK_82_SNAKEYE = (6, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38_ = (6, Weapons._2_GBU_38_)
+        _2_GBU_54_V_1_B_ = (6, Weapons._2_GBU_54_V_1_B_)
         BDU_33 = (6, Weapons.BDU_33)
         BRU_42_3_BDU_33 = (6, Weapons.BRU_42_3_BDU_33)
         LAU_117_AGM_65E = (6, Weapons.LAU_117_AGM_65E)
@@ -13825,18 +13879,20 @@ class AV8BNA(PlaneType):
         GBU_38 = (7, Weapons.GBU_38)
         GBU_32_V_2_B = (7, Weapons.GBU_32_V_2_B)
         GBU_54_V_1_B = (7, Weapons.GBU_54_V_1_B)
-        _3_MK_81_LD = (7, Weapons._3_MK_81_LD)
         _2_MK_82_ = (7, Weapons._2_MK_82_)
-        _3_MK_82_LD = (7, Weapons._3_MK_82_LD)
         _2_Mk_20_Rockeye__ = (7, Weapons._2_Mk_20_Rockeye__)
         _2_GBU_12_ = (7, Weapons._2_GBU_12_)
-        _3_GBU_12 = (7, Weapons._3_GBU_12)
         _2_MK_82_AIR_ = (7, Weapons._2_MK_82_AIR_)
-        _3_Mk_82AIR_ = (7, Weapons._3_Mk_82AIR_)
         _2_MK_82_SNAKEYE_ = (7, Weapons._2_MK_82_SNAKEYE_)
-        _3_MK_82_SNAKEYE = (7, Weapons._3_MK_82_SNAKEYE)
         _2_GBU_38_ = (7, Weapons._2_GBU_38_)
+        _2_GBU_54_V_1_B_ = (7, Weapons._2_GBU_54_V_1_B_)
+        _3_MK_81_LD = (7, Weapons._3_MK_81_LD)
+        _3_MK_82_LD = (7, Weapons._3_MK_82_LD)
+        _3_Mk_82AIR_ = (7, Weapons._3_Mk_82AIR_)
+        _3_MK_82_SNAKEYE = (7, Weapons._3_MK_82_SNAKEYE)
+        _3_GBU_12 = (7, Weapons._3_GBU_12)
         _3_GBU_38 = (7, Weapons._3_GBU_38)
+        _3_GBU_54_V_1_B = (7, Weapons._3_GBU_54_V_1_B)
         BDU_33 = (7, Weapons.BDU_33)
         BRU_42_3_BDU_33 = (7, Weapons.BRU_42_3_BDU_33)
         LAU_117_AGM_65E = (7, Weapons.LAU_117_AGM_65E)
@@ -14342,6 +14398,9 @@ class C_101CC(PlaneType):
 
         class Georgia(Enum):
             aviodev_skin = "aviodev skin"
+            georgia_combat_fictional_green = "georgia combat fictional green"
+            georgia_combat_fictional_spots = "georgia combat fictional spots"
+            georgia_combat_fictional_wolf = "georgia combat fictional wolf"
 
         class Venezuela(Enum):
             aviodev_skin = "aviodev skin"
@@ -14916,8 +14975,6 @@ class JF_17(PlaneType):
         "LaserCode10": 8,
         "LaserCode1": 8,
         "AARProbe": False,
-        "FPB_AGL": False,
-        "FPB_Alt": 10,
     }
 
     class Properties:
@@ -14933,12 +14990,6 @@ class JF_17(PlaneType):
 
         class AARProbe:
             id = "AARProbe"
-
-        class FPB_AGL:
-            id = "FPB_AGL"
-
-        class FPB_Alt:
-            id = "FPB_Alt"
 
     class Liveries:
 
@@ -18105,6 +18156,7 @@ class F_16C_50(PlaneType):
         TER_9A___3_x_BDU_33 = (4, Weapons.TER_9A___3_x_BDU_33)
         Fuel_tank_370_gal = (4, Weapons.Fuel_tank_370_gal)
         MXU_648_TP = (4, Weapons.MXU_648_TP)
+        AGM_88C_ = (4, Weapons.AGM_88C_)
 #ERRR <CLEAN>
         TER_9A___2_x_Mk_82 = (4, Weapons.TER_9A___2_x_Mk_82)
         TER_9A___2_x_Mk_82_SnakeEye = (4, Weapons.TER_9A___2_x_Mk_82_SnakeEye)
@@ -18139,6 +18191,7 @@ class F_16C_50(PlaneType):
         TER_9A___3_x_BDU_33 = (6, Weapons.TER_9A___3_x_BDU_33)
         Fuel_tank_370_gal = (6, Weapons.Fuel_tank_370_gal)
         MXU_648_TP = (6, Weapons.MXU_648_TP)
+        AGM_88C_ = (6, Weapons.AGM_88C_)
 #ERRR <CLEAN>
         TER_9A___2_x_Mk_82_ = (6, Weapons.TER_9A___2_x_Mk_82_)
         TER_9A___2_x_Mk_82_SnakeEye_ = (6, Weapons.TER_9A___2_x_Mk_82_SnakeEye_)
@@ -21974,155 +22027,220 @@ class FA_18C_hornet(PlaneType):
     class Liveries:
 
         class USSR(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Georgia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Venezuela(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Australia(Enum):
             australian_75th_squadron = "australian 75th squadron"
             australian_77th_squadron = "australian 77th squadron"
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Israel(Enum):
+            f_18_iriaf = "f-18 iriaf"
             fictional_israel_air_force = "fictional israel air force"
             default_livery = "default livery"
 
+        class Combined_Joint_Task_Forces_Blue(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
         class Sudan(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Norway(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Romania(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Iran(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Ukraine(Enum):
+            f_18_iriaf = "f-18 iriaf"
             fictional_ukraine_air_force = "fictional ukraine air force"
             default_livery = "default livery"
 
         class Libya(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Belgium(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Slovakia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Greece(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class UK(Enum):
+            f_18_iriaf = "f-18 iriaf"
             fictional_uk_air_force = "fictional uk air force"
             default_livery = "default livery"
 
         class Third_Reich(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Hungary(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Abkhazia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Morocco(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
+        class United_Nations_Peacekeepers(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
         class Switzerland(Enum):
+            f_18_iriaf = "f-18 iriaf"
             switzerland = "switzerland"
             default_livery = "default livery"
 
         class SouthOssetia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Vietnam(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class China(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Yemen(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Kuwait(Enum):
             kuwait_25th_squadron = "kuwait 25th squadron"
             kuwait_9th_squadron = "kuwait 9th squadron"
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Serbia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Oman(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class India(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Egypt(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class TheNetherlands(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Poland(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Syria(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Finland(Enum):
+            f_18_iriaf = "f-18 iriaf"
             finland_21 = "finland 21"
             finland_31 = "finland 31"
             default_livery = "default livery"
 
         class Kazakhstan(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Denmark(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Sweden(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Croatia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class CzechRepublic(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
+        class GDR(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
         class Yugoslavia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Bulgaria(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class SouthKorea(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Tunisia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
+        class Combined_Joint_Task_Forces_Red(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
+        class Lebanon(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
+        class Portugal(Enum):
+            f_18_iriaf = "f-18 iriaf"
+
         class Cuba(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Insurgents(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class SaudiArabia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class France(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class USA(Enum):
             vfa_37 = "vfa-37"
+            f_18_iriaf = "f-18 iriaf"
             vfa_106 = "vfa-106"
             vfa_106_high_visibility = "vfa-106 high visibility"
             vfa_113 = "vfa-113"
@@ -22162,68 +22280,89 @@ class FA_18C_hornet(PlaneType):
             blue_angels_jet_team = "blue angels jet team"
 
         class Honduras(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Qatar(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Russia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             fictional_russia_air_force = "fictional russia air force"
             default_livery = "default livery"
 
         class United_Arab_Emirates(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Italian_Social_Republi(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Austria(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Bahrain(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Italy(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Chile(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Turkey(Enum):
             fictional_turkey_162nd_sq = "fictional turkey 162nd sq"
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Philippines(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Algeria(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Pakistan(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Malaysia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Indonesia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Iraq(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Germany(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class South_Africa(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Jordan(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Mexico(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class USAFAggressors(Enum):
+            f_18_iriaf = "f-18 iriaf"
             fictional_russia_air_force = "fictional russia air force"
             vfc_12 = "vfc-12"
             nawdc_blue = "nawdc blue"
@@ -22234,9 +22373,11 @@ class FA_18C_hornet(PlaneType):
             default_livery = "default livery"
 
         class Brazil(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Spain(Enum):
+            f_18_iriaf = "f-18 iriaf"
             spain_462th_escuadron_c_15_79 = "spain 462th escuadron c.15-79"
             spain_111th_escuadron_c_15_73 = "spain 111th escuadron c.15-73"
             spain_111th_escuadron_c_15_88 = "spain 111th escuadron c.15-88"
@@ -22255,6 +22396,7 @@ class FA_18C_hornet(PlaneType):
             default_livery = "default livery"
 
         class Belarus(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Canada(Enum):
@@ -22262,18 +22404,23 @@ class FA_18C_hornet(PlaneType):
             canada_409th_squadron = "canada 409th squadron"
             canada_425th_squadron = "canada 425th squadron"
             canada_norad_60_demo_jet = "canada norad 60 demo jet"
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class NorthKorea(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Ethiopia(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Japan(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
         class Thailand(Enum):
+            f_18_iriaf = "f-18 iriaf"
             default_livery = "default livery"
 
     class Pylon1:
@@ -28563,39 +28710,6 @@ class B_17G(PlaneType):
     task_default = task.GroundAttack
 
 
-class A_20G(PlaneType):
-    id = "A-20G"
-    height = 4.83
-    width = 18.69
-    length = 14.63
-    fuel_max = 1500
-    max_speed = 619.2
-
-    property_defaults = {
-    }
-
-    class Liveries:
-
-        class UK(Enum):
-            _107_sqn = "107 sqn"
-
-        class USA(Enum):
-            usaf_645th_bs = "usaf 645th bs"
-            usaf_668th_bs = "usaf 668th bs"
-
-        class Russia(Enum):
-            ussr_1st_gmtap = "ussr 1st gmtap"
-            ussr_27_ape_dd = "ussr 27 ape dd"
-
-    class Pylon1:
-        _4___AN_M64 = (1, Weapons._4___AN_M64)
-
-    pylons = {1}
-
-    tasks = [task.GroundAttack, task.RunwayAttack, task.CAS]
-    task_default = task.CAS
-
-
 class Ju_88A4(PlaneType):
     id = "Ju-88A4"
     height = 5.07
@@ -28960,6 +29074,7 @@ plane_map = {
     "P-47D-30": P_47D_30,
     "P-47D-30bl1": P_47D_30bl1,
     "P-47D-40": P_47D_40,
+    "A-20G": A_20G,
     "A-10A": A_10A,
     "A-10C": A_10C,
     "A-10C_2": A_10C_2,
@@ -28992,7 +29107,6 @@ plane_map = {
     "Su-34": Su_34,
     "Yak-52": Yak_52,
     "B-17G": B_17G,
-    "A-20G": A_20G,
     "Ju-88A4": Ju_88A4,
     "TF-51D": TF_51D,
 }

--- a/dcs/ships.py
+++ b/dcs/ships.py
@@ -320,7 +320,7 @@ class LCVP__Higgins_boat(unittype.ShipType):
 class Uboat_VIIC_U_flak(unittype.ShipType):
     id = "Uboat_VIIC"
     name = "Uboat VIIC U-flak"
-    detection_range = 12000
+    detection_range = 10000
     threat_range = 4000
     air_weapon_dist = 4000
 
@@ -328,9 +328,9 @@ class Uboat_VIIC_U_flak(unittype.ShipType):
 class Schnellboot_type_S130(unittype.ShipType):
     id = "Schnellboot_type_S130"
     name = "Schnellboot type S130"
-    detection_range = 12000
-    threat_range = 7000
-    air_weapon_dist = 7000
+    detection_range = 10000
+    threat_range = 4000
+    air_weapon_dist = 4000
 
 ship_map = {
     "speedboat": Armed_speedboat,

--- a/dcs/statics.py
+++ b/dcs/statics.py
@@ -459,13 +459,13 @@ class Fortification:
     class Warning_Board_A(unittype.StaticType):
         id = "warning_board_a"
         name = "Warning Board A"
-        shape_name = None
+        shape_name = "biaoyu"
         rate = 1
 
     class Warning_Board_B(unittype.StaticType):
         id = "warning_board_b"
         name = "Warning Board B"
-        shape_name = None
+        shape_name = "biaoyu-2"
         rate = 1
 
     class Belgian_gate(unittype.StaticType):
@@ -606,6 +606,18 @@ class Fortification:
         shape_name = "Siegfried_Line"
         rate = 20
 
+    class Freya_Shelter_Brick(unittype.StaticType):
+        id = "Freya_Shelter_Brick"
+        name = "Freya Shelter Brick"
+        shape_name = "Freya_Shelter_Brick"
+        rate = 20
+
+    class Freya_Shelter_Concrete(unittype.StaticType):
+        id = "Freya_Shelter_Concrete"
+        name = "Freya Shelter Concrete"
+        shape_name = "Freya_Shelter_Concrete"
+        rate = 20
+
 fortification_map = {
     ".Command Center": Fortification.Command_Center,
     "Hangar A": Fortification.Hangar_A,
@@ -707,6 +719,8 @@ fortification_map = {
     "Log ramps 2": Fortification.Log_ramps_2,
     "Log ramps 3": Fortification.Log_ramps_3,
     "Siegfried Line": Fortification.Siegfried_line,
+    "Freya_Shelter_Brick": Fortification.Freya_Shelter_Brick,
+    "Freya_Shelter_Concrete": Fortification.Freya_Shelter_Concrete,
 }
 
 

--- a/dcs/vehicles.py
+++ b/dcs/vehicles.py
@@ -616,6 +616,13 @@ class AirDefence:
         threat_range = 0
         air_weapon_dist = 0
 
+    class AAA_Bofors_40mm(unittype.VehicleType):
+        id = "bofors40"
+        name = "AAA Bofors 40mm"
+        detection_range = 0
+        threat_range = 7160
+        air_weapon_dist = 7160
+
     class Rapier_FSA_Launcher(unittype.VehicleType):
         id = "rapier_fsa_launcher"
         name = "Rapier FSA Launcher"
@@ -637,6 +644,13 @@ class AirDefence:
         threat_range = 0
         air_weapon_dist = 0
 
+    class AAA_8_8cm_Flak_18(unittype.VehicleType):
+        id = "flak18"
+        name = "AAA 8,8cm Flak 18"
+        detection_range = 0
+        threat_range = 15000
+        air_weapon_dist = 15000
+
     class HQ_7_Self_Propelled_LN(unittype.VehicleType):
         id = "HQ-7_LN_SP"
         name = "HQ-7 Self-Propelled LN"
@@ -650,13 +664,6 @@ class AirDefence:
         detection_range = 30000
         threat_range = 0
         air_weapon_dist = 0
-
-    class AAA_8_8cm_Flak_18(unittype.VehicleType):
-        id = "flak18"
-        name = "AAA 8,8cm Flak 18"
-        detection_range = 0
-        threat_range = 15000
-        air_weapon_dist = 15000
 
     class AAA_Flak_38(unittype.VehicleType):
         id = "flak30"
@@ -696,8 +703,8 @@ class AirDefence:
     class Flak_Searchlight_37(unittype.VehicleType):
         id = "Flakscheinwerfer_37"
         name = "Flak Searchlight 37"
-        detection_range = 8000
-        threat_range = 6000
+        detection_range = 15000
+        threat_range = 15000
         air_weapon_dist = 0
 
     class Maschinensatz_33(unittype.VehicleType):
@@ -714,12 +721,33 @@ class AirDefence:
         threat_range = 20000
         air_weapon_dist = 20000
 
-    class AAA_Bofors_40mm(unittype.VehicleType):
-        id = "bofors40"
-        name = "AAA Bofors 40mm"
+    class EWR_FuMG_401_Freya_LZ(unittype.VehicleType):
+        id = "FuMG-401"
+        name = "EWR FuMG-401 Freya LZ"
+        detection_range = 160000
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class AA_gun_QF_3_7(unittype.VehicleType):
+        id = "QF_37_AA"
+        name = "AA gun QF 3,7\""
         detection_range = 0
-        threat_range = 7160
-        air_weapon_dist = 7160
+        threat_range = 9000
+        air_weapon_dist = 9000
+
+    class AAA_M45_Quadmount(unittype.VehicleType):
+        id = "M45_Quadmount"
+        name = "AAA M45 Quadmount"
+        detection_range = 0
+        threat_range = 1500
+        air_weapon_dist = 1500
+
+    class AAA_M1_37mm(unittype.VehicleType):
+        id = "M1_37mm"
+        name = "AAA M1 37mm"
+        detection_range = 0
+        threat_range = 5700
+        air_weapon_dist = 5700
 
 
 class Fortification:
@@ -1015,6 +1043,13 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
+    class Bedford_MWD(unittype.VehicleType):
+        id = "Bedford_MWD"
+        name = "Bedford MWD"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
     class Land_Rover_101_FC(unittype.VehicleType):
         id = "Land_Rover_101_FC"
         name = "Land Rover 101 FC"
@@ -1029,16 +1064,16 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
-    class Kübelwagen_82(unittype.VehicleType):
-        id = "Kubelwagen_82"
-        name = "Kübelwagen 82"
+    class Blitz_3_6_6700A(unittype.VehicleType):
+        id = "Blitz_36-6700A"
+        name = "Blitz 3.6-6700A"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
 
-    class Blitz_3_6_6700A(unittype.VehicleType):
-        id = "Blitz_36-6700A"
-        name = "Blitz 3.6-6700A"
+    class Kübelwagen_82(unittype.VehicleType):
+        id = "Kubelwagen_82"
+        name = "Kübelwagen 82"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1060,13 +1095,6 @@ class Unarmed:
     class Horch_901_typ_40(unittype.VehicleType):
         id = "Horch_901_typ_40_kfz_21"
         name = "Horch 901 typ 40"
-        detection_range = 0
-        threat_range = 0
-        air_weapon_dist = 0
-
-    class Bedford_MWD(unittype.VehicleType):
-        id = "Bedford_MWD"
-        name = "Bedford MWD"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1327,6 +1355,34 @@ class Armor:
         threat_range = 3500
         air_weapon_dist = 1200
 
+    class MT_M4_Sherman(unittype.VehicleType):
+        id = "M4_Sherman"
+        name = "MT M4 Sherman"
+        detection_range = 0
+        threat_range = 3000
+        air_weapon_dist = 0
+
+    class APC_M2A1(unittype.VehicleType):
+        id = "M2A1_halftrack"
+        name = "APC M2A1"
+        detection_range = 0
+        threat_range = 1200
+        air_weapon_dist = 0
+
+    class MT_Pz_Kpfw_IV_Ausf_H(unittype.VehicleType):
+        id = "Pz_IV_H"
+        name = "MT Pz.Kpfw.IV Ausf.H"
+        detection_range = 0
+        threat_range = 3000
+        air_weapon_dist = 0
+
+    class APC_Sd_Kfz_251(unittype.VehicleType):
+        id = "Sd_Kfz_251"
+        name = "APC Sd.Kfz.251"
+        detection_range = 0
+        threat_range = 1100
+        air_weapon_dist = 0
+
     class ZTZ_96B(unittype.VehicleType):
         id = "ZTZ96B"
         name = "ZTZ-96B"
@@ -1350,9 +1406,9 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 0
 
-    class HT_Pz_Kpfw_VI_Ausf__B__Tiger_II(unittype.VehicleType):
+    class HT_Pz_Kpfw_VI_Ausf__B_Tiger_II(unittype.VehicleType):
         id = "Tiger_II_H"
-        name = "HT Pz.Kpfw.VI Ausf. B 'Tiger II'"
+        name = "HT Pz.Kpfw.VI Ausf. B Tiger II"
         detection_range = 0
         threat_range = 6000
         air_weapon_dist = 0
@@ -1360,13 +1416,6 @@ class Armor:
     class MT_Pz_Kpfw_V_Panther_Ausf_G(unittype.VehicleType):
         id = "Pz_V_Panther_G"
         name = "MT Pz.Kpfw.V Panther Ausf.G"
-        detection_range = 0
-        threat_range = 3000
-        air_weapon_dist = 0
-
-    class MT_Pz_Kpfw_IV_Ausf_H(unittype.VehicleType):
-        id = "Pz_IV_H"
-        name = "MT Pz.Kpfw.IV Ausf.H"
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
@@ -1392,18 +1441,11 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 0
 
-    class IFV_Sd_Kfz_234_2_Puma(unittype.VehicleType):
+    class AC_Sd_Kfz_234_2_Puma(unittype.VehicleType):
         id = "Sd_Kfz_234_2_Puma"
-        name = "IFV Sd.Kfz.234/2 Puma"
+        name = "AC Sd.Kfz.234/2 Puma"
         detection_range = 0
         threat_range = 2000
-        air_weapon_dist = 0
-
-    class APC_Sd_Kfz_251(unittype.VehicleType):
-        id = "Sd_Kfz_251"
-        name = "APC Sd.Kfz.251"
-        detection_range = 0
-        threat_range = 1100
         air_weapon_dist = 0
 
     class StuG_III_Ausf__G(unittype.VehicleType):
@@ -1434,9 +1476,9 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 0
 
-    class ST_Centaur_IV(unittype.VehicleType):
+    class CT_Centaur_IV(unittype.VehicleType):
         id = "Centaur_IV"
-        name = "ST Centaur IV"
+        name = "CT Centaur IV"
         detection_range = 0
         threat_range = 6000
         air_weapon_dist = 0
@@ -1448,23 +1490,23 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 0
 
-    class MT_M4_Sherman(unittype.VehicleType):
-        id = "M4_Sherman"
-        name = "MT M4 Sherman"
+    class Daimler_Armoured_Car(unittype.VehicleType):
+        id = "Daimler_AC"
+        name = "Daimler Armoured Car"
         detection_range = 0
-        threat_range = 3000
+        threat_range = 2000
+        air_weapon_dist = 0
+
+    class LT_Mk_VII_Tetrarch(unittype.VehicleType):
+        id = "Tetrarch"
+        name = "LT Mk VII Tetrarch"
+        detection_range = 0
+        threat_range = 2000
         air_weapon_dist = 0
 
     class M30_Cargo_Carrier(unittype.VehicleType):
         id = "M30_CC"
         name = "M30 Cargo Carrier"
-        detection_range = 0
-        threat_range = 1200
-        air_weapon_dist = 0
-
-    class APC_M2A1(unittype.VehicleType):
-        id = "M2A1_halftrack"
-        name = "APC M2A1"
         detection_range = 0
         threat_range = 1200
         air_weapon_dist = 0
@@ -1481,6 +1523,13 @@ class Armor:
         name = "LAC M8 Greyhound"
         detection_range = 0
         threat_range = 2000
+        air_weapon_dist = 0
+
+    class M4_Tractor(unittype.VehicleType):
+        id = "M4_Tractor"
+        name = "M4 Tractor"
+        detection_range = 0
+        threat_range = 1200
         air_weapon_dist = 0
 
 
@@ -1792,8 +1841,12 @@ vehicle_map = {
     "Coach a passenger": Carriage.Coach_for_passengers,
     "Coach a platform": Carriage.Coach_flatbed,
     "Scud_B": MissilesSS.SRBM_SS_1C_Scud_B_9K72_LN_9P117M,
+    "M4_Sherman": Armor.MT_M4_Sherman,
+    "M2A1_halftrack": Armor.APC_M2A1,
     "S_75M_Volhov": AirDefence.SAM_SA_2_LN_SM_90,
     "SNR_75V": AirDefence.SAM_SA_2_TR_SNR_75_Fan_Song,
+    "Bedford_MWD": Unarmed.Bedford_MWD,
+    "bofors40": AirDefence.AAA_Bofors_40mm,
     "rapier_fsa_launcher": AirDefence.Rapier_FSA_Launcher,
     "rapier_fsa_optical_tracker_unit": AirDefence.Rapier_FSA_Optical_Tracker,
     "rapier_fsa_blindfire_radar": AirDefence.Rapier_FSA_Blindfire_Tracker,
@@ -1805,26 +1858,26 @@ vehicle_map = {
     "Boxcartrinity": Carriage.Boxcartrinity,
     "Tankcartrinity": Carriage.Tankcartrinity,
     "Wellcarnsc": Carriage.Wellcarnsc,
+    "Pz_IV_H": Armor.MT_Pz_Kpfw_IV_Ausf_H,
+    "Sd_Kfz_251": Armor.APC_Sd_Kfz_251,
+    "flak18": AirDefence.AAA_8_8cm_Flak_18,
+    "Blitz_36-6700A": Unarmed.Blitz_3_6_6700A,
     "ZTZ96B": Armor.ZTZ_96B,
     "ZBD04A": Armor.ZBD_04A,
     "HQ-7_LN_SP": AirDefence.HQ_7_Self_Propelled_LN,
     "HQ-7_STR_SP": AirDefence.HQ_7_Self_Propelled_STR,
     "Kubelwagen_82": Unarmed.Kübelwagen_82,
-    "Blitz_36-6700A": Unarmed.Blitz_3_6_6700A,
     "Sd_Kfz_2": Unarmed.Sd_Kfz_2,
     "Sd_Kfz_7": Unarmed.Sd_Kfz_7,
     "Horch_901_typ_40_kfz_21": Unarmed.Horch_901_typ_40,
     "Tiger_I": Armor.HT_Pz_Kpfw_VI_Tiger_I,
-    "Tiger_II_H": Armor.HT_Pz_Kpfw_VI_Ausf__B__Tiger_II,
+    "Tiger_II_H": Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II,
     "Pz_V_Panther_G": Armor.MT_Pz_Kpfw_V_Panther_Ausf_G,
-    "Pz_IV_H": Armor.MT_Pz_Kpfw_IV_Ausf_H,
     "Jagdpanther_G1": Armor.TD_Jagdpanther_G1,
     "JagdPz_IV": Armor.TD_Jagdpanzer_IV,
     "Stug_IV": Armor.StuG_IV,
     "SturmPzIV": Artillery.Sturmpanzer_IV_Brummbär,
-    "Sd_Kfz_234_2_Puma": Armor.IFV_Sd_Kfz_234_2_Puma,
-    "Sd_Kfz_251": Armor.APC_Sd_Kfz_251,
-    "flak18": AirDefence.AAA_8_8cm_Flak_18,
+    "Sd_Kfz_234_2_Puma": Armor.AC_Sd_Kfz_234_2_Puma,
     "flak30": AirDefence.AAA_Flak_38,
     "flak36": AirDefence.AAA_8_8cm_Flak_36,
     "flak37": AirDefence.AAA_8_8cm_Flak_37,
@@ -1839,22 +1892,25 @@ vehicle_map = {
     "Elefant_SdKfz_184": Armor.Sd_Kfz_184_Elefant,
     "flak41": AirDefence.AAA_8_8cm_Flak_41,
     "v1_launcher": MissilesSS.V_1_ramp,
-    "Bedford_MWD": Unarmed.Bedford_MWD,
+    "FuMG-401": AirDefence.EWR_FuMG_401_Freya_LZ,
     "Cromwell_IV": Armor.CT_Cromwell_IV,
     "M4A4_Sherman_FF": Armor.MT_M4A4_Sherman_Firefly,
-    "bofors40": AirDefence.AAA_Bofors_40mm,
     "soldier_wwii_br_01": Infantry.Infantry_SMLE_No_4_Mk_1,
-    "Centaur_IV": Armor.ST_Centaur_IV,
+    "Centaur_IV": Armor.CT_Centaur_IV,
     "Churchill_VII": Armor.HIT_Churchill_VII,
+    "Daimler_AC": Armor.Daimler_Armoured_Car,
+    "Tetrarch": Armor.LT_Mk_VII_Tetrarch,
+    "QF_37_AA": AirDefence.AA_gun_QF_3_7,
     "CCKW_353": Unarmed.CCKW_353,
     "Willys_MB": Unarmed.Willys_MB,
-    "M4_Sherman": Armor.MT_M4_Sherman,
     "M12_GMC": Artillery.M12_GMC,
     "M30_CC": Armor.M30_Cargo_Carrier,
-    "M2A1_halftrack": Armor.APC_M2A1,
     "soldier_wwii_us": Infantry.Infantry_M1_Garand,
     "M10_GMC": Armor.TD_M10_GMC,
     "M8_Greyhound": Armor.LAC_M8_Greyhound,
+    "M4_Tractor": Armor.M4_Tractor,
+    "M45_Quadmount": AirDefence.AAA_M45_Quadmount,
+    "M1_37mm": AirDefence.AAA_M1_37mm,
     "DR_50Ton_Flat_Wagon": Carriage.DR_50_ton_flat_wagon,
     "DRG_Class_86": Locomotive.DRG_Class_86,
     "German_covered_wagon_G10": Carriage.German_covered_wagon_G10,

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -829,6 +829,8 @@ class Weapons:
     _2_GBU_16_ = {"clsid": "{BRU-42_2*GBU-16_RIGHT}", "name": "2 GBU-16", "weight": 1050}
     _2_GBU_38 = {"clsid": "{BRU-42_2*GBU-38_LEFT}", "name": "2 GBU-38", "weight": 610}
     _2_GBU_38_ = {"clsid": "{BRU-42_2*GBU-38_RIGHT}", "name": "2 GBU-38", "weight": 610}
+    _2_GBU_54_V_1_B = {"clsid": "{BRU-70A_2*GBU-54_LEFT}", "name": "2 GBU-54(V)1/B", "weight": 566}
+    _2_GBU_54_V_1_B_ = {"clsid": "{BRU-70A_2*GBU-54_RIGHT}", "name": "2 GBU-54(V)1/B", "weight": 566}
     _2_LAU_10___4_ZUNI_MK_71 = {"clsid": "{BRU42_2*LAU10 L}", "name": "2 LAU-10 - 4 ZUNI MK 71", "weight": 1008}
     _2_LAU_10___4_ZUNI_MK_71_ = {"clsid": "{BRU3242_2*LAU10 L}", "name": "2 LAU-10 - 4 ZUNI MK 71", "weight": 1065.38}
     _2_LAU_10___4_ZUNI_MK_71__ = {"clsid": "{BRU42_2*LAU10 R}", "name": "2 LAU-10 - 4 ZUNI MK 71", "weight": 1008}
@@ -916,6 +918,7 @@ class Weapons:
     _3_GBU_16 = {"clsid": "{88D49E04-78DF-4F08-B47E-B81247A9E3C5}", "name": "3 GBU-16", "weight": 666}
     _3_GBU_16_ = {"clsid": "{BRU-42A_3*GBU-16}", "name": "3 GBU-16", "weight": 1545}
     _3_GBU_38 = {"clsid": "{BRU-42_3*GBU-38}", "name": "3 GBU-38", "weight": 885}
+    _3_GBU_54_V_1_B = {"clsid": "{BRU-70A_3*GBU-54}", "name": "3 GBU-54(V)1/B", "weight": 819}
     _3_MK_20_Rockeye = {"clsid": "{BRU-42_3*MK-20}", "name": "3 MK-20 Rockeye", "weight": 726}
     _3_MK_81_LD = {"clsid": "{BRU-42_3*Mk-81LD}", "name": "3 MK-81 LD", "weight": 414}
     _3_MK_82_LD = {"clsid": "{BRU-42_3*Mk-82LD}", "name": "3 MK-82 LD", "weight": 783}
@@ -1784,6 +1787,8 @@ weapon_ids = {
     "{BRU-42_2*GBU-16_RIGHT}": Weapons._2_GBU_16_,
     "{BRU-42_2*GBU-38_LEFT}": Weapons._2_GBU_38,
     "{BRU-42_2*GBU-38_RIGHT}": Weapons._2_GBU_38_,
+    "{BRU-70A_2*GBU-54_LEFT}": Weapons._2_GBU_54_V_1_B,
+    "{BRU-70A_2*GBU-54_RIGHT}": Weapons._2_GBU_54_V_1_B_,
     "{BRU42_2*LAU10 L}": Weapons._2_LAU_10___4_ZUNI_MK_71,
     "{BRU3242_2*LAU10 L}": Weapons._2_LAU_10___4_ZUNI_MK_71_,
     "{BRU42_2*LAU10 R}": Weapons._2_LAU_10___4_ZUNI_MK_71__,
@@ -1871,6 +1876,7 @@ weapon_ids = {
     "{88D49E04-78DF-4F08-B47E-B81247A9E3C5}": Weapons._3_GBU_16,
     "{BRU-42A_3*GBU-16}": Weapons._3_GBU_16_,
     "{BRU-42_3*GBU-38}": Weapons._3_GBU_38,
+    "{BRU-70A_3*GBU-54}": Weapons._3_GBU_54_V_1_B,
     "{BRU-42_3*MK-20}": Weapons._3_MK_20_Rockeye,
     "{BRU-42_3*Mk-81LD}": Weapons._3_MK_81_LD,
     "{BRU-42_3*Mk-82LD}": Weapons._3_MK_82_LD,

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -660,3 +660,22 @@ class BasicTests(unittest.TestCase):
                 result = content.find('["unknown_test_key"]')
 
         self.assertNotEqual(result, -1)
+
+    def test_mission_with_qf17_aaa(self):
+
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        usa = m.country("USA")
+        caucasus = m.terrain
+        batumi = caucasus.batumi()
+        m.vehicle_group(usa, "qf17", dcs.countries.USA.Vehicle.AirDefence.AA_gun_QF_3_7, position=batumi.random_unit_zone().center())
+
+        m.save('missions/test_mission_qf17.miz')
+
+        m2 = dcs.mission.Mission()
+        self.assertTrue(m2.load_file('missions/test_mission_qf17.miz'))
+
+        group = m2.country("USA").find_group("qf17")
+        self.assertEqual(group.units[0].type, dcs.vehicles.AirDefence.AA_gun_QF_3_7.id)
+
+

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -23,10 +23,17 @@ local function safe_name(name)
     safeName = string.gsub(safeName, "[-()/., *'+`#%[%]]", "_")
     safeName = string.gsub(safeName, "_*$", "")  -- strip __ from end
     safeName = string.gsub(safeName, "^([0-9])", "_%1")
+    safeName = string.gsub(safeName, '%"', '') -- Remove the " character (Example unit using it : AA gun QF 3,7")
     if safeName == 'None' then
         safeName = 'None_'
     end
     return safeName
+end
+
+local function safe_display_name(name)
+    local safeDisplayName = name
+    safeDisplayName = string.gsub(safeDisplayName, '%"', '\\"')
+    return safeDisplayName
 end
 
 local function has_value (tab, val)
@@ -582,6 +589,7 @@ for i in pairs(unit_categories) do
     for j in pairs(unit_categories[i]) do
         local unit = unit_categories[i][j]
         local safename = safe_name(unit.DisplayName)
+        local safeDisplayName = safe_display_name(unit.DisplayName)
         local threat_range = 'None'
         if unit.ThreatRange ~= nil then
             threat_range = unit.ThreatRange
@@ -593,7 +601,7 @@ for i in pairs(unit_categories) do
         writeln(file, '')
         writeln(file, '    class '..safename..'(unittype.VehicleType):')
         writeln(file, '        id = "'..unit.type..'"')
-        writeln(file, '        name = "'..unit.DisplayName..'"')
+        writeln(file, '        name = "'..safeDisplayName..'"')
         writeln(file, '        detection_range = '..unit.DetectionRange)
         writeln(file, '        threat_range = '..threat_range)
         writeln(file, '        air_weapon_dist = '..air_weapon_dist)
@@ -654,10 +662,11 @@ writeln(file, 'class Fortification:')
 for i in pairs(db.Units.Fortifications.Fortification) do
     local unit = db.Units.Fortifications.Fortification[i]
     local safename = safe_name(unit.DisplayName)
+    local safeDisplayName = safe_display_name(unit.DisplayName)
     writeln(file, '')
     writeln(file, '    class '..safename..'(unittype.StaticType):')
     writeln(file, '        id = "'..unit.type..'"')
-    writeln(file, '        name = "'..unit.DisplayName..'"')
+    writeln(file, '        name = "'..safeDisplayName..'"')
     if unit.ShapeName ~= nil then
         writeln(file, '        shape_name = "'..unit.ShapeName..'"')
     else
@@ -677,10 +686,11 @@ writeln(file, 'class GroundObject:')
 for i in pairs(db.Units.GroundObjects.GroundObject) do
     local unit = db.Units.GroundObjects.GroundObject[i]
     local safename = safe_name(unit.DisplayName)
+    local safeDisplayName = safe_display_name(unit.DisplayName)
     writeln(file, '')
     writeln(file, '    class '..safename..'(unittype.StaticType):')
     writeln(file, '        id = "'..unit.type..'"')
-    writeln(file, '        name = "'..unit.DisplayName..'"')
+    writeln(file, '        name = "'..safeDisplayName..'"')
     writeln(file, '        category = ""')
 end
 
@@ -692,10 +702,11 @@ writeln(file, 'class Warehouse:')
 for i in pairs(db.Units.Warehouses.Warehouse) do
     local unit = db.Units.Warehouses.Warehouse[i]
     local safename = safe_name(unit.DisplayName)
+    local safeDisplayName = safe_display_name(unit.DisplayName)
     writeln(file, '')
     writeln(file, '    class '..safename..'(unittype.StaticType):')
     writeln(file, '        id = "'..unit.type..'"')
-    writeln(file, '        name = "'..unit.DisplayName..'"')
+    writeln(file, '        name = "'..safeDisplayName..'"')
     writeln(file, '        shape_name = "'..unit.ShapeName..'"')
     writeln(file, '        category = "Warehouses"')
     writeln(file, '        rate = '..unit.Rate)
@@ -712,10 +723,11 @@ writeln(file, 'class Cargo:')
 for i in pairs(db.Units.Cargos.Cargo) do
     local unit = db.Units.Cargos.Cargo[i]
     local safename = safe_name(unit.DisplayName)
+    local safeDisplayName = safe_display_name(unit.DisplayName)
     writeln(file, '')
     writeln(file, '    class '..safename..'(unittype.StaticType):')
     writeln(file, '        id = "'..unit.type..'"')
-    writeln(file, '        name = "'..unit.DisplayName..'"')
+    writeln(file, '        name = "'..safeDisplayName..'"')
     writeln(file, '        shape_name = "'..unit.ShapeName..'"')
     writeln(file, '        category = "Cargos"')
     writeln(file, '        rate = '..unit.Rate)
@@ -741,11 +753,12 @@ import dcs.unittype as unittype
 for i in pairs(db.Units.Ships.Ship) do
     local unit = db.Units.Ships.Ship[i]
     local safename = safe_name(unit.DisplayName)
+    local safeDisplayName = safe_display_name(unit.DisplayName)
     writeln(file, '')
     writeln(file, '')
     writeln(file, 'class '..safename..'(unittype.ShipType):')
     writeln(file, '    id = "'..unit.type..'"')
-    writeln(file, '    name = "'..unit.DisplayName..'"')
+    writeln(file, '    name = "'..safeDisplayName..'"')
     if unit.Plane_Num_ ~= nil then
         writeln(file, '    plane_num = '..unit.Plane_Num_)
     end
@@ -853,6 +866,7 @@ while i <= country.maxIndex do
                 for j in pairs(unit_categories[i]) do
                     local unit = unit_categories[i][j]
                     local safename = safe_name(unit.DisplayName)
+                    local safeDisplayName = safe_display_name(unit.DisplayName)
                     writeln(file, '            '..safename..' = vehicles.'..i..'.'..safename)
                 end
             end


### PR DESCRIPTION
Data export for DCS version 2.5.6.57264

It mainly adds a few new units that were added in the WW2 asset pack : 
* M1 37mm AAA
* M45 quadmount AAA
* QF 3.7-inch AAA
* Daimler Armoured Car
* M4 High-Speed Tractor
* Light Tank Mk VII Tetrarch
* FuMG 401 Freya LZ radar

I had to modify the pydcs export script, because of the display name of the QF_17 gun containing the '"' character.
