### PR TITLE
Fix : SpitfireLFMkIXCW not interpreted as flyable

### DIFF
--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -8979,6 +8979,7 @@ class SpitfireLFMkIX(PlaneType):
 
 class SpitfireLFMkIXCW(PlaneType):
     id = "SpitfireLFMkIXCW"
+    flyable = True
     height = 4.77
     width = 11.25
     length = 12.13

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -266,6 +266,7 @@ flyable["Ka-50"] = true
 flyable["Mi-8MT"] = true
 flyable["UH-1H"] = true
 flyable["SpitfireLFMkIX"] = true
+flyable["SpitfireLFMkIXCW"] = true
 flyable["SA342L"] = true
 flyable["SA342M"] = true
 flyable["SA342Minigun"] = true


### PR DESCRIPTION
Here is a small fix : The SpitfireLFMkIXCW module was not seen as a flyable module.