### PR TITLE
Fix waypoint order when loading from miz

### DIFF
--- a/dcs/coalition.py
+++ b/dcs/coalition.py
@@ -22,8 +22,19 @@ class Coalition:
         self.nav_points = []  # TODO
 
     @staticmethod
+    def _sort_keys(points):
+        keys = []
+        for imp_point_idx in points:
+            keys.append(int(imp_point_idx))
+
+        keys.sort()
+        return keys
+
+    @staticmethod
     def _import_moving_point(mission, group: unitgroup.Group, imp_group) -> unitgroup.Group:
-        for imp_point_idx in imp_group["route"]["points"]:
+        keys = Coalition._sort_keys(imp_group["route"]["points"])
+
+        for imp_point_idx in keys:
             imp_point = imp_group["route"]["points"][imp_point_idx]
             point = MovingPoint()
             point.load_from_dict(imp_point, mission.translation)
@@ -32,7 +43,9 @@ class Coalition:
 
     @staticmethod
     def _import_static_point(mission, group: unitgroup.Group, imp_group) -> unitgroup.Group:
-        for imp_point_idx in imp_group["route"]["points"]:
+        keys = Coalition._sort_keys(imp_group["route"]["points"])
+
+        for imp_point_idx in keys:
             imp_point = imp_group["route"]["points"][imp_point_idx]
             point = StaticPoint()
             point.load_from_dict(imp_point, mission.translation)


### PR DESCRIPTION
In lua points are stored as a dict not an array and the order can get messed up(which is not a problem as it is keyed). I suspect it is using string sorting so if there are more then 10 WPs the order gets messed up when the mission is loaded back([1, 10, 11, 12, 2, ...]). This change fixes the issue.