### PR TITLE
onboard/tail numbers auto assign

### DIFF
--- a/dcs/coalition.py
+++ b/dcs/coalition.py
@@ -147,8 +147,10 @@ class Coalition:
                         plane.load_from_dict(imp_unit)
 
                         if _country.reserve_onboard_num(plane.onboard_num):
-                            print("WARN:", "{c} Plane '{p}' already using tail number: {t}".format(
-                                c=self.name.upper(), p=plane.name, t=plane.onboard_num), file=sys.stderr)
+                            msg = "{c} Plane '{p}' already using tail number: {t}".format(
+                                c=self.name.upper(), p=plane.name, t=plane.onboard_num)
+                            status.append(StatusMessage(msg, MessageType.WARN))
+                            print("WARN:", msg, file=sys.stderr)
                         self._park_unit_on_airport(mission, plane_group, plane)
 
                         mission.current_unit_id = max(mission.current_unit_id, plane.id)
@@ -183,8 +185,10 @@ class Coalition:
                         heli.load_from_dict(imp_unit)
 
                         if _country.reserve_onboard_num(heli.onboard_num):
-                            print("WARN:", "{c} Helicopter '{h}' already using tail number: {t}".format(
-                                c=self.name.upper(), h=heli.name, t=heli.onboard_num), file=sys.stderr)
+                            msg = "{c} Helicopter '{h}' already using tail number: {t}".format(
+                                c=self.name.upper(), h=heli.name, t=heli.onboard_num)
+                            status.append(StatusMessage(msg, MessageType.WARN))
+                            print("WARN:", msg, file=sys.stderr)
                         self._park_unit_on_airport(mission, helicopter_group, heli)
 
                         mission.current_unit_id = max(mission.current_unit_id, heli.id)

--- a/dcs/coalition.py
+++ b/dcs/coalition.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, Union, TYPE_CHECKING
+from typing import Dict, Union, List, TYPE_CHECKING
 import dcs.countries as countries
 import dcs.unitgroup as unitgroup
 import dcs.planes as planes
@@ -9,6 +9,7 @@ from dcs.unit import Vehicle, Static, Ship, FARP, SingleHeliPad
 from dcs.flyingunit import Plane, Helicopter
 from dcs.point import MovingPoint, StaticPoint
 from dcs.country import Country
+from dcs.status_message import StatusMessage, MessageType
 
 if TYPE_CHECKING:
     from . import Mission
@@ -72,7 +73,8 @@ class Coalition:
                           .format(u=unit.name, a=airport.name, p=group.name),
                           file=sys.stderr)
 
-    def load_from_dict(self, mission, d):
+    def load_from_dict(self, mission, d) -> List[StatusMessage]:
+        status: List[StatusMessage] = []
         for country_idx in d["country"]:
             imp_country = d["country"][country_idx]
             _country = countries.get_by_id(imp_country["id"])
@@ -226,6 +228,7 @@ class Coalition:
                         static_group.add_unit(static)
                     _country.add_static_group(static_group)
             self.add_country(_country)
+        return status
 
     def set_bullseye(self, bulls):
         self.bullseye = bulls

--- a/dcs/coalition.py
+++ b/dcs/coalition.py
@@ -144,6 +144,9 @@ class Coalition:
                             _country=_country)
                         plane.load_from_dict(imp_unit)
 
+                        if _country.reserve_onboard_num(plane.onboard_num):
+                            print("WARN:", "{c} Plane '{p}' already using tail number: {t}".format(
+                                c=self.name.upper(), p=plane.name, t=plane.onboard_num), file=sys.stderr)
                         self._park_unit_on_airport(mission, plane_group, plane)
 
                         mission.current_unit_id = max(mission.current_unit_id, plane.id)
@@ -177,6 +180,9 @@ class Coalition:
                             _country=_country)
                         heli.load_from_dict(imp_unit)
 
+                        if _country.reserve_onboard_num(heli.onboard_num):
+                            print("WARN:", "{c} Helicopter '{h}' already using tail number: {t}".format(
+                                c=self.name.upper(), h=heli.name, t=heli.onboard_num), file=sys.stderr)
                         self._park_unit_on_airport(mission, helicopter_group, heli)
 
                         mission.current_unit_id = max(mission.current_unit_id, heli.id)

--- a/dcs/coalition.py
+++ b/dcs/coalition.py
@@ -149,9 +149,9 @@ class Coalition:
                         if _country.reserve_onboard_num(plane.onboard_num):
                             msg = "{c} Plane '{p}' already using tail number: {t}".format(
                                 c=self.name.upper(), p=plane.name, t=plane.onboard_num)
-                            status.append(StatusMessage(msg, MessageType.WARN))
+                            status.append(StatusMessage(msg, MessageType.ONBOARD_NUM_DUPLICATE, MessageSeverity.WARN))
                             print("WARN:", msg, file=sys.stderr)
-                        self._park_unit_on_airport(mission, plane_group, plane)
+                        status += self._park_unit_on_airport(mission, plane_group, plane)
 
                         mission.current_unit_id = max(mission.current_unit_id, plane.id)
                         plane_group.add_unit(plane)
@@ -187,9 +187,9 @@ class Coalition:
                         if _country.reserve_onboard_num(heli.onboard_num):
                             msg = "{c} Helicopter '{h}' already using tail number: {t}".format(
                                 c=self.name.upper(), h=heli.name, t=heli.onboard_num)
-                            status.append(StatusMessage(msg, MessageType.WARN))
+                            status.append(StatusMessage(msg, MessageType.ONBOARD_NUM_DUPLICATE, MessageSeverity.WARN))
                             print("WARN:", msg, file=sys.stderr)
-                        self._park_unit_on_airport(mission, helicopter_group, heli)
+                        status += self._park_unit_on_airport(mission, helicopter_group, heli)
 
                         mission.current_unit_id = max(mission.current_unit_id, heli.id)
                         helicopter_group.add_unit(heli)

--- a/dcs/country.py
+++ b/dcs/country.py
@@ -144,6 +144,13 @@ class Country:
     def unused_onboard_numbers(self) -> Set[int]:
         return self._tail_numbers
 
+    def reset_onboard_numbers(self):
+        """
+        Resets/clears reserved onboard numbers for this country.
+        :return:
+        """
+        self._tail_numbers = set()
+
     def reserve_onboard_num(self, number: int) -> bool:
         """
         Reserve the give onboard_num (tail number), if already used return True.

--- a/dcs/country.py
+++ b/dcs/country.py
@@ -1,5 +1,5 @@
 from dcs.unitgroup import VehicleGroup, ShipGroup, PlaneGroup, StaticGroup, HelicopterGroup, FlyingGroup, Group
-from typing import List, Dict
+from typing import List, Dict, Set
 
 
 def find_exact(group_name, find_name):
@@ -31,6 +31,7 @@ class Country:
         self.static_group = []  # type: List[StaticGroup]
         self.current_callsign_id = 99
         self.current_callsign_category = {}  # type: Dict[str,int]
+        self._tail_numbers: Set[int] = set()
 
     def add_vehicle_group(self, vgroup):
         self.vehicle_group.append(vgroup)
@@ -138,6 +139,26 @@ class Country:
         if self.current_callsign_category[category] >= len(self.callsign[category]):
             self.current_callsign_category[category] = 0
         return self.callsign.get(category)[self.current_callsign_category[category]]
+
+    @property
+    def unused_onboard_numbers(self) -> Set[int]:
+        return self._tail_numbers
+
+    def reserve_onboard_num(self, number: int) -> bool:
+        """
+        Reserve the give onboard_num (tail number), if already used return True.
+        :param int number: onboard num
+        :return: True if number is already in use, else False
+        """
+        is_in = number in self._tail_numbers
+        self._tail_numbers.add(number)
+        return is_in
+
+    def next_onboard_num(self) -> int:
+        free_set = {x for x in range(10, 999)} - self._tail_numbers
+        tailnum = free_set.pop()
+        self.reserve_onboard_num(tailnum)
+        return tailnum
 
     def dict(self):
         d = {

--- a/dcs/flyingunit.py
+++ b/dcs/flyingunit.py
@@ -17,7 +17,7 @@ class FlyingUnit(Unit):
         self.parking = None  # crossroad idx
         self.parking_id = None  # parking slot name (01, 02, ..)
         self.psi = 0
-        self.onboard_num = "010"
+        self.onboard_num: int = 9
         self.alt = 0
         self.alt_type = "BARO"
         self.flare = _type.flare
@@ -46,7 +46,7 @@ class FlyingUnit(Unit):
         self.chaff = d["payload"]["chaff"]
         self.ammo_type = d["payload"].get("ammo_type")
         self.pylons = d["payload"]["pylons"]
-        self.onboard_num = d["onboard_num"]
+        self.onboard_num = int(d["onboard_num"])
         if isinstance(d["callsign"], int):
             self.callsign = d["callsign"]
         else:
@@ -190,7 +190,7 @@ class FlyingUnit(Unit):
         if self.livery_id:
             d["livery_id"] = self.livery_id
         d["psi"] = self.psi
-        d["onboard_num"] = self.onboard_num
+        d["onboard_num"] = "{:03}".format(self.onboard_num)
         d["speed"] = round(self.speed, 13)
         if self.hardpoint_racks is not None:
             d["hardpoint_racks"] = self.hardpoint_racks

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -907,6 +907,11 @@ class Mission:
                 u.callsign = _country.next_callsign_id()
             i += 1
 
+    @classmethod
+    def _assign_onboard_num(cls, _country, group: unitgroup.FlyingGroup):
+        for u in group.units:
+            u.onboard_num = _country.next_onboard_num()
+
     @staticmethod
     def _load_tasks(mp: MovingPoint, maintask: task.MainTask):
         for t in maintask.perform_task:
@@ -941,6 +946,7 @@ class Mission:
         group.load_task_default_loadout(maintask)
 
         self._assign_callsign(_country, group)
+        self._assign_onboard_num(_country, group)
 
         point_start_type_map = {
             StartType.Cold: ("TakeOffParking", PointAction.FromParkingArea),
@@ -974,6 +980,7 @@ class Mission:
             i += 1
 
         self._assign_callsign(_country, group)
+        self._assign_onboard_num(_country, group)
 
         group.load_task_default_loadout(maintask)
 
@@ -1123,6 +1130,7 @@ class Mission:
         ag.load_task_default_loadout(maintask)
 
         self._assign_callsign(country, ag)
+        self._assign_onboard_num(country, ag)
 
         point_start_type_map = {
             StartType.Cold: ("TakeOffParking", PointAction.FromParkingArea),

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -1839,7 +1839,8 @@ class Mission:
                 group="Ship",
                 gc=d[low]["ship_groups"]["count"], u=d[low]["ship_groups"]["unit_count"]))
             output[low].append("-" * 28)
-            output[low].append("{group:<15s} {gc:6d} {u:5d}".format(group="Sum", gc=d[low]["count"], u=d[low]["unit_count"]))
+            output[low].append(
+                "{group:<15s} {gc:6d} {u:5d}".format(group="Sum", gc=d[low]["count"], u=d[low]["unit_count"]))
 
         # merge tables
         for i in range(0, len(output["blue"])):

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -40,7 +40,7 @@ from dcs.unit import Unit, Ship, Vehicle, Static
 from dcs.flyingunit import Plane, Helicopter
 from dcs.helicopters import HelicopterType
 from dcs.planes import PlaneType
-from dcs.status_message import StatusMessage
+from dcs.status_message import StatusMessage, MessageType, MessageSeverity
 
 
 class StartType(Enum):
@@ -249,7 +249,9 @@ class Mission:
             mission_dict = loaddict('mission', miz, reserved_files)
 
             if mission_dict["mission"]["version"] < 16:
-                print("Mission file is using an old format, be aware!", file=sys.stderr)
+                msg = "Mission file is using an old format, be aware!"
+                print(msg, file=sys.stderr)
+                status.append(StatusMessage(msg, MessageType.MISSION_FORMAT_OLD, MessageSeverity.WARN))
             options_dict = loaddict('options', miz, reserved_files)
             warehouse_dict = loaddict('warehouses', miz, reserved_files)
             dictionary_dict = loaddict('l10n/DEFAULT/dictionary', miz, reserved_files)

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -1740,6 +1740,20 @@ class Mission:
         """
         return country.name in self.coalition["blue"].countries
 
+    def reassign_onboard_numbers(self):
+        """
+        Resets all onboard numbers of units and reassigns them.
+
+        :return: None
+        """
+        for coalation_name in self.coalition:
+            coaltion = self.coalition[coalation_name]
+            for country_name in coaltion.countries:
+                country = coaltion.country(country_name)
+                country.reset_onboard_numbers()
+                for group in country.plane_group + country.helicopter_group:
+                    self._assign_onboard_num(country, group)
+
     def random_date(self):
         """Sets a random date for the mission"""
         self.start_time = datetime.fromtimestamp(1306886400 + 43200, timezone.utc)  # 01-06-2011 12:00:00 UTC

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -38,6 +38,8 @@ from dcs.point import StaticPoint, MovingPoint, PointAction, PointProperties
 from dcs.translation import Translation, String, ResourceKey
 from dcs.unit import Unit, Ship, Vehicle, Static
 from dcs.flyingunit import Plane, Helicopter
+from dcs.helicopters import HelicopterType
+from dcs.planes import PlaneType
 
 
 class StartType(Enum):
@@ -216,7 +218,7 @@ class Mission:
             'F-86F Sabre AI by Eagle Dynamics': True
         }
 
-        self.aircraft_kneeboards: Dict[unittype.FlyingType, List[Path]] = defaultdict(list)
+        self.aircraft_kneeboards: Dict[Type[unittype.FlyingType], List[Path]] = defaultdict(list)
 
     def load_file(self, filename: str, bypass_triggers: bool = False):
         """Load a mission file (.miz) file, replacing all current data.
@@ -851,7 +853,10 @@ class Mission:
         """
         return Helicopter(self.next_unit_id(), self.string(name), _type, country)
 
-    def aircraft(self, name, _type: Type[unittype.FlyingType], country: Country) -> Union[Plane, Helicopter]:
+    def aircraft(self,
+                 name,
+                 _type: Type[Union[unittype.FlyingType, HelicopterType, PlaneType]],
+                 country: Country) -> Union[Plane, Helicopter]:
         """Creates a new plane or helicopter unit, depending on the _type.
 
         This method is a advanced interface method not intended for simple usage.
@@ -1654,7 +1659,7 @@ class Mission:
 
         return sf
 
-    def add_aircraft_kneeboard(self, aircraft: unittype.FlyingType, page: Path):
+    def add_aircraft_kneeboard(self, aircraft: Type[unittype.FlyingType], page: Path):
         """Adds an aircraft specific kneeboard page to the mission.
 
         Note that DCS does not support flight-specific kneeboards, so the

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -40,6 +40,7 @@ from dcs.unit import Unit, Ship, Vehicle, Static
 from dcs.flyingunit import Plane, Helicopter
 from dcs.helicopters import HelicopterType
 from dcs.planes import PlaneType
+from dcs.status_message import StatusMessage
 
 
 class StartType(Enum):
@@ -220,27 +221,21 @@ class Mission:
 
         self.aircraft_kneeboards: Dict[Type[unittype.FlyingType], List[Path]] = defaultdict(list)
 
-    def load_file(self, filename: str, bypass_triggers: bool = False):
-        """Load a mission file (.miz) file, replacing all current data.
+    def load_file(self, filename: str, bypass_triggers: bool = False) -> List[StatusMessage]:
+        """
+        Load a mission file (.miz) file, replacing all current data.
 
-        Args:
-            filename: path to the mission(.miz) file.
-            bypass_triggers: do not parse triggers, if a mission is loaded this way
-                             the same triggers will be exported on save.
-        Returns:
-            bool: True if everything loaded correctly
-
-        Raises:
-            RuntimeError: if an unknown value is encountered
+        :param filename: path to the mission(.miz) file.
+        :param bypass_triggers: do not parse triggers, if a mission is loaded this way
+            the same triggers will be exported on save.
+        :return: List of LoadStatus objects, might be empty if everything was fine
+        :raises RuntimeError: if an unknown value is encountered
         """
         self.filename = filename
         self.current_unit_id = 0
         self.current_group_id = 0
         self.current_dict_id = 0
-        mission_dict = {}
-        options_dict = {}
-        warehouse_dict = {}
-        dictionary_dict = {}
+        status = []
 
         def loaddict(fname, mizfile, reserved_files):
             reserved_files.append(fname)
@@ -374,9 +369,9 @@ class Mission:
         for col_name in ["blue", "red", "neutrals"]:
             if col_name in imp_mission["coalition"]:
                 self.coalition[col_name] = Coalition(col_name, imp_mission["coalition"][col_name]["bullseye"])
-                self.coalition[col_name].load_from_dict(self, imp_mission["coalition"][col_name])
+                status += self.coalition[col_name].load_from_dict(self, imp_mission["coalition"][col_name])
 
-        return True
+        return status
 
     def sortie_text(self) -> str:
         """Returns the mission sortie text.

--- a/dcs/status_message.py
+++ b/dcs/status_message.py
@@ -9,6 +9,9 @@ class MessageSeverity(IntEnum):
 
 class MessageType(IntEnum):
     ONBOARD_NUM_DUPLICATE = 0
+    PARKING_SLOT_NOT_VALID = 1
+    PARKING_SLOTS_FULL = 3
+    MISSION_FORMAT_OLD = 4
 
 
 class StatusMessage:

--- a/dcs/status_message.py
+++ b/dcs/status_message.py
@@ -1,0 +1,30 @@
+from enum import IntEnum
+
+
+class MessageSeverity(IntEnum):
+    INFO = 0
+    WARN = 1
+    ERROR = 2
+
+
+class MessageType(IntEnum):
+    ONBOARD_NUM_DUPLICATE = 0
+
+
+class StatusMessage:
+    def __init__(self, message: str, type_: MessageType, severity: MessageSeverity = MessageSeverity.ERROR):
+        self._message = message
+        self._type = type_
+        self._severity = severity
+
+    @property
+    def type(self) -> MessageType:
+        return self._type
+
+    @property
+    def severity(self) -> MessageSeverity:
+        return self._severity
+
+    @property
+    def message(self) -> str:
+        return self._message

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -4,7 +4,7 @@ import copy
 from enum import Enum
 from typing import List, Union, Optional
 
-from dcs.unit import Unit, Skill
+from dcs.unit import Unit, Skill, Ship, Vehicle, Static
 from dcs.flyingunit import FlyingUnit, Plane, Helicopter
 from dcs.unittype import FlyingType
 from dcs.planes import PlaneType
@@ -37,7 +37,7 @@ class Group:
         self.hidden = False
         self.hidden_on_planner = False
         self.hidden_on_mfd = False
-        self.units = []  # type: List[Unit]
+        self.units: List[Union[Unit, Ship, Plane, Helicopter, Vehicle, Static]] = []
         self.points = []  # type: List[Union[StaticPoint, MovingPoint]]
         self.name = name if name else String()
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -67,7 +67,7 @@ class BasicTests(unittest.TestCase):
         self.assertIsNotNone(usa)
 
         house = m.static_group(usa, "house", dcs.statics.Fortification.Small_house_1A,
-                       batumi.unit_zones[0].random_point(), 230)
+                               batumi.unit_zones[0].random_point(), 230)
         self.assertEqual(str(house.name), "house")
 
         pg = m.flight_group_from_airport(usa, "Airgroup", dcs.planes.A_10C, kobuleti,
@@ -136,13 +136,13 @@ class BasicTests(unittest.TestCase):
         p = last_wp.position.point_from_heading(heading, distance - 1000)
         last_wp = su25.add_waypoint(p, 3000)
         last_wp.tasks.append(dcs.task.CAS.EnrouteTasks.EngageGroup(ustanks.id))
-        last_wp = su25.add_waypoint(dcs.mapping.Point(last_wp.position.x + 1000 * 10, last_wp.position.y), 3000)
+        su25.add_waypoint(dcs.mapping.Point(last_wp.position.x + 1000 * 10, last_wp.position.y), 3000)
         su25.add_runway_waypoint(sukhumi)
         su25.land_at(sukhumi)
 
         sg = m.ship_group(russia, "TaskForce", dcs.ships.CG_1164_Moskva,
                           dcs.mapping.Point(-209571.42857143, 500728.57142858), 0)
-        wp = sg.add_waypoint(dcs.mapping.Point(sg.x - 1000 * 60, sg.y + 1000 * 10))
+        sg.add_waypoint(dcs.mapping.Point(sg.x - 1000 * 60, sg.y + 1000 * 10))
 
         seapoint = batumi.unit_zones[0].random_point()
         seapoint.y -= 10 * 1000
@@ -175,7 +175,6 @@ class BasicTests(unittest.TestCase):
         m.save('missions/basic_mission.miz')
 
     def test_nav_target_points(self):
-
         m = dcs.Mission()
         batumi = m.terrain.batumi()
         batumi.set_blue()
@@ -220,9 +219,7 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(jeff_miz.nav_target_points[0].position.y, pp1_pos.y)
         self.assertEqual(jeff_miz.nav_target_points[0].index, 1)
 
-
     def test_create_mission_with_marks(self):
-
         m = dcs.Mission()
         batumi = m.terrain.batumi()
         batumi.set_blue()
@@ -232,13 +229,16 @@ class BasicTests(unittest.TestCase):
         rus = m.country("Russia")
 
         # Create some group to use if you want to check visibility of marks in game
-        su25_group = m.flight_group_from_airport(usa, "SU25", dcs.planes.Su_25T, group_size=1, airport=m.terrain.batumi())
+        su25_group = m.flight_group_from_airport(usa, "SU25", dcs.planes.Su_25T,
+                                                 group_size=1, airport=m.terrain.batumi())
         su25_group.set_client()
 
-        f15_group = m.flight_group_from_airport(usa, "F15C", dcs.planes.F_15C, group_size=1, airport=m.terrain.batumi())
+        f15_group = m.flight_group_from_airport(usa, "F15C", dcs.planes.F_15C,
+                                                group_size=1, airport=m.terrain.batumi())
         f15_group.set_client()
 
-        su25_red_group = m.flight_group_from_airport(rus, "SU25 RED", dcs.planes.Su_25T, group_size=1, airport=m.terrain.kutaisi())
+        su25_red_group = m.flight_group_from_airport(rus, "SU25 RED", dcs.planes.Su_25T,
+                                                     group_size=1, airport=m.terrain.kutaisi())
         su25_red_group.set_client()
 
         # In DCS, you have to create a trigger zone to add a mark.
@@ -309,7 +309,6 @@ class BasicTests(unittest.TestCase):
         m.save("missions/mission_with_marks_triggers.miz")
 
     def test_create_mission_on_channel_map(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.TheChannel())
 
         usa = m.country("USA")
@@ -329,16 +328,15 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.terrain.__class__, dcs.terrain.TheChannel)
 
     def test_create_mission_on_syria_map(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Syria())
 
         usa = m.country("USA")
         russia = m.country("Russia")
         fa18 = m.flight_group_from_airport(usa, "F/A-18C", dcs.planes.FA_18C_hornet, group_size=1,
-                                            airport=m.terrain.damascus())
+                                           airport=m.terrain.damascus())
         fa18.add_waypoint(m.terrain.damascus().position.point_from_heading(-90, 40000), 500, 300)
         su22 = m.flight_group_from_airport(russia, "Su22", dcs.planes.Su_17M4, group_size=1,
-                                          airport=m.terrain.damascus())
+                                           airport=m.terrain.damascus())
         su22.add_waypoint(m.terrain.damascus().position.point_from_heading(-90, 40000), 500, 300)
 
         m.save('missions/test_mission_syria.miz')
@@ -349,21 +347,23 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Syria)
 
     def test_create_mission_with_part_of_coalition_zone_trigger(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
 
-        trigger_zone = m.triggers.add_triggerzone(m.terrain.batumi().position.point_from_heading(90, 15000), radius=5000, hidden=False, name="TRIGGER_ZONE")
+        trigger_zone = m.triggers.add_triggerzone(m.terrain.batumi().position.point_from_heading(90, 15000),
+                                                  radius=5000, hidden=False, name="TRIGGER_ZONE")
         trigger = dcs.triggers.TriggerOnce(dcs.triggers.Event.NoEvent, "Detection of blue aircraft")
         trigger.add_condition(dcs.condition.PartOfCoalitionInZone("blue", trigger_zone.id, "AIRPLANE"))
         trigger.add_action(dcs.action.MessageToAll(text=String("Blue aircraft detected in trigger zone !")))
         m.triggerrules.triggers.append(trigger)
 
-        trigger_zone_2 = m.triggers.add_triggerzone(m.terrain.batumi().position, radius=5000, hidden=False, name="BATUMI_ZONE")
+        trigger_zone_2 = m.triggers.add_triggerzone(m.terrain.batumi().position, radius=5000, hidden=False,
+                                                    name="BATUMI_ZONE")
         trigger_outside = dcs.triggers.TriggerOnce(dcs.triggers.Event.NoEvent, "No blue in batumi zone")
         trigger_outside.add_condition(dcs.condition.PartOfCoalitionOutsideZone("blue", trigger_zone_2.id, "AIRPLANE"))
-        trigger_outside.add_action(dcs.action.MessageToAll(text=String("Blue aircraft are not in batumi zone anymore!")))
+        trigger_outside.add_action(dcs.action.MessageToAll(
+            text=String("Blue aircraft are not in batumi zone anymore!")))
         m.triggerrules.triggers.append(trigger_outside)
 
         f15 = m.flight_group_inflight(usa, "F15", dcs.planes.F_15C, m.terrain.batumi().position, 1000)
@@ -383,7 +383,7 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.triggerrules.triggers[1].rules[0].zone, trigger_zone_2.id)
         self.assertEqual(m2.triggerrules.triggers[1].rules[0].coalitionlist, "blue")
 
-    def assert_prepared_mission_load(self, m: dcs.mission.Mission):
+    def _assert_prepared_mission_load(self, m: dcs.mission.Mission):
         usa = m.country(dcs.countries.USA.name)
 
         # find single heli pad
@@ -436,7 +436,7 @@ class BasicTests(unittest.TestCase):
         m = dcs.mission.Mission()
         m.load_file('tests/loadtest.miz')
 
-        self.assert_prepared_mission_load(m)
+        self._assert_prepared_mission_load(m)
 
         m.save('missions/loadtest.miz')
 
@@ -444,10 +444,11 @@ class BasicTests(unittest.TestCase):
         m = dcs.mission.Mission()
         m.load_file('missions/loadtest.miz')
 
-        self.assert_prepared_mission_load(m)
+        self._assert_prepared_mission_load(m)
 
     def test_load_test_missions(self):
-        current_milli_time = lambda: int(round(time.time() * 1000))
+        def current_milli_time():
+            return int(round(time.time() * 1000))
         test_mission_folder = os.path.join(os.path.dirname(__file__), 'missions')
         for f in os.listdir(test_mission_folder):
             if f.endswith('.miz'):
@@ -541,11 +542,10 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(unit.frequency, frequency)
 
     def test_create_scenery_destruction_zone(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
-        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        point = dcs.Point(-217283, 564863)  # This is a compound north of sukhmi, with buildings and trees
         m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
 
         # Create trigger zone
@@ -568,11 +568,10 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, destruction_zone.id)
 
     def test_remove_trees_in_zone(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
-        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        point = dcs.Point(-217283, 564863)  # This is a compound north of sukhmi, with buildings and trees
         m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
 
         # Create trigger zone
@@ -590,16 +589,16 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(0, len(m2.load_file('missions/test_mission_remove_trees.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.TREES_ONLY)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask,
+                         dcs.action.RemoveSceneObjectsMask.TREES_ONLY)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_remove_objects_in_zone(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
-        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        point = dcs.Point(-217283, 564863)  # This is a compound north of sukhmi, with buildings and trees
         m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
 
         # Create trigger zone
@@ -617,16 +616,16 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(0, len(m2.load_file('missions/test_mission_remove_objects.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY)
+        self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask,
+                         dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_remove_trees_and_objects_in_zone(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
-        point = dcs.Point(-217283, 564863) # This is a compound north of sukhmi, with buildings and trees
+        point = dcs.Point(-217283, 564863)  # This is a compound north of sukhmi, with buildings and trees
         m.vehicle_group(usa, "Vehicle", dcs.countries.USA.Vehicle.AirDefence.AAA_Vulcan_M163, position=point)
 
         # Create trigger zone
@@ -649,7 +648,6 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_bypass_triggers(self):
-
         m = dcs.mission.Mission()
         self.assertEqual(0, len(m.load_file('tests/bypass_triggers.miz', True)))
 
@@ -665,13 +663,13 @@ class BasicTests(unittest.TestCase):
         self.assertNotEqual(result, -1)
 
     def test_mission_with_qf17_aaa(self):
-
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
 
         usa = m.country("USA")
         caucasus = m.terrain
         batumi = caucasus.batumi()
-        m.vehicle_group(usa, "qf17", dcs.countries.USA.Vehicle.AirDefence.AA_gun_QF_3_7, position=batumi.random_unit_zone().center())
+        m.vehicle_group(usa, "qf17", dcs.countries.USA.Vehicle.AirDefence.AA_gun_QF_3_7,
+                        position=batumi.random_unit_zone().center())
 
         m.save('missions/test_mission_qf17.miz')
 
@@ -706,8 +704,8 @@ class BasicTests(unittest.TestCase):
     def test_mission_save_pictureFileName(self):
         m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
         image_path = 'tests/images/blue.png'
-        reskey_B = m.add_picture_blue(image_path)
-        reskey_R = m.add_picture_red(image_path)
+        reskey_b = m.add_picture_blue(image_path)
+        reskey_r = m.add_picture_red(image_path)
 
         mission_path = 'missions/test_mission_pictureFileName.miz'
         m.save(mission_path)
@@ -716,6 +714,6 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(0, len(m2.load_file(mission_path)))
 
         self.assertEqual(len(m2.pictureFileNameB), 1)
-        self.assertEqual(m2.pictureFileNameB[0], reskey_B.key)
+        self.assertEqual(m2.pictureFileNameB[0], reskey_b.key)
         self.assertEqual(len(m2.pictureFileNameR), 1)
-        self.assertEqual(m2.pictureFileNameR[0], reskey_R.key)
+        self.assertEqual(m2.pictureFileNameR[0], reskey_r.key)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -6,7 +6,7 @@ import zipfile
 
 import dcs
 from dcs.translation import String
-from dcs.status_message import MessageType
+from dcs.status_message import MessageSeverity, MessageType
 from dcs.flyingunit import FlyingUnit
 from dcs.unit import Ship
 
@@ -461,6 +461,21 @@ class BasicTests(unittest.TestCase):
                 start = current_milli_time()
                 self.assertTrue(m.save('missions/unittest_' + f))
                 print('-' * 10, "Saved", f, "in", current_milli_time() - start, "ms")
+
+    def test_fix_onboard_numbers(self):
+        m = dcs.mission.Mission()
+        msgs = m.load_file(os.path.join(os.path.dirname(__file__), 'missions', 'Forestry_Operations.miz'))
+        self.assertEqual(4, len(msgs))
+        self.assertTrue(all([x.severity == MessageSeverity.WARN for x in msgs]))
+
+        m.reassign_onboard_numbers()
+
+        save_path = os.path.join('missions', 'fix_onboard_Forestry_Operations.miz')
+        m.save(save_path)
+        print('-' * 10, "Saved", save_path)
+        # reload mission
+        m = dcs.mission.Mission()
+        msgs = m.load_file(save_path)
 
     def test_kneeboard(self):
         m = dcs.mission.Mission()

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -6,6 +6,7 @@ import zipfile
 
 import dcs
 from dcs.translation import String
+from dcs.status_message import MessageType
 from dcs.flyingunit import FlyingUnit
 from dcs.unit import Ship
 
@@ -208,7 +209,7 @@ class BasicTests(unittest.TestCase):
 
         # load the mission back
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file("missions/mission_with_nav_target_points.miz"))
+        self.assertEqual(0, len(m2.load_file("missions/mission_with_nav_target_points.miz")))
         usa_miz = m2.country("USA")
         jeff_miz = usa_miz.find_group("JF17")
 
@@ -324,7 +325,7 @@ class BasicTests(unittest.TestCase):
 
         # Test load mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_the_channel.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_the_channel.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.TheChannel)
 
     def test_create_mission_on_syria_map(self):
@@ -344,7 +345,7 @@ class BasicTests(unittest.TestCase):
 
         # Test load mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_syria.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_syria.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Syria)
 
     def test_create_mission_with_part_of_coalition_zone_trigger(self):
@@ -372,7 +373,7 @@ class BasicTests(unittest.TestCase):
 
         # Test load mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/mission_with_part_of_coalition_zone_trigger.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/mission_with_part_of_coalition_zone_trigger.miz')))
 
         self.assertEqual(m2.triggerrules.triggers[0].rules[0].unitType, "AIRPLANE")
         self.assertEqual(m2.triggerrules.triggers[0].rules[0].zone, trigger_zone.id)
@@ -433,7 +434,7 @@ class BasicTests(unittest.TestCase):
 
     def test_load_prepared_mission(self):
         m = dcs.mission.Mission()
-        self.assertTrue(m.load_file('tests/loadtest.miz'))
+        m.load_file('tests/loadtest.miz')
 
         self.assert_prepared_mission_load(m)
 
@@ -441,7 +442,7 @@ class BasicTests(unittest.TestCase):
 
         # reload mission
         m = dcs.mission.Mission()
-        self.assertTrue(m.load_file('missions/loadtest.miz'))
+        m.load_file('missions/loadtest.miz')
 
         self.assert_prepared_mission_load(m)
 
@@ -453,7 +454,7 @@ class BasicTests(unittest.TestCase):
                 print('-' * 10, "Loading", f)
                 start = current_milli_time()
                 m = dcs.mission.Mission()
-                self.assertTrue(m.load_file(os.path.join(test_mission_folder, f)))
+                m.load_file(os.path.join(test_mission_folder, f))
                 print('-' * 10, "Loaded", f, "in", current_milli_time() - start, "ms")
                 print('-' * 10, "Saving", f)
                 start = current_milli_time()
@@ -493,7 +494,7 @@ class BasicTests(unittest.TestCase):
         m.save(mission_file)
 
         m = dcs.mission.Mission()
-        self.assertTrue(m.load_file('missions/radio_channels.miz'))
+        self.assertEqual(0, len(m.load_file('missions/radio_channels.miz')))
         group = m.country(country_name).find_group(group_name)
         self.assertIsNotNone(group)
         self.assertIsInstance(group, dcs.unitgroup.FlyingGroup)
@@ -530,7 +531,7 @@ class BasicTests(unittest.TestCase):
         m.save(mission_file)
 
         m = dcs.mission.Mission()
-        self.assertTrue(m.load_file(f"missions/{mission_name}.miz"))
+        self.assertEqual(0, len(m.load_file(f"missions/{mission_name}.miz")))
         group = m.country(country_name).find_group(group_name)
         self.assertIsNotNone(group)
         self.assertIsInstance(group, dcs.unitgroup.ShipGroup)
@@ -559,7 +560,7 @@ class BasicTests(unittest.TestCase):
 
         # Test reload the mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_scenery_destruction.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_scenery_destruction.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.SceneryDestructionZone)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].destruction_level, 95)
@@ -586,7 +587,7 @@ class BasicTests(unittest.TestCase):
 
         # Test reload the mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_remove_trees.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_remove_trees.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.TREES_ONLY)
@@ -613,7 +614,7 @@ class BasicTests(unittest.TestCase):
 
         # Test reload the mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_remove_objects.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_remove_objects.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY)
@@ -640,7 +641,7 @@ class BasicTests(unittest.TestCase):
 
         # Test reload the mission
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_remove_all.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_remove_all.miz')))
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.ALL)
@@ -650,7 +651,7 @@ class BasicTests(unittest.TestCase):
     def test_bypass_triggers(self):
 
         m = dcs.mission.Mission()
-        m.load_file('tests/bypass_triggers.miz', True)
+        self.assertEqual(0, len(m.load_file('tests/bypass_triggers.miz', True)))
 
         saved_mission = 'missions/test_bypass_triggers.miz'
         m.save(saved_mission)
@@ -675,14 +676,14 @@ class BasicTests(unittest.TestCase):
         m.save('missions/test_mission_qf17.miz')
 
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file('missions/test_mission_qf17.miz'))
+        self.assertEqual(0, len(m2.load_file('missions/test_mission_qf17.miz')))
 
         group = m2.country("USA").find_group("qf17")
         self.assertEqual(group.units[0].type, dcs.vehicles.AirDefence.AA_gun_QF_3_7.id)
 
     def test_mission_neutral(self):
         m = dcs.mission.Mission()
-        m.load_file('tests/loadtest.miz')
+        self.assertEqual(0, len(m.load_file('tests/loadtest.miz')))
 
         neutral_country_name = "Sweden"
         sweden = m.country(neutral_country_name)
@@ -695,7 +696,7 @@ class BasicTests(unittest.TestCase):
         m.save(mission_path)
 
         m2 = dcs.mission.Mission()
-        self.assertTrue(m2.load_file(mission_path))
+        self.assertEqual(0, len(m2.load_file(mission_path)))
 
         sweden2 = m.country(neutral_country_name)
         self.assertTrue(sweden2 is not None)
@@ -712,7 +713,7 @@ class BasicTests(unittest.TestCase):
         m.save(mission_path)
 
         m2 = dcs.mission.Mission()
-        m2.load_file(mission_path)
+        self.assertEqual(0, len(m2.load_file(mission_path)))
 
         self.assertEqual(len(m2.pictureFileNameB), 1)
         self.assertEqual(m2.pictureFileNameB[0], reskey_B.key)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -476,6 +476,8 @@ class BasicTests(unittest.TestCase):
         # reload mission
         m = dcs.mission.Mission()
         msgs = m.load_file(save_path)
+        self.assertEqual(1, len(msgs))
+        self.assertEqual(MessageType.MISSION_FORMAT_OLD, msgs[0].type)
 
     def test_kneeboard(self):
         m = dcs.mission.Mission()

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -6,6 +6,8 @@ import zipfile
 
 import dcs
 from dcs.translation import String
+from dcs.flyingunit import FlyingUnit
+from dcs.unit import Ship
 
 
 class BasicTests(unittest.TestCase):
@@ -497,7 +499,7 @@ class BasicTests(unittest.TestCase):
         self.assertIsInstance(group, dcs.unitgroup.FlyingGroup)
         self.assertEqual(1, len(group.units))
         unit = group.units[0]
-        self.assertIsInstance(unit, dcs.flyingunit.FlyingUnit)
+        self.assertIsInstance(unit, FlyingUnit)
         self.assertAlmostEqual(unit.radio[2]["channels"][1], frequency)
 
     def test_ship_frequency(self):
@@ -516,7 +518,7 @@ class BasicTests(unittest.TestCase):
             dcs.countries.USA.Ship.CVN_70_Carl_Vinson,
             seapoint
         )
-        unit = group.units[0]
+        unit: Ship = group.units[0]
         frequency = 300000000
         self.assertNotEqual(unit.frequency, frequency)
         unit.set_frequency(frequency)


### PR DESCRIPTION
pydcs now will keep track of used onboard numbers
and new units created via the mission interface
will automatically get assigned a free number.
Also warn on mission load if a number is already in use,
but do not fail as DCS allows multiple tail numbers.

closes #112 