### PR TITLE
Respect original data type of onboard_num

### DIFF
--- a/dcs/country.py
+++ b/dcs/country.py
@@ -140,6 +140,10 @@ class Country:
             self.current_callsign_category[category] = 0
         return self.callsign.get(category)[self.current_callsign_category[category]]
 
+    @property
+    def unused_onboard_numbers(self) -> Set[str]:
+        return self._tail_numbers
+
     def reset_onboard_numbers(self):
         """
         Resets/clears reserved onboard numbers for this country.
@@ -158,7 +162,7 @@ class Country:
         return is_in
 
     def next_onboard_num(self) -> str:
-        free_set = {str(x) for x in range(10, 999)} - self._tail_numbers
+        free_set = {"{:03}".format(x) for x in range(10, 999)} - self._tail_numbers
         tailnum = free_set.pop()
         self.reserve_onboard_num(tailnum)
         return tailnum

--- a/dcs/country.py
+++ b/dcs/country.py
@@ -31,7 +31,7 @@ class Country:
         self.static_group = []  # type: List[StaticGroup]
         self.current_callsign_id = 99
         self.current_callsign_category = {}  # type: Dict[str,int]
-        self._tail_numbers: Set[int] = set()
+        self._tail_numbers: Set[str] = set()
 
     def add_vehicle_group(self, vgroup):
         self.vehicle_group.append(vgroup)
@@ -140,10 +140,6 @@ class Country:
             self.current_callsign_category[category] = 0
         return self.callsign.get(category)[self.current_callsign_category[category]]
 
-    @property
-    def unused_onboard_numbers(self) -> Set[int]:
-        return self._tail_numbers
-
     def reset_onboard_numbers(self):
         """
         Resets/clears reserved onboard numbers for this country.
@@ -151,7 +147,7 @@ class Country:
         """
         self._tail_numbers = set()
 
-    def reserve_onboard_num(self, number: int) -> bool:
+    def reserve_onboard_num(self, number: str) -> bool:
         """
         Reserve the give onboard_num (tail number), if already used return True.
         :param int number: onboard num
@@ -161,8 +157,8 @@ class Country:
         self._tail_numbers.add(number)
         return is_in
 
-    def next_onboard_num(self) -> int:
-        free_set = {x for x in range(10, 999)} - self._tail_numbers
+    def next_onboard_num(self) -> str:
+        free_set = {str(x) for x in range(10, 999)} - self._tail_numbers
         tailnum = free_set.pop()
         self.reserve_onboard_num(tailnum)
         return tailnum

--- a/dcs/flyingunit.py
+++ b/dcs/flyingunit.py
@@ -17,7 +17,7 @@ class FlyingUnit(Unit):
         self.parking = None  # crossroad idx
         self.parking_id = None  # parking slot name (01, 02, ..)
         self.psi = 0
-        self.onboard_num: int = 9
+        self.onboard_num = '9'
         self.alt = 0
         self.alt_type = "BARO"
         self.flare = _type.flare
@@ -46,7 +46,7 @@ class FlyingUnit(Unit):
         self.chaff = d["payload"]["chaff"]
         self.ammo_type = d["payload"].get("ammo_type")
         self.pylons = d["payload"]["pylons"]
-        self.onboard_num = int(d["onboard_num"])
+        self.onboard_num = d["onboard_num"]
         if isinstance(d["callsign"], int):
             self.callsign = d["callsign"]
         else:
@@ -190,7 +190,7 @@ class FlyingUnit(Unit):
         if self.livery_id:
             d["livery_id"] = self.livery_id
         d["psi"] = self.psi
-        d["onboard_num"] = "{:03}".format(self.onboard_num)
+        d["onboard_num"] = self.onboard_num
         d["speed"] = round(self.speed, 13)
         if self.hardpoint_racks is not None:
             d["hardpoint_racks"] = self.hardpoint_racks


### PR DESCRIPTION
Resolves #122 

Respects the original data type of onboard_num while still allowing uniquely generated tail numbers.

Ran all unit tests before and after making this change with no discrepancies.

I've only recently picked up Python after 7-8 years of years since I last touched it, please do tell me if there's something I haven't done or confirmed.