### PR TITLE
Support DCS 2.7 cloud presets.

### DIFF
--- a/dcs/cloud_presets.py
+++ b/dcs/cloud_presets.py
@@ -1,0 +1,285 @@
+from enum import Enum, unique
+
+from dcs.weather import CloudPreset
+
+
+@unique
+class Clouds(Enum):
+
+    @staticmethod
+    def from_name(name: str) -> "CloudPreset":
+        return CLOUD_PRESETS[name]
+
+    LightScattered1 = CloudPreset(
+        name='Preset1',
+        ui_name='Light Scattered 1',
+        description='01 ##Few Scattered Clouds \nMETAR:FEW/SCT 7/8',
+        min_base=840,
+        max_base=4200,
+    )
+
+    Scattered5 = CloudPreset(
+        name='Preset10',
+        ui_name='Scattered 5',
+        description='10 ##Two Layers Scattered Large Thick Clouds  \nMETAR:SCT/BKN 18/20 FEW36/38 FEW 40',
+        min_base=1260,
+        max_base=4200,
+    )
+
+    Scattered6 = CloudPreset(
+        name='Preset11',
+        ui_name='Scattered 6',
+        description='11 ##Two Layers Scattered Large Clouds High Ceiling \nMETAR:BKN 18/20 BKN 32/33 FEW 41',
+        min_base=2520,
+        max_base=5460,
+    )
+
+    Scattered7 = CloudPreset(
+        name='Preset12',
+        ui_name='Scattered 7',
+        description='12 ##Two Layers Scattered Large Clouds High Ceiling \nMETAR:BKN 12/14 SCT 22/23 FEW 41',
+        min_base=1680,
+        max_base=3360,
+    )
+
+    Broken1 = CloudPreset(
+        name='Preset13',
+        ui_name='Broken 1',
+        description='13 ##Two Layers Broken Clouds \nMETAR:BKN 12/14 BKN 26/28 FEW 41',
+        min_base=1680,
+        max_base=3360,
+    )
+
+    Broken2 = CloudPreset(
+        name='Preset14',
+        ui_name='Broken 2',
+        description='14 ##Broken Thick Low Layer with Few High Layer\nMETAR:BKN LYR 7/16 FEW 41',
+        min_base=1680,
+        max_base=3360,
+    )
+
+    Broken3 = CloudPreset(
+        name='Preset15',
+        ui_name='Broken 3',
+        description='15 ##Two Layers Broken Large Clouds \nMETAR:SCT/BKN 14/18 BKN 24/27 FEW 40',
+        min_base=840,
+        max_base=5040,
+    )
+
+    Broken4 = CloudPreset(
+        name='Preset16',
+        ui_name='Broken 4',
+        description='16 ##Two Layers Broken Large Clouds \nMETAR:BKN 14/18 BKN 28/30 FEW 40',
+        min_base=1260,
+        max_base=4200,
+    )
+
+    Broken5 = CloudPreset(
+        name='Preset17',
+        ui_name='Broken 5',
+        description='17 ##Three Layers Broken/Overcast \nMETAR:BKN/OVC LYR 7/13 20/22 32/34',
+        min_base=0,
+        max_base=2520,
+    )
+
+    Broken6 = CloudPreset(
+        name='Preset18',
+        ui_name='Broken 6',
+        description='18 ##Three Layers Broken/Overcast \nMETAR:BKN/OVC LYR 13/15 25/29 38/41',
+        min_base=0,
+        max_base=3780,
+    )
+
+    Broken7 = CloudPreset(
+        name='Preset19',
+        ui_name='Broken 7',
+        description='19 ##Three Layers Overcast At Low Level \nMETAR:OVC 9/16 BKN/OVC LYR 23/24 31/33',
+        min_base=0,
+        max_base=2940,
+    )
+
+    LightScattered2 = CloudPreset(
+        name='Preset2',
+        ui_name='Light Scattered 2',
+        description='02 ##Two Layers Few and Scattered \nMETAR:FEW/SCT 8/10 SCT 23/24',
+        min_base=1260,
+        max_base=2520,
+    )
+
+    Broken8 = CloudPreset(
+        name='Preset20',
+        ui_name='Broken 8',
+        description='20 ##Three Layers Overcast Low Level \nMETAR:BKN/OVC 13/18 BKN 28/30 SCT FEW 38',
+        min_base=0,
+        max_base=3780,
+    )
+
+    Overcast1 = CloudPreset(
+        name='Preset21',
+        ui_name='Overcast 1',
+        description='21 ##Overcast low level \nMETAR:BKN/OVC LYR 7/8 17/19',
+        min_base=1260,
+        max_base=4200,
+    )
+
+    Overcast2 = CloudPreset(
+        name='Preset22',
+        ui_name='Overcast 2',
+        description='22 ##Overcast low Level \nMETAR:BKN LYR 7/10 17/20',
+        min_base=420,
+        max_base=4200,
+    )
+
+    Overcast3 = CloudPreset(
+        name='Preset23',
+        ui_name='Overcast 3',
+        description='23 ##Three Layer Broken Low Level Scattered High \nMETAR:BKN LYR 11/14 18/25 SCT 32/35',
+        min_base=840,
+        max_base=3360,
+    )
+
+    Overcast4 = CloudPreset(
+        name='Preset24',
+        ui_name='Overcast 4',
+        description='24 ##Three Layer Overcast \nMETAR:BKN/OVC 3/7 17/22 BKN 34',
+        min_base=420,
+        max_base=2520,
+    )
+
+    Overcast5 = CloudPreset(
+        name='Preset25',
+        ui_name='Overcast 5',
+        description='25 ##Three Layer Overcast \nMETAR:OVC LYR 12/14 22/25 40/42',
+        min_base=420,
+        max_base=3360,
+    )
+
+    Overcast6 = CloudPreset(
+        name='Preset26',
+        ui_name='Overcast 6',
+        description='26 ##Three Layer Overcast \nMETAR:OVC 9/15 BKN 23/25 SCT 32',
+        min_base=420,
+        max_base=2940,
+    )
+
+    Overcast7 = CloudPreset(
+        name='Preset27',
+        ui_name='Overcast 7',
+        description='27 ##Three Layer Overcast \nMETAR:OVC 8/15 SCT/BKN 25/26 34/36',
+        min_base=420,
+        max_base=2520,
+    )
+
+    HighScattered1 = CloudPreset(
+        name='Preset3',
+        ui_name='High Scattered 1',
+        description='03 ##Two Layer Scattered \nMETAR:SCT 8/9 FEW 21',
+        min_base=840,
+        max_base=2520,
+    )
+
+    HighScattered2 = CloudPreset(
+        name='Preset4',
+        ui_name='High Scattered 2',
+        description='04 ##Two Layer Scattered \nMETAR:SCT 8/10 FEW/SCT 24/26',
+        min_base=1260,
+        max_base=2520,
+    )
+
+    Scattered1 = CloudPreset(
+        name='Preset5',
+        ui_name='Scattered 1',
+        description='05 ##Three Layer High altitude Scattered \nMETAR:SCT 14/17 FEW 27/29 BKN 40',
+        min_base=1260,
+        max_base=4620,
+    )
+
+    Scattered2 = CloudPreset(
+        name='Preset6',
+        ui_name='Scattered 2',
+        description='06 ##One Layer Scattered/Broken \nMETAR:SCT/BKN 8/10 FEW 40',
+        min_base=1260,
+        max_base=4200,
+    )
+
+    Scattered3 = CloudPreset(
+        name='Preset7',
+        ui_name='Scattered 3',
+        description='07 ##Two Layer Scattered/Broken \nMETAR:BKN 7.5/12 SCT/BKN 21/23 SCT 40',
+        min_base=1680,
+        max_base=5040,
+    )
+
+    HighScattered3 = CloudPreset(
+        name='Preset8',
+        ui_name='High Scattered 3',
+        description='08 ##Two Layer Scattered/Broken High Altitude \nMETAR:SCT/BKN 18/20 FEW 36/38 FEW 40',
+        min_base=3780,
+        max_base=5460,
+    )
+
+    Scattered4 = CloudPreset(
+        name='Preset9',
+        ui_name='Scattered 4',
+        description='09 ##Two Layer Broken/Scattered \nMETAR:BKN 7.5/10 SCT 20/22 FEW41',
+        min_base=1680,
+        max_base=3780,
+    )
+
+    OvercastAndRain1 = CloudPreset(
+        name='RainyPreset1',
+        ui_name='Overcast And Rain 1',
+        description='28 ##Overcast with Rain \nMETAR:VIS 3-5KM RA OVC 3/15 28/30 FEW 40',
+        min_base=420,
+        max_base=2940,
+    )
+
+    OvercastAndRain2 = CloudPreset(
+        name='RainyPreset2',
+        ui_name='Overcast And Rain 2',
+        description='29 ##Overcast with Rain \nMETAR:VIS 1-5KM RA BKN/OVC 3/11 SCT 18/29 FEW 40',
+        min_base=840,
+        max_base=2520,
+    )
+
+    OvercastAndRain3 = CloudPreset(
+        name='RainyPreset3',
+        ui_name='Overcast And Rain 3',
+        description='30 ##Overcast with Rain \nMETAR:VIS 3-5KM RA OVC LYR 6/18 19/21 SCT 34',
+        min_base=840,
+        max_base=2520,
+    )
+
+
+CLOUD_PRESETS = {
+    'Preset1': Clouds.LightScattered1,
+    'Preset10': Clouds.Scattered5,
+    'Preset11': Clouds.Scattered6,
+    'Preset12': Clouds.Scattered7,
+    'Preset13': Clouds.Broken1,
+    'Preset14': Clouds.Broken2,
+    'Preset15': Clouds.Broken3,
+    'Preset16': Clouds.Broken4,
+    'Preset17': Clouds.Broken5,
+    'Preset18': Clouds.Broken6,
+    'Preset19': Clouds.Broken7,
+    'Preset2': Clouds.LightScattered2,
+    'Preset20': Clouds.Broken8,
+    'Preset21': Clouds.Overcast1,
+    'Preset22': Clouds.Overcast2,
+    'Preset23': Clouds.Overcast3,
+    'Preset24': Clouds.Overcast4,
+    'Preset25': Clouds.Overcast5,
+    'Preset26': Clouds.Overcast6,
+    'Preset27': Clouds.Overcast7,
+    'Preset3': Clouds.HighScattered1,
+    'Preset4': Clouds.HighScattered2,
+    'Preset5': Clouds.Scattered1,
+    'Preset6': Clouds.Scattered2,
+    'Preset7': Clouds.Scattered3,
+    'Preset8': Clouds.HighScattered3,
+    'Preset9': Clouds.Scattered4,
+    'RainyPreset1': Clouds.OvercastAndRain1,
+    'RainyPreset2': Clouds.OvercastAndRain2,
+    'RainyPreset3': Clouds.OvercastAndRain3,
+}

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,65 @@
+import unittest
+
+from dcs.terrain import Caucasus
+from dcs.weather import CloudPreset, Weather
+from dcs.cloud_presets import Clouds
+
+
+class CloudPresetTests(unittest.TestCase):
+    def test_validate_base(self) -> None:
+        preset = CloudPreset("test preset", "", "", 2, 3)
+
+        with self.assertRaises(ValueError):
+            preset.validate_base(1)
+
+        preset.validate_base(2)
+        preset.validate_base(3)
+
+        with self.assertRaises(ValueError):
+            preset.validate_base(4)
+
+    def test_by_name(self) -> None:
+        with self.assertRaises(KeyError):
+            CloudPreset.by_name("does not exist")
+
+        self.assertEqual(CloudPreset.by_name("Preset1"), Clouds.LightScattered1.value)
+
+
+class CloudsTests(unittest.TestCase):
+    def test_list(self) -> None:
+        self.assertGreater(len(Clouds), 0)
+
+    def test_enum(self) -> None:
+        self.assertIsNotNone(Clouds.LightScattered1)
+
+
+class WeatherTests(unittest.TestCase):
+    def test_old_clouds(self) -> None:
+        weather = Weather(Caucasus())
+        clouds = weather.dict()["clouds"]
+        self.assertNotIn("preset", clouds)
+
+    def test_cloud_presets(self) -> None:
+        weather = Weather(Caucasus())
+        weather.clouds_preset = Clouds.LightScattered1.value
+        weather.clouds_base = 1000
+        weather_dict = weather.dict()
+        clouds = weather.dict()["clouds"]
+
+        self.assertEqual(clouds["preset"], "Preset1")
+        self.assertEqual(clouds["base"], 1000)
+        self.assertEqual(clouds["thickness"], 200)
+        self.assertEqual(clouds["density"], 0)
+        self.assertEqual(clouds["iprecptns"], 0)
+
+        weather.clouds_base = 0
+        with self.assertRaises(ValueError):
+            weather.dict()
+
+        weather_dict["clouds"]["preset"] = "Preset2"
+        weather.load_from_dict(weather_dict)
+        self.assertEqual(weather.clouds_preset.name, "Preset2")
+
+        del weather_dict["clouds"]["preset"]
+        weather.load_from_dict(weather_dict)
+        self.assertIsNone(weather.clouds_preset)

--- a/tools/weather_import.py
+++ b/tools/weather_import.py
@@ -1,0 +1,229 @@
+"""Generates resources/dcs/beacons.json from the DCS installation.
+
+DCS has a clouds.lua file that defines all the cloud presets introduced in DCS 2.7.
+Example below. The only values we need for serialization are the names of the presets
+and their min/max preset altitudes, but the names might also be useful to clients.
+Translation of names and descriptions are not handled.
+
+clouds =
+{
+	presets =
+	{
+		Preset1 =
+		{
+			visibleInGUI = true,
+			readableName = '01 ##'.. _('Few Scattered Clouds \nMETAR:FEW/SCT 7/8'),
+			readableNameShort = _('Light Scattered 1'),
+			thumbnailName = 'Bazar/Effects/Clouds/Thumbnails/cloud_1.png',
+			levelMap = 'bazar/effects/clouds/cloudsMap01.png',
+			detailNoiseMapSize = 8500.00,
+			precipitationPower = -1.00,
+			presetAltMin = 840.00,
+			presetAltMax = 4200.00,
+			layers = {
+				{
+					altitudeMin = 2520,
+					altitudeMax = 3780,
+					tile = 9.024,
+					shapeFactor = 0.015,
+					density = 0.396,
+					densityGrad = 0.622,
+					coverage = 0.359,
+					noiseFreq = 0.384,
+					noiseBlur = 1.125,
+					coverageMapFactor = 0.00,
+					coverageMapUVOffsetX = 0.00,
+					coverageMapUVOffsetY = 0.00,
+				},
+				{
+					altitudeMin = 5040,
+					altitudeMax = 6300,
+					tile = 5.104,
+					shapeFactor = 0.132,
+					density = 0.410,
+					densityGrad = 1.032,
+					coverage = 0.308,
+					noiseFreq = 0.813,
+					noiseBlur = 1.500,
+					coverageMapFactor = 0.00,
+					coverageMapUVOffsetX = 0.00,
+					coverageMapUVOffsetY = 0.00,
+				},
+				{
+					altitudeMin = 10500,
+					altitudeMax = 12180,
+					tile = 0.880,
+					shapeFactor = 0.201,
+					density = 0.000,
+					densityGrad = 2.000,
+					coverage = 0.000,
+					noiseFreq = 3.000,
+					noiseBlur = 1.500,
+					coverageMapFactor = 0.00,
+					coverageMapUVOffsetX = 0.00,
+					coverageMapUVOffsetY = 0.00,
+				},
+			}
+		},
+        ...
+"""
+import argparse
+from contextlib import contextmanager
+import dataclasses
+import logging
+
+try:
+    import lupa
+except ImportError as ex:
+    raise RuntimeError(
+        "Run `pip install lupa` to use this tool. It is not included in "
+        "requirements.txt since most users will not need this dependency."
+    ) from ex
+
+from pathlib import Path
+import operator
+import os
+import textwrap
+from typing import Dict, Iterable, Union
+
+from dcs.weather import CloudPreset
+
+THIS_DIR = Path(__file__).parent.resolve()
+SRC_DIR = THIS_DIR.parent
+EXPORT_PATH = SRC_DIR / "dcs/cloud_presets.py"
+
+
+@contextmanager
+def cd(path: Path):
+    cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
+
+
+def cloud_presets(dcs_path: Path) -> Iterable[CloudPreset]:
+    clouds_lua = dcs_path / "Config/Effects/clouds.lua"
+    logging.info(f"Loading cloud presets from {clouds_lua}")
+
+    with cd(dcs_path):
+        lua = lupa.LuaRuntime()
+
+        # Define the translation function to a no-op because we don't need it.
+        lua.execute(
+            textwrap.dedent(
+                """\
+                function _(key)
+                    return key
+                end
+
+                """
+            )
+        )
+
+        lua.execute(clouds_lua.read_text())
+
+    for name, data in lua.eval("clouds['presets']").items():
+        if not data["visibleInGUI"]:
+            # Not something choosable in the ME, so skip it.
+            continue
+
+        yield CloudPreset(
+            name,
+            ui_name=data["readableNameShort"],
+            description=data["readableName"],
+            min_base=data["presetAltMin"],
+            max_base=data["presetAltMax"],
+        )
+
+
+class Importer:
+    """Imports cloud presets."""
+
+    def __init__(self, dcs_path: Path, export_path: Path) -> None:
+        self.dcs_path = dcs_path
+        self.export_path = export_path
+
+    def run(self) -> None:
+        """Exports the beacons for each available terrain mod."""
+        self.export_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with self.export_path.open("w") as output:
+            output.write(textwrap.dedent(
+                """\
+                from enum import Enum, unique
+
+                from dcs.weather import CloudPreset
+
+
+                @unique
+                class Clouds(Enum):
+
+                    @staticmethod
+                    def from_name(name: str) -> "CloudPreset":
+                        return CLOUD_PRESETS[name]
+
+                """
+            ))
+
+            presets = sorted(cloud_presets(self.dcs_path),
+                             key=operator.attrgetter("name"))
+            names = {}
+            for preset in presets:
+                name = preset.ui_name.replace(" ", "")
+                names[preset.name] = name
+                preset_src = textwrap.dedent(
+                    f"""\
+                    {name} = CloudPreset(
+                        name={repr(preset.name)},
+                        ui_name={repr(preset.ui_name)},
+                        description={repr(preset.description)},
+                        min_base={repr(preset.min_base)},
+                        max_base={repr(preset.max_base)},
+                    )
+
+                    """
+                )
+                output.write(textwrap.indent(preset_src, "    "))
+
+            output.write("\nCLOUD_PRESETS = {\n")
+            for name in names:
+                output.write(f"    {repr(name)}: Clouds.{names[name]},\n")
+            output.write("}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parses and returns command line arguments."""
+    parser = argparse.ArgumentParser()
+
+    def resolved_path(val: str) -> Path:
+        """Returns the given string as a fully resolved Path."""
+        return Path(val).resolve()
+
+    parser.add_argument(
+        "--export-to",
+        type=resolved_path,
+        default=EXPORT_PATH,
+        help="Output directory for generated JSON files.",
+    )
+
+    parser.add_argument(
+        "dcs_path",
+        metavar="DCS_PATH",
+        type=resolved_path,
+        help="Path to DCS installation.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Program entry point."""
+    logging.basicConfig(level=logging.DEBUG)
+    args = parse_args()
+    Importer(args.dcs_path, args.export_to).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In 2.7 cloud presets can be selected, which will:

* Override cloud thickness, density, and precipitation
* Bound the cloud base
* Set the "preset" property in the mission file

This patch adds an import script to load the names and cloud base
boundaries from the config file in the DCS install. The script requires
lupa because the parser in dcs.lua is not capable of parsing complex lua
files (I think it's because there are function calls, but I didn't dig
much).

This also removes the `Weather.fog_density` property, since DCS no
longer supports that.

Fixes https://github.com/pydcs/dcs/issues/118