### PR TITLE
Implement a get_name method for unitgroup

### DIFF
--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -48,6 +48,11 @@ class Unit:
         new.id = _id
         return new
 
+    def get_name(self):
+        if isinstance(self.name, String):
+            return self.name.id
+        return self.name
+
     def dict(self):
         d = {
             "type": self.type,
@@ -55,7 +60,7 @@ class Unit:
             "y": self.position.y,
             "heading": round(math.radians(self.heading), 13),
             "unitId": self.id,
-            "name": self.name.id
+            "name": self.get_name()
         }
         if self.skill is not None:
             d["skill"] = self.skill.value

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -71,6 +71,11 @@ class Group:
     def position(self) -> mapping.Point:
         return self.units[0].position
 
+    def get_name(self):
+        if isinstance(self.name, String):
+            return self.name.id
+        return self.name
+
     def formation_line(self, heading, distance=20):
         pos = self.units[0].position
         for i in range(1, len(self.units)):
@@ -180,7 +185,7 @@ class Group:
 
     def dict(self):
         d = {
-            "name": self.name.id,
+            "name": self.get_name(),
             "groupId": self.id
         }
         if self.hidden is not None:


### PR DESCRIPTION
Resolves #134 which was introduced with the [following change](https://github.com/pydcs/dcs/commit/22c147026553f378f70bc06234e35a9061aca96c#diff-6ee1958457b38b9cfd91d89b14992a4407084ae9b65a5a2926da4b369b1011bd)

Caused by `name` being one of two types:
- `str`
- `String`