### PR TITLE
data-export 2.7.1.6430

### DIFF
--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -17,12 +17,12 @@ class Russia(Country):
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
 
         class Infantry:
@@ -36,7 +36,7 @@ class Russia(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -64,6 +64,7 @@ class Russia(Country):
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
 
         class Fortification:
@@ -88,26 +89,28 @@ class Russia(Country):
             Bus_LiAZ_677 = vehicles.Unarmed.Bus_LiAZ_677
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -116,7 +119,8 @@ class Russia(Country):
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             MBT_T_90 = vehicles.Armor.MBT_T_90
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -320,6 +324,7 @@ class Russia(Country):
         Bulker_Yakushev = ships.Bulker_Yakushev
         Cargo_Ivanov = ships.Cargo_Ivanov
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
 
     class CallsignAWACS:
@@ -456,13 +461,13 @@ class Ukraine(Country):
         class Artillery:
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
 
         class Infantry:
             Paratrooper_AKS = vehicles.Infantry.Paratrooper_AKS
@@ -473,7 +478,7 @@ class Ukraine(Country):
             SAM_SA_19_Tunguska_Grison = vehicles.AirDefence.SAM_SA_19_Tunguska_Grison
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -500,6 +505,7 @@ class Ukraine(Country):
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
 
@@ -528,32 +534,34 @@ class Ukraine(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_80U = vehicles.Armor.MBT_T_80U
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -781,7 +789,7 @@ class USA(Country):
         class Artillery:
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
@@ -793,7 +801,7 @@ class USA(Country):
         class AirDefence:
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
@@ -808,7 +816,7 @@ class USA(Country):
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
@@ -830,8 +838,8 @@ class USA(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
@@ -849,16 +857,16 @@ class USA(Country):
             APC_M113 = vehicles.Armor.APC_M113
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             IFV_M1126_Stryker_ICV = vehicles.Armor.IFV_M1126_Stryker_ICV
             SPG_Stryker_MGS = vehicles.Armor.SPG_Stryker_MGS
             ATGM_Stryker = vehicles.Armor.ATGM_Stryker
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
@@ -1076,6 +1084,7 @@ class USA(Country):
         CVN_73_George_Washington = ships.CVN_73_George_Washington
         CVN_75_Harry_S__Truman = ships.CVN_75_Harry_S__Truman
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -1208,19 +1217,20 @@ class Turkey(Country):
 
         class Artillery:
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
+            SPH_T155_Firtina_155mm = vehicles.Artillery.SPH_T155_Firtina_155mm
 
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
@@ -1238,10 +1248,10 @@ class Turkey(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
@@ -1250,14 +1260,15 @@ class Turkey(Country):
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
+            MBT_Leopard_2A4_Trs = vehicles.Armor.MBT_Leopard_2A4_Trs
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -1266,6 +1277,7 @@ class Turkey(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -1401,6 +1413,7 @@ class Turkey(Country):
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -1533,7 +1546,7 @@ class UK(Country):
 
         class Artillery:
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
         class Infantry:
@@ -1548,7 +1561,7 @@ class UK(Country):
             SAM_Rapier_Blindfire_TR = vehicles.AirDefence.SAM_Rapier_Blindfire_TR
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
 
         class Fortification:
@@ -1562,7 +1575,7 @@ class UK(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
@@ -1581,14 +1594,15 @@ class UK(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
+            MBT_Chieftain_Mk_3 = vehicles.Armor.MBT_Chieftain_Mk_3
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
 
@@ -1731,6 +1745,7 @@ class UK(Country):
         LST_Mk_II = ships.LST_Mk_II
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
         Boat_Schnellboot_type_S130 = ships.Boat_Schnellboot_type_S130
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
 
@@ -1859,16 +1874,16 @@ class France(Country):
 
         class Artillery:
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
@@ -1903,9 +1918,10 @@ class France(Country):
         class Armor:
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
@@ -2045,6 +2061,7 @@ class France(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
@@ -2175,12 +2192,11 @@ class Germany(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -2194,7 +2210,7 @@ class Germany(Country):
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -2203,7 +2219,7 @@ class Germany(Country):
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -2212,7 +2228,7 @@ class Germany(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_10_S_300_Grumble_TEL_D = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_D
@@ -2250,11 +2266,11 @@ class Germany(Country):
             Bunker_with_Fire_Control_Center = vehicles.Fortification.Bunker_with_Fire_Control_Center
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Refueler_ATMZ_5 = vehicles.Unarmed.Refueler_ATMZ_5
             Refueler_ATZ_10 = vehicles.Unarmed.Refueler_ATZ_10
@@ -2264,33 +2280,37 @@ class Germany(Country):
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             LUV_Kettenrad = vehicles.Unarmed.LUV_Kettenrad
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
             LUV_Kubelwagen_82 = vehicles.Unarmed.LUV_Kubelwagen_82
             Carrier_Sd_Kfz_7_Tractor = vehicles.Unarmed.Carrier_Sd_Kfz_7_Tractor
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             IFV_Marder = vehicles.Armor.IFV_Marder
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
+            MBT_Leopard_2A4 = vehicles.Armor.MBT_Leopard_2A4
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -2308,6 +2328,7 @@ class Germany(Country):
         class Carriage:
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
@@ -2436,6 +2457,8 @@ class Germany(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
         U_boat_VIIC_U_flak = ships.U_boat_VIIC_U_flak
         Boat_Schnellboot_type_S130 = ships.Boat_Schnellboot_type_S130
 
@@ -2569,23 +2592,23 @@ class USAFAggressors(Country):
     class Vehicle:
 
         class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             PLZ_05 = vehicles.Artillery.PLZ_05
+            SPH_T155_Firtina_155mm = vehicles.Artillery.SPH_T155_Firtina_155mm
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -2618,7 +2641,7 @@ class USAFAggressors(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -2643,8 +2666,9 @@ class USAFAggressors(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -2654,12 +2678,12 @@ class USAFAggressors(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
             MANPADS_SA_18_Igla_S_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -2711,10 +2735,10 @@ class USAFAggressors(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
@@ -2722,25 +2746,27 @@ class USAFAggressors(Country):
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             Car_Willys_Jeep = vehicles.Unarmed.Car_Willys_Jeep
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -2748,6 +2774,7 @@ class USAFAggressors(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -2755,7 +2782,7 @@ class USAFAggressors(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -2765,14 +2792,15 @@ class USAFAggressors(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
@@ -2780,23 +2808,28 @@ class USAFAggressors(Country):
             MBT_T_90 = vehicles.Armor.MBT_T_90
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
             MBT_Merkava_IV = vehicles.Armor.MBT_Merkava_IV
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             IFV_Marder = vehicles.Armor.IFV_Marder
+            MBT_Leopard_2A4 = vehicles.Armor.MBT_Leopard_2A4
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             ZBD_04A = vehicles.Armor.ZBD_04A
             ZTZ_96B = vehicles.Armor.ZTZ_96B
+            MBT_Leopard_2A4_Trs = vehicles.Armor.MBT_Leopard_2A4_Trs
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             IFV_M1126_Stryker_ICV = vehicles.Armor.IFV_M1126_Stryker_ICV
             SPG_Stryker_MGS = vehicles.Armor.SPG_Stryker_MGS
             ATGM_Stryker = vehicles.Armor.ATGM_Stryker
             IFV_Warrior = vehicles.Armor.IFV_Warrior
+            MBT_Chieftain_Mk_3 = vehicles.Armor.MBT_Chieftain_Mk_3
 
         class MissilesSS:
             SSM_V_1_Launcher = vehicles.MissilesSS.SSM_V_1_Launcher
@@ -2822,6 +2855,8 @@ class USAFAggressors(Country):
             Well_Car = vehicles.Carriage.Well_Car
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
@@ -3094,9 +3129,11 @@ class USAFAggressors(Country):
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Battlecruiser_1144_2_Pyotr_Velikiy = ships.Battlecruiser_1144_2_Pyotr_Velikiy
         CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
@@ -3248,7 +3285,7 @@ class Canada(Country):
         class AirDefence:
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
@@ -3264,10 +3301,10 @@ class Canada(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
@@ -3278,10 +3315,10 @@ class Canada(Country):
             APC_M113 = vehicles.Armor.APC_M113
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
@@ -3299,6 +3336,7 @@ class Canada(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -3559,14 +3597,14 @@ class Spain(Country):
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             SAM_Patriot_CR__AMG_AN_MRC_137 = vehicles.AirDefence.SAM_Patriot_CR__AMG_AN_MRC_137
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
@@ -3586,7 +3624,7 @@ class Spain(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
@@ -3594,12 +3632,12 @@ class Spain(Country):
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -3608,6 +3646,7 @@ class Spain(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -3733,6 +3772,7 @@ class Spain(Country):
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -3866,7 +3906,7 @@ class TheNetherlands(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
         class AirDefence:
@@ -3878,12 +3918,12 @@ class TheNetherlands(Country):
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
             SAM_Rapier_Tracker = vehicles.AirDefence.SAM_Rapier_Tracker
             SAM_Rapier_Blindfire_TR = vehicles.AirDefence.SAM_Rapier_Blindfire_TR
@@ -3905,7 +3945,7 @@ class TheNetherlands(Country):
             Bunker_with_Fire_Control_Center = vehicles.Fortification.Bunker_with_Fire_Control_Center
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
@@ -3916,15 +3956,16 @@ class TheNetherlands(Country):
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
 
         class Armor:
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
@@ -3942,6 +3983,7 @@ class TheNetherlands(Country):
         class Carriage:
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
@@ -4070,6 +4112,7 @@ class TheNetherlands(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
@@ -4210,12 +4253,12 @@ class Belgium(Country):
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -4234,7 +4277,7 @@ class Belgium(Country):
             Bunker_with_Fire_Control_Center = vehicles.Fortification.Bunker_with_Fire_Control_Center
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
@@ -4246,7 +4289,7 @@ class Belgium(Country):
             APC_M113 = vehicles.Armor.APC_M113
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
@@ -4519,17 +4562,17 @@ class Norway(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -4544,13 +4587,13 @@ class Norway(Country):
             Bunker_with_Fire_Control_Center = vehicles.Fortification.Bunker_with_Fire_Control_Center
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
 
@@ -4561,6 +4604,7 @@ class Norway(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -4681,6 +4725,7 @@ class Norway(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -4814,17 +4859,17 @@ class Denmark(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -4839,17 +4884,18 @@ class Denmark(Country):
             Bunker_with_Fire_Control_Center = vehicles.Fortification.Bunker_with_Fire_Control_Center
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -5110,7 +5156,7 @@ class Israel(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class AirDefence:
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
@@ -5122,7 +5168,7 @@ class Israel(Country):
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
@@ -5132,7 +5178,7 @@ class Israel(Country):
             MANPADS_Stinger_C2_Desert = vehicles.AirDefence.MANPADS_Stinger_C2_Desert
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
 
         class Fortification:
@@ -5146,7 +5192,7 @@ class Israel(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
 
         class Armor:
@@ -5155,14 +5201,14 @@ class Israel(Country):
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_Merkava_IV = vehicles.Armor.MBT_Merkava_IV
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
 
@@ -5309,6 +5355,7 @@ class Israel(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -5445,8 +5492,8 @@ class Georgia(Country):
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
         class Infantry:
@@ -5503,26 +5550,27 @@ class Georgia(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
@@ -5795,7 +5843,7 @@ class Insurgents(Country):
 
         class Artillery:
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
 
@@ -5808,8 +5856,8 @@ class Insurgents(Country):
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_13_Strela_10M3_Gopher_TEL = vehicles.AirDefence.SAM_SA_13_Strela_10M3_Gopher_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             MANPADS_SA_18_Igla_Grouse_Ins = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_Ins
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
@@ -5844,13 +5892,14 @@ class Insurgents(Country):
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
@@ -6018,7 +6067,7 @@ class Abkhazia(Country):
         class Artillery:
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
@@ -6030,7 +6079,7 @@ class Abkhazia(Country):
         class AirDefence:
             SAM_SA_19_Tunguska_Grison = vehicles.AirDefence.SAM_SA_19_Tunguska_Grison
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_11_Buk_Gadfly_C2 = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_C2
@@ -6069,21 +6118,22 @@ class Abkhazia(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -6268,7 +6318,7 @@ class SouthOssetia(Country):
         class Artillery:
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
@@ -6312,21 +6362,22 @@ class SouthOssetia(Country):
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -6491,18 +6542,18 @@ class Italy(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
 
         class AirDefence:
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -6515,10 +6566,10 @@ class Italy(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
@@ -6527,9 +6578,9 @@ class Italy(Country):
             APC_M113 = vehicles.Armor.APC_M113
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -6668,6 +6719,7 @@ class Italy(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -6802,7 +6854,7 @@ class Australia(Country):
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
             SAM_Rapier_Tracker = vehicles.AirDefence.SAM_Rapier_Tracker
             SAM_Rapier_Blindfire_TR = vehicles.AirDefence.SAM_Rapier_Blindfire_TR
@@ -6821,7 +6873,7 @@ class Australia(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
@@ -6839,7 +6891,7 @@ class Australia(Country):
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
             APC_M113 = vehicles.Armor.APC_M113
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
@@ -6959,6 +7011,7 @@ class Australia(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         CH_47D = helicopters.CH_47D
+        SH_60B = helicopters.SH_60B
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         SA342M = helicopters.SA342M
@@ -6969,6 +7022,7 @@ class Australia(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.CH_47D,
+        Helicopter.SH_60B,
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.SA342M,
@@ -6981,6 +7035,7 @@ class Australia(Country):
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
@@ -7120,7 +7175,7 @@ class Switzerland(Country):
         class AirDefence:
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
             SAM_Rapier_Tracker = vehicles.AirDefence.SAM_Rapier_Tracker
             SAM_Rapier_Blindfire_TR = vehicles.AirDefence.SAM_Rapier_Blindfire_TR
@@ -7141,7 +7196,7 @@ class Switzerland(Country):
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
 
         class Armor:
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             APC_M113 = vehicles.Armor.APC_M113
 
         class Locomotive:
@@ -7151,6 +7206,7 @@ class Switzerland(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -7389,7 +7445,7 @@ class Austria(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -7420,6 +7476,7 @@ class Austria(Country):
         class Carriage:
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
@@ -7655,12 +7712,12 @@ class Belarus(Country):
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
 
         class Infantry:
@@ -7674,7 +7731,7 @@ class Belarus(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -7698,6 +7755,7 @@ class Belarus(Country):
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -7723,30 +7781,32 @@ class Belarus(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -7940,7 +8000,6 @@ class Bulgaria(Country):
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -7953,7 +8012,7 @@ class Bulgaria(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_10_S_300_Grumble_Flap_Lid_TR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR
@@ -7966,6 +8025,7 @@ class Bulgaria(Country):
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
             AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
@@ -7991,7 +8051,7 @@ class Bulgaria(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
@@ -8005,14 +8065,15 @@ class Bulgaria(Country):
             LUV_Horch_901_Staff_Car = vehicles.Unarmed.LUV_Horch_901_Staff_Car
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -8020,6 +8081,7 @@ class Bulgaria(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -8297,11 +8359,11 @@ class CzechRepublic(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
@@ -8335,12 +8397,12 @@ class CzechRepublic(Country):
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
@@ -8612,7 +8674,7 @@ class China(Country):
         class Artillery:
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             PLZ_05 = vehicles.Artillery.PLZ_05
 
         class AirDefence:
@@ -8624,7 +8686,7 @@ class China(Country):
             SAM_SA_10_S_300_Grumble_TEL_C = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_C
             SAM_SA_10_S_300_Grumble_C2 = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_C2
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
@@ -8634,6 +8696,7 @@ class China(Country):
             HQ_7_Self_Propelled_STR = vehicles.AirDefence.HQ_7_Self_Propelled_STR
             HQ_7_Self_Propelled_LN = vehicles.AirDefence.HQ_7_Self_Propelled_LN
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -8647,12 +8710,12 @@ class China(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             ZBD_04A = vehicles.Armor.ZBD_04A
             ZTZ_96B = vehicles.Armor.ZTZ_96B
 
@@ -8803,6 +8866,7 @@ class China(Country):
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
         Type_071_Amphibious_Transport_Dock = ships.Type_071_Amphibious_Transport_Dock
         Type_093_Attack_Submarine = ships.Type_093_Attack_Submarine
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignHelipad:
         Otkrytka = "Otkrytka"
@@ -8854,7 +8918,7 @@ class Croatia(Country):
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
 
         class Fortification:
@@ -8873,7 +8937,7 @@ class Croatia(Country):
 
         class Armor:
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
         class Locomotive:
@@ -9121,13 +9185,13 @@ class Egypt(Country):
     class Vehicle:
 
         class Artillery:
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
@@ -9137,7 +9201,7 @@ class Egypt(Country):
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
@@ -9145,7 +9209,7 @@ class Egypt(Country):
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_10_S_300_Grumble_Flap_Lid_TR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR
             SAM_SA_10_S_300_Grumble_Clam_Shell_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR
@@ -9166,6 +9230,7 @@ class Egypt(Country):
             MANPADS_Stinger_C2_Desert = vehicles.AirDefence.MANPADS_Stinger_C2_Desert
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -9179,24 +9244,25 @@ class Egypt(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_80U = vehicles.Armor.MBT_T_80U
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -9330,6 +9396,7 @@ class Egypt(Country):
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Corvette_1241_1_Molniya = ships.Corvette_1241_1_Molniya
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -9464,13 +9531,12 @@ class Finland(Country):
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_37 = vehicles.AirDefence.AAA_8_8cm_Flak_37
             AAA_Flak_38_20mm = vehicles.AirDefence.AAA_Flak_38_20mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
@@ -9530,7 +9596,9 @@ class Finland(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            LT_PT_76 = vehicles.Armor.LT_PT_76
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -9538,6 +9606,7 @@ class Finland(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -9552,6 +9621,7 @@ class Finland(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -9788,7 +9858,7 @@ class Greece(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
 
         class Infantry:
@@ -9812,16 +9882,17 @@ class Greece(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_SA_10_S_300_Grumble_Flap_Lid_TR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR
             SAM_SA_10_S_300_Grumble_Clam_Shell_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR
             SAM_SA_10_S_300_Grumble_Big_Bird_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Big_Bird_SR
             SAM_SA_10_S_300_Grumble_TEL_D = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_D
             SAM_SA_10_S_300_Grumble_TEL_C = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_C
             SAM_SA_10_S_300_Grumble_C2 = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_18 = vehicles.AirDefence.AAA_8_8cm_Flak_18
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -9834,9 +9905,9 @@ class Greece(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
@@ -9844,10 +9915,10 @@ class Greece(Country):
         class Armor:
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
@@ -9861,6 +9932,7 @@ class Greece(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -9988,6 +10060,7 @@ class Greece(Country):
 
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -10123,7 +10196,6 @@ class Hungary(Country):
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -10138,7 +10210,7 @@ class Hungary(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
@@ -10170,7 +10242,7 @@ class Hungary(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
@@ -10183,20 +10255,21 @@ class Hungary(Country):
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_MTLB = vehicles.Armor.APC_MTLB
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -10212,6 +10285,7 @@ class Hungary(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
@@ -10466,7 +10540,7 @@ class India(Country):
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -10476,7 +10550,7 @@ class India(Country):
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
@@ -10504,14 +10578,15 @@ class India(Country):
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -10651,6 +10726,7 @@ class India(Country):
         SSK_877V_Kilo = ships.SSK_877V_Kilo
         Corvette_1241_1_Molniya = ships.Corvette_1241_1_Molniya
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -10791,7 +10867,7 @@ class Iran(Country):
             Infantry_RPG = vehicles.Infantry.Infantry_RPG
 
         class AirDefence:
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_SA_10_S_300_Grumble_Flap_Lid_TR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR
             SAM_SA_10_S_300_Grumble_Clam_Shell_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR
@@ -10799,13 +10875,13 @@ class Iran(Country):
             SAM_SA_10_S_300_Grumble_TEL_D = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_D
             SAM_SA_10_S_300_Grumble_TEL_C = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_C
             SAM_SA_10_S_300_Grumble_C2 = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_C2
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             MANPADS_SA_18_Igla_Grouse_Ins = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_Ins
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_SA_11_Buk_Gadfly_Snow_Drift_SR = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Snow_Drift_SR
@@ -10822,6 +10898,7 @@ class Iran(Country):
             HQ_7_Self_Propelled_STR = vehicles.AirDefence.HQ_7_Self_Propelled_STR
             HQ_7_Self_Propelled_LN = vehicles.AirDefence.HQ_7_Self_Propelled_LN
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -10848,8 +10925,8 @@ class Iran(Country):
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -11000,6 +11077,8 @@ class Iran(Country):
         Bulker_Yakushev = ships.Bulker_Yakushev
         Cargo_Ivanov = ships.Cargo_Ivanov
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -11137,9 +11216,9 @@ class Iraq(Country):
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -11150,7 +11229,7 @@ class Iraq(Country):
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
@@ -11176,24 +11255,25 @@ class Iraq(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -11456,18 +11536,17 @@ class Japan(Country):
 
         class Artillery:
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Patriot_CR__AMG_AN_MRC_137 = vehicles.AirDefence.SAM_Patriot_CR__AMG_AN_MRC_137
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
@@ -11503,7 +11582,7 @@ class Japan(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_Opel_Blitz = vehicles.Unarmed.Truck_Opel_Blitz
             LUV_Kubelwagen_82 = vehicles.Unarmed.LUV_Kubelwagen_82
             LUV_Kettenrad = vehicles.Unarmed.LUV_Kettenrad
@@ -11511,8 +11590,8 @@ class Japan(Country):
             LUV_Horch_901_Staff_Car = vehicles.Unarmed.LUV_Horch_901_Staff_Car
 
         class Armor:
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -11520,6 +11599,7 @@ class Japan(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -11648,6 +11728,7 @@ class Japan(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         U_boat_VIIC_U_flak = ships.U_boat_VIIC_U_flak
         Boat_Schnellboot_type_S130 = ships.Boat_Schnellboot_type_S130
 
@@ -11783,9 +11864,9 @@ class Kazakhstan(Country):
         class Artillery:
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
@@ -11808,7 +11889,7 @@ class Kazakhstan(Country):
             SAM_SA_11_Buk_Gadfly_Snow_Drift_SR = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Snow_Drift_SR
             SAM_SA_11_Buk_Gadfly_C2 = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_C2
             SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
@@ -11828,6 +11909,7 @@ class Kazakhstan(Country):
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
 
@@ -11861,28 +11943,28 @@ class Kazakhstan(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             MBT_T_80U = vehicles.Armor.MBT_T_80U
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -12188,11 +12270,12 @@ class NorthKorea(Country):
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -12452,7 +12535,7 @@ class Pakistan(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -12481,9 +12564,10 @@ class Pakistan(Country):
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             AShM_SS_N_2_Silkworm = vehicles.MissilesSS.AShM_SS_N_2_Silkworm
@@ -12613,6 +12697,7 @@ class Pakistan(Country):
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -12752,7 +12837,7 @@ class Poland(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -12761,7 +12846,7 @@ class Poland(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
@@ -12782,7 +12867,7 @@ class Poland(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
@@ -12796,21 +12881,23 @@ class Poland(Country):
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
+            LT_PT_76 = vehicles.Armor.LT_PT_76
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
@@ -12828,6 +12915,7 @@ class Poland(Country):
         class Carriage:
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
@@ -12957,6 +13045,7 @@ class Poland(Country):
         SSK_877V_Kilo = ships.SSK_877V_Kilo
         Corvette_1241_1_Molniya = ships.Corvette_1241_1_Molniya
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         LST_Mk_II = ships.LST_Mk_II
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
@@ -13093,7 +13182,6 @@ class Romania(Country):
         class Artillery:
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -13105,7 +13193,7 @@ class Romania(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
@@ -13135,7 +13223,7 @@ class Romania(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
@@ -13150,18 +13238,19 @@ class Romania(Country):
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
             MT_Pz_Kpfw_V_Panther_Ausf_G = vehicles.Armor.MT_Pz_Kpfw_V_Panther_Ausf_G
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -13294,6 +13383,7 @@ class Romania(Country):
         SSK_877V_Kilo = ships.SSK_877V_Kilo
         Corvette_1241_1_Molniya = ships.Corvette_1241_1_Molniya
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         U_boat_VIIC_U_flak = ships.U_boat_VIIC_U_flak
         Boat_Schnellboot_type_S130 = ships.Boat_Schnellboot_type_S130
 
@@ -13429,7 +13519,7 @@ class SaudiArabia(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
 
         class AirDefence:
@@ -13444,10 +13534,10 @@ class SaudiArabia(Country):
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -13460,20 +13550,20 @@ class SaudiArabia(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
 
         class Locomotive:
@@ -13609,6 +13699,7 @@ class SaudiArabia(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -13754,7 +13845,7 @@ class Serbia(Country):
             SAM_SA_11_Buk_Gadfly_Snow_Drift_SR = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Snow_Drift_SR
             SAM_SA_11_Buk_Gadfly_C2 = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_C2
             SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_13_Strela_10M3_Gopher_TEL = vehicles.AirDefence.SAM_SA_13_Strela_10M3_Gopher_TEL
@@ -13766,7 +13857,7 @@ class Serbia(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
 
@@ -13789,11 +13880,11 @@ class Serbia(Country):
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
@@ -13802,11 +13893,11 @@ class Serbia(Country):
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_72B = vehicles.Armor.MBT_T_72B
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -14069,7 +14160,7 @@ class Slovakia(Country):
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_10_S_300_Grumble_TEL_D = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_D
             SAM_SA_10_S_300_Grumble_TEL_C = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_C
             SAM_SA_10_S_300_Grumble_C2 = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_C2
@@ -14079,6 +14170,7 @@ class Slovakia(Country):
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -14092,7 +14184,7 @@ class Slovakia(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
@@ -14101,7 +14193,7 @@ class Slovakia(Country):
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
@@ -14360,15 +14452,15 @@ class SouthKorea(Country):
 
         class Artillery:
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Patriot_CR__AMG_AN_MRC_137 = vehicles.AirDefence.SAM_Patriot_CR__AMG_AN_MRC_137
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
@@ -14393,7 +14485,7 @@ class SouthKorea(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
@@ -14402,7 +14494,7 @@ class SouthKorea(Country):
             APC_M113 = vehicles.Armor.APC_M113
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             MBT_T_80U = vehicles.Armor.MBT_T_80U
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -14531,6 +14623,7 @@ class SouthKorea(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -14662,11 +14755,11 @@ class Sweden(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
 
         class Fortification:
@@ -14681,12 +14774,12 @@ class Sweden(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -14695,6 +14788,7 @@ class Sweden(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -14938,7 +15032,7 @@ class Syria(Country):
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
@@ -14953,7 +15047,7 @@ class Syria(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL = vehicles.AirDefence.SAM_SA_11_Buk_Gadfly_Fire_Dome_TEL
@@ -14979,21 +15073,23 @@ class Syria(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
+            LT_PT_76 = vehicles.Armor.LT_PT_76
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -15251,13 +15347,13 @@ class Yemen(Country):
     class Vehicle:
 
         class Artillery:
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
@@ -15267,7 +15363,7 @@ class Yemen(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
@@ -15284,13 +15380,13 @@ class Yemen(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
@@ -15557,7 +15653,7 @@ class Vietnam(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -15566,7 +15662,7 @@ class Vietnam(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_10_S_300_Grumble_TEL_D = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_D
             SAM_SA_10_S_300_Grumble_TEL_C = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_TEL_C
@@ -15578,6 +15674,7 @@ class Vietnam(Country):
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -15595,11 +15692,12 @@ class Vietnam(Country):
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_90 = vehicles.Armor.MBT_T_90
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -15867,7 +15965,7 @@ class Venezuela(Country):
 
         class AirDefence:
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -15885,6 +15983,7 @@ class Venezuela(Country):
             SAM_SA_15_Tor_Gauntlet = vehicles.AirDefence.SAM_SA_15_Tor_Gauntlet
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
             MANPADS_SA_18_Igla_S_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -16166,11 +16265,11 @@ class Tunisia(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
 
         class Locomotive:
@@ -16412,7 +16511,7 @@ class Thailand(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
@@ -16432,12 +16531,12 @@ class Thailand(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
 
@@ -16562,6 +16661,7 @@ class Thailand(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -16698,7 +16798,7 @@ class Sudan(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
@@ -16717,14 +16817,14 @@ class Sudan(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
@@ -16978,7 +17078,7 @@ class Philippines(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -16992,14 +17092,14 @@ class Philippines(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -17257,7 +17357,7 @@ class Morocco(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             SAM_SA_19_Tunguska_Grison = vehicles.AirDefence.SAM_SA_19_Tunguska_Grison
@@ -17281,8 +17381,8 @@ class Morocco(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
@@ -17290,7 +17390,7 @@ class Morocco(Country):
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
             MBT_T_72B = vehicles.Armor.MBT_T_72B
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
 
         class Locomotive:
@@ -17540,7 +17640,7 @@ class Mexico(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
 
@@ -17556,13 +17656,13 @@ class Mexico(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -17681,6 +17781,7 @@ class Mexico(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -17812,7 +17913,7 @@ class Malaysia(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
             MANPADS_SA_18_Igla_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse_C2
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
@@ -17950,6 +18051,8 @@ class Malaysia(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -18088,7 +18191,7 @@ class Libya(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -18097,7 +18200,7 @@ class Libya(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
@@ -18124,7 +18227,7 @@ class Libya(Country):
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
 
@@ -18245,6 +18348,7 @@ class Libya(Country):
 
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -18376,12 +18480,12 @@ class Jordan(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
@@ -18403,14 +18507,14 @@ class Jordan(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
             IFV_Marder = vehicles.Armor.IFV_Marder
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
@@ -18668,7 +18772,7 @@ class Indonesia(Country):
 
         class AirDefence:
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
@@ -18702,7 +18806,8 @@ class Indonesia(Country):
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             IFV_Marder = vehicles.Armor.IFV_Marder
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -18711,6 +18816,7 @@ class Indonesia(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -18829,6 +18935,7 @@ class Indonesia(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -18971,10 +19078,10 @@ class Honduras(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
 
         class Locomotive:
@@ -19234,7 +19341,7 @@ class Ethiopia(Country):
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
@@ -19251,17 +19358,17 @@ class Ethiopia(Country):
 
         class Unarmed:
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             MBT_T_55 = vehicles.Armor.MBT_T_55
             MBT_T_72B = vehicles.Armor.MBT_T_72B
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -19516,7 +19623,7 @@ class Chile(Country):
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             SPAAA_Gepard = vehicles.AirDefence.SPAAA_Gepard
@@ -19532,17 +19639,18 @@ class Chile(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
 
         class Armor:
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             IFV_Marder = vehicles.Armor.IFV_Marder
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -19551,6 +19659,7 @@ class Chile(Country):
             Loco_DRG_Class_86 = vehicles.Locomotive.Loco_DRG_Class_86
 
         class Carriage:
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Freight_Van = vehicles.Carriage.Freight_Van
             Open_Wagon = vehicles.Carriage.Open_Wagon
             Tank_Car_blue = vehicles.Carriage.Tank_Car_blue
@@ -19671,6 +19780,7 @@ class Chile(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -19811,7 +19921,7 @@ class Brazil(Country):
         class AirDefence:
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
@@ -19832,7 +19942,7 @@ class Brazil(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
@@ -19841,7 +19951,7 @@ class Brazil(Country):
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
 
         class Locomotive:
             Loco_ES44AH = vehicles.Locomotive.Loco_ES44AH
@@ -19958,6 +20068,7 @@ class Brazil(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -20091,7 +20202,7 @@ class Bahrain(Country):
         class Artillery:
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
 
         class Infantry:
             Infantry_M4 = vehicles.Infantry.Infantry_M4
@@ -20103,10 +20214,10 @@ class Bahrain(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -20120,12 +20231,12 @@ class Bahrain(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             APC_M113 = vehicles.Armor.APC_M113
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
 
@@ -20368,9 +20479,6 @@ class ThirdReich(Country):
 
     class Vehicle:
 
-        class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
-
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
@@ -20407,7 +20515,7 @@ class ThirdReich(Country):
             LUV_Horch_901_Staff_Car = vehicles.Unarmed.LUV_Horch_901_Staff_Car
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -20415,6 +20523,7 @@ class ThirdReich(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -20673,11 +20782,11 @@ class Yugoslavia(Country):
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             SAM_SA_3_S_125_Low_Blow_TR = vehicles.AirDefence.SAM_SA_3_S_125_Low_Blow_TR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
             AAA_M1_37mm = vehicles.AirDefence.AAA_M1_37mm
@@ -20702,9 +20811,10 @@ class Yugoslavia(Country):
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
@@ -20885,13 +20995,13 @@ class USSR(Country):
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
 
@@ -20906,7 +21016,7 @@ class USSR(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -20931,9 +21041,10 @@ class USSR(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_8_8cm_Flak_36 = vehicles.AirDefence.AAA_8_8cm_Flak_36
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -20961,10 +21072,10 @@ class USSR(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
@@ -20972,6 +21083,8 @@ class USSR(Country):
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             Car_Willys_Jeep = vehicles.Unarmed.Car_Willys_Jeep
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
@@ -20982,7 +21095,7 @@ class USSR(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -20992,10 +21105,11 @@ class USSR(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
@@ -21233,9 +21347,6 @@ class ItalianSocialRepublic(Country):
 
     class Vehicle:
 
-        class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
-
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
 
@@ -21272,7 +21383,7 @@ class ItalianSocialRepublic(Country):
             LUV_Horch_901_Staff_Car = vehicles.Unarmed.LUV_Horch_901_Staff_Car
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -21280,6 +21391,7 @@ class ItalianSocialRepublic(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -21544,7 +21656,7 @@ class Algeria(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -21566,10 +21678,11 @@ class Algeria(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             HQ_7_Self_Propelled_LN = vehicles.AirDefence.HQ_7_Self_Propelled_LN
             HQ_7_Self_Propelled_STR = vehicles.AirDefence.HQ_7_Self_Propelled_STR
 
@@ -21589,7 +21702,7 @@ class Algeria(Country):
             Truck_GAZ_3307 = vehicles.Unarmed.Truck_GAZ_3307
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_GAZ_66 = vehicles.Unarmed.Truck_GAZ_66
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Bus_LAZ_695 = vehicles.Unarmed.Bus_LAZ_695
@@ -21597,23 +21710,24 @@ class Algeria(Country):
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
@@ -21923,7 +22037,7 @@ class Kuwait(Country):
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Patriot_CR__AMG_AN_MRC_137 = vehicles.AirDefence.SAM_Patriot_CR__AMG_AN_MRC_137
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
@@ -21945,12 +22059,12 @@ class Kuwait(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
@@ -22207,7 +22321,7 @@ class Qatar(Country):
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
@@ -22230,12 +22344,12 @@ class Qatar(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
 
         class Armor:
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
 
         class Locomotive:
@@ -22493,7 +22607,7 @@ class Oman(Country):
             SAM_Patriot_EPP_III = vehicles.AirDefence.SAM_Patriot_EPP_III
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             MANPADS_Stinger_C2_Desert = vehicles.AirDefence.MANPADS_Stinger_C2_Desert
@@ -22512,9 +22626,9 @@ class Oman(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
@@ -22522,7 +22636,7 @@ class Oman(Country):
         class Armor:
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
 
@@ -22644,6 +22758,7 @@ class Oman(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -22788,11 +22903,11 @@ class UnitedArabEmirates(Country):
             SAM_Patriot_ECS = vehicles.AirDefence.SAM_Patriot_ECS
             SAM_Patriot_C2_ICC = vehicles.AirDefence.SAM_Patriot_C2_ICC
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Hawk_TR__AN_MPQ_46 = vehicles.AirDefence.SAM_Hawk_TR__AN_MPQ_46
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Rapier_LN = vehicles.AirDefence.SAM_Rapier_LN
             SAM_Rapier_Tracker = vehicles.AirDefence.SAM_Rapier_Tracker
@@ -22812,7 +22927,7 @@ class UnitedArabEmirates(Country):
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
@@ -22821,7 +22936,7 @@ class UnitedArabEmirates(Country):
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -22953,6 +23068,7 @@ class UnitedArabEmirates(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -23086,7 +23202,7 @@ class SouthAfrica(Country):
         class AirDefence:
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -23103,7 +23219,7 @@ class SouthAfrica(Country):
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
 
         class Armor:
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
 
         class Locomotive:
@@ -23223,6 +23339,7 @@ class SouthAfrica(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -23378,7 +23495,7 @@ class Cuba(Country):
             SAM_SA_2_S_75_Fan_Song_TR = vehicles.AirDefence.SAM_SA_2_S_75_Fan_Song_TR
             SAM_SA_2_S_75_Guideline_LN = vehicles.AirDefence.SAM_SA_2_S_75_Guideline_LN
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             MANPADS_SA_18_Igla_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_Grouse
@@ -23404,19 +23521,20 @@ class Cuba(Country):
             Bus_IKARUS_280 = vehicles.Unarmed.Bus_IKARUS_280
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
 
         class Armor:
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55
             IFV_BMD_1 = vehicles.Armor.IFV_BMD_1
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
+            LT_PT_76 = vehicles.Armor.LT_PT_76
 
         class MissilesSS:
             SSM_SS_1C_Scud_B = vehicles.MissilesSS.SSM_SS_1C_Scud_B
@@ -23699,7 +23817,7 @@ class Portugal(Country):
             MANPADS_Stinger = vehicles.AirDefence.MANPADS_Stinger
             MANPADS_Stinger_C2 = vehicles.AirDefence.MANPADS_Stinger_C2
             SPAAA_Vulcan_M163 = vehicles.AirDefence.SPAAA_Vulcan_M163
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             MANPADS_Stinger_C2_Desert = vehicles.AirDefence.MANPADS_Stinger_C2_Desert
 
         class Fortification:
@@ -23717,7 +23835,7 @@ class Portugal(Country):
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
 
         class Armor:
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
@@ -23997,11 +24115,12 @@ class GDR(Country):
             SAM_SA_10_S_300_Grumble_Clam_Shell_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR
             SAM_SA_10_S_300_Grumble_Big_Bird_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Big_Bird_SR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
 
         class Fortification:
             Bunker_2 = vehicles.Fortification.Bunker_2
@@ -24014,22 +24133,23 @@ class GDR(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             GPU_APA_80_on_ZIL_131 = vehicles.Unarmed.GPU_APA_80_on_ZIL_131
             Refueler_ATMZ_5 = vehicles.Unarmed.Refueler_ATMZ_5
             Refueler_ATZ_10 = vehicles.Unarmed.Refueler_ATZ_10
             Truck_GAZ_66 = vehicles.Unarmed.Truck_GAZ_66
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
 
         class Armor:
             APC_MTLB = vehicles.Armor.APC_MTLB
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             MBT_T_55 = vehicles.Armor.MBT_T_55
@@ -24296,7 +24416,7 @@ class Lebanon(Country):
             Infantry_M4 = vehicles.Infantry.Infantry_M4
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SPAAA_ZU_23_2_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375
             SAM_SA_9_Strela_1_Gaskin_TEL = vehicles.AirDefence.SAM_SA_9_Strela_1_Gaskin_TEL
             SAM_SA_13_Strela_10M3_Gopher_TEL = vehicles.AirDefence.SAM_SA_13_Strela_10M3_Gopher_TEL
@@ -24316,7 +24436,7 @@ class Lebanon(Country):
 
         class Unarmed:
             Refueler_ATMZ_5 = vehicles.Unarmed.Refueler_ATMZ_5
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
@@ -24327,11 +24447,12 @@ class Lebanon(Country):
             APC_M113 = vehicles.Armor.APC_M113
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             MBT_T_55 = vehicles.Armor.MBT_T_55
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
 
         class Locomotive:
             Loco_VL80_Electric = vehicles.Locomotive.Loco_VL80_Electric
@@ -24446,6 +24567,7 @@ class Lebanon(Country):
     class Ship:
         Boat_Armed_Hi_speed = ships.Boat_Armed_Hi_speed
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
 
     class CallsignAWACS:
         Overlord = "Overlord"
@@ -24577,23 +24699,23 @@ class CombinedJointTaskForcesBlue(Country):
     class Vehicle:
 
         class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             PLZ_05 = vehicles.Artillery.PLZ_05
+            SPH_T155_Firtina_155mm = vehicles.Artillery.SPH_T155_Firtina_155mm
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -24626,7 +24748,7 @@ class CombinedJointTaskForcesBlue(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -24651,8 +24773,9 @@ class CombinedJointTaskForcesBlue(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -24662,12 +24785,12 @@ class CombinedJointTaskForcesBlue(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
             MANPADS_SA_18_Igla_S_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -24719,10 +24842,10 @@ class CombinedJointTaskForcesBlue(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
@@ -24730,25 +24853,27 @@ class CombinedJointTaskForcesBlue(Country):
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             Car_Willys_Jeep = vehicles.Unarmed.Car_Willys_Jeep
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -24756,6 +24881,7 @@ class CombinedJointTaskForcesBlue(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -24763,7 +24889,7 @@ class CombinedJointTaskForcesBlue(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -24773,14 +24899,15 @@ class CombinedJointTaskForcesBlue(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
@@ -24788,23 +24915,28 @@ class CombinedJointTaskForcesBlue(Country):
             MBT_T_90 = vehicles.Armor.MBT_T_90
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
             MBT_Merkava_IV = vehicles.Armor.MBT_Merkava_IV
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             IFV_Marder = vehicles.Armor.IFV_Marder
+            MBT_Leopard_2A4 = vehicles.Armor.MBT_Leopard_2A4
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             ZBD_04A = vehicles.Armor.ZBD_04A
             ZTZ_96B = vehicles.Armor.ZTZ_96B
+            MBT_Leopard_2A4_Trs = vehicles.Armor.MBT_Leopard_2A4_Trs
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             IFV_M1126_Stryker_ICV = vehicles.Armor.IFV_M1126_Stryker_ICV
             SPG_Stryker_MGS = vehicles.Armor.SPG_Stryker_MGS
             ATGM_Stryker = vehicles.Armor.ATGM_Stryker
             IFV_Warrior = vehicles.Armor.IFV_Warrior
+            MBT_Chieftain_Mk_3 = vehicles.Armor.MBT_Chieftain_Mk_3
 
         class MissilesSS:
             SSM_V_1_Launcher = vehicles.MissilesSS.SSM_V_1_Launcher
@@ -24830,6 +24962,8 @@ class CombinedJointTaskForcesBlue(Country):
             Well_Car = vehicles.Carriage.Well_Car
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
@@ -25102,9 +25236,11 @@ class CombinedJointTaskForcesBlue(Country):
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Battlecruiser_1144_2_Pyotr_Velikiy = ships.Battlecruiser_1144_2_Pyotr_Velikiy
         CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
@@ -25250,23 +25386,23 @@ class CombinedJointTaskForcesRed(Country):
     class Vehicle:
 
         class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             PLZ_05 = vehicles.Artillery.PLZ_05
+            SPH_T155_Firtina_155mm = vehicles.Artillery.SPH_T155_Firtina_155mm
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -25299,7 +25435,7 @@ class CombinedJointTaskForcesRed(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -25324,8 +25460,9 @@ class CombinedJointTaskForcesRed(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -25335,12 +25472,12 @@ class CombinedJointTaskForcesRed(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
             MANPADS_SA_18_Igla_S_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -25392,10 +25529,10 @@ class CombinedJointTaskForcesRed(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
@@ -25403,25 +25540,27 @@ class CombinedJointTaskForcesRed(Country):
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             Car_Willys_Jeep = vehicles.Unarmed.Car_Willys_Jeep
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -25429,6 +25568,7 @@ class CombinedJointTaskForcesRed(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -25436,7 +25576,7 @@ class CombinedJointTaskForcesRed(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -25446,14 +25586,15 @@ class CombinedJointTaskForcesRed(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
@@ -25461,23 +25602,28 @@ class CombinedJointTaskForcesRed(Country):
             MBT_T_90 = vehicles.Armor.MBT_T_90
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
             MBT_Merkava_IV = vehicles.Armor.MBT_Merkava_IV
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             IFV_Marder = vehicles.Armor.IFV_Marder
+            MBT_Leopard_2A4 = vehicles.Armor.MBT_Leopard_2A4
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             ZBD_04A = vehicles.Armor.ZBD_04A
             ZTZ_96B = vehicles.Armor.ZTZ_96B
+            MBT_Leopard_2A4_Trs = vehicles.Armor.MBT_Leopard_2A4_Trs
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             IFV_M1126_Stryker_ICV = vehicles.Armor.IFV_M1126_Stryker_ICV
             SPG_Stryker_MGS = vehicles.Armor.SPG_Stryker_MGS
             ATGM_Stryker = vehicles.Armor.ATGM_Stryker
             IFV_Warrior = vehicles.Armor.IFV_Warrior
+            MBT_Chieftain_Mk_3 = vehicles.Armor.MBT_Chieftain_Mk_3
 
         class MissilesSS:
             SSM_V_1_Launcher = vehicles.MissilesSS.SSM_V_1_Launcher
@@ -25503,6 +25649,8 @@ class CombinedJointTaskForcesRed(Country):
             Well_Car = vehicles.Carriage.Well_Car
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
@@ -25775,9 +25923,11 @@ class CombinedJointTaskForcesRed(Country):
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Battlecruiser_1144_2_Pyotr_Velikiy = ships.Battlecruiser_1144_2_Pyotr_Velikiy
         CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
@@ -25923,23 +26073,23 @@ class UnitedNationsPeacekeepers(Country):
     class Vehicle:
 
         class Artillery:
-            SPG_Sturmpanzer_IV_Brummbar = vehicles.Artillery.SPG_Sturmpanzer_IV_Brummbar
             Mortar_2B11_120mm = vehicles.Artillery.Mortar_2B11_120mm
             Grad_MRL_FDDM__FC = vehicles.Artillery.Grad_MRL_FDDM__FC
             MLRS_BM_21_Grad_122mm = vehicles.Artillery.MLRS_BM_21_Grad_122mm
-            SPH_2S9_Nona_120mm_M = vehicles.Artillery.SPH_2S9_Nona_120mm_M
+            SPM_2S9_Nona_120mm_M = vehicles.Artillery.SPM_2S9_Nona_120mm_M
             SPH_2S3_Akatsia_152mm = vehicles.Artillery.SPH_2S3_Akatsia_152mm
             SPH_2S1_Gvozdika_122mm = vehicles.Artillery.SPH_2S1_Gvozdika_122mm
             SPH_2S19_Msta_152mm = vehicles.Artillery.SPH_2S19_Msta_152mm
             MLRS_9A52_Smerch_CM_300mm = vehicles.Artillery.MLRS_9A52_Smerch_CM_300mm
             MLRS_9A52_Smerch_HE_300mm = vehicles.Artillery.MLRS_9A52_Smerch_HE_300mm
-            MLRS_BM_27_Uragan_220mm = vehicles.Artillery.MLRS_BM_27_Uragan_220mm
+            MLRS_9K57_Uragan_BM_27_220mm = vehicles.Artillery.MLRS_9K57_Uragan_BM_27_220mm
             SPH_Dana_vz77_152mm = vehicles.Artillery.SPH_Dana_vz77_152mm
             SPG_M12_GMC_155mm = vehicles.Artillery.SPG_M12_GMC_155mm
             SPH_M109_Paladin_155mm = vehicles.Artillery.SPH_M109_Paladin_155mm
             MLRS_M270_227mm = vehicles.Artillery.MLRS_M270_227mm
-            HUMVEE_JTAC = vehicles.Artillery.HUMVEE_JTAC
+            MRLS_FDDM__FC = vehicles.Artillery.MRLS_FDDM__FC
             PLZ_05 = vehicles.Artillery.PLZ_05
+            SPH_T155_Firtina_155mm = vehicles.Artillery.SPH_T155_Firtina_155mm
 
         class Infantry:
             Infantry_Mauser_98 = vehicles.Infantry.Infantry_Mauser_98
@@ -25972,7 +26122,7 @@ class UnitedNationsPeacekeepers(Country):
             EWR_55G6 = vehicles.AirDefence.EWR_55G6
             SAM_SA_3_S_125_Goa_LN = vehicles.AirDefence.SAM_SA_3_S_125_Goa_LN
             MCC_SR_Sborka_Dog_Ear_SR = vehicles.AirDefence.MCC_SR_Sborka_Dog_Ear_SR
-            SAM_SA_6_Kub_Long_Track_STR = vehicles.AirDefence.SAM_SA_6_Kub_Long_Track_STR
+            SAM_SA_6_Kub_Straight_Flush_STR = vehicles.AirDefence.SAM_SA_6_Kub_Straight_Flush_STR
             SAM_SA_6_Kub_Gainful_TEL = vehicles.AirDefence.SAM_SA_6_Kub_Gainful_TEL
             SAM_SA_8_Osa_Gecko_TEL = vehicles.AirDefence.SAM_SA_8_Osa_Gecko_TEL
             SAM_P19_Flat_Face_SR__SA_2_3 = vehicles.AirDefence.SAM_P19_Flat_Face_SR__SA_2_3
@@ -25997,8 +26147,9 @@ class UnitedNationsPeacekeepers(Country):
             SPAAA_ZSU_23_4_Shilka_Gun_Dish = vehicles.AirDefence.SPAAA_ZSU_23_4_Shilka_Gun_Dish
             AAA_ZU_23_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement
             AAA_ZU_23_Emplacement = vehicles.AirDefence.AAA_ZU_23_Emplacement
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             AAA_S_60_57mm = vehicles.AirDefence.AAA_S_60_57mm
+            Disel_Power_Station_5I57A = vehicles.AirDefence.Disel_Power_Station_5I57A
             SPAAA_ZSU_57_2 = vehicles.AirDefence.SPAAA_ZSU_57_2
             AAA_QF_3_7 = vehicles.AirDefence.AAA_QF_3_7
             AAA_M45_Quadmount_HB_12_7mm = vehicles.AirDefence.AAA_M45_Quadmount_HB_12_7mm
@@ -26008,12 +26159,12 @@ class UnitedNationsPeacekeepers(Country):
             SAM_Hawk_SR__AN_MPQ_50 = vehicles.AirDefence.SAM_Hawk_SR__AN_MPQ_50
             SAM_Hawk_LN_M192 = vehicles.AirDefence.SAM_Hawk_LN_M192
             SAM_Hawk_CWAR_AN_MPQ_55 = vehicles.AirDefence.SAM_Hawk_CWAR_AN_MPQ_55
-            SAM_Hawk_Generator__PCP = vehicles.AirDefence.SAM_Hawk_Generator__PCP
+            SAM_Hawk_Platoon_Command_Post__PCP = vehicles.AirDefence.SAM_Hawk_Platoon_Command_Post__PCP
             SAM_Chaparral_M48 = vehicles.AirDefence.SAM_Chaparral_M48
             MANPADS_SA_18_Igla_S_Grouse = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse
             MANPADS_SA_18_Igla_S_Grouse_C2 = vehicles.AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2
-            AAA_ZU_23_Closed_Emplacement_Insurgent = vehicles.AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent
-            AAA_ZU_23_Insurgent = vehicles.AirDefence.AAA_ZU_23_Insurgent
+            AAA_ZU_23_Insurgent_Closed_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement
+            AAA_ZU_23_Insurgent_Emplacement = vehicles.AirDefence.AAA_ZU_23_Insurgent_Emplacement
             SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375 = vehicles.AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375
             SAM_Avenger__Stinger = vehicles.AirDefence.SAM_Avenger__Stinger
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
@@ -26065,10 +26216,10 @@ class UnitedNationsPeacekeepers(Country):
             Truck_SKP_11_Mobile_ATC = vehicles.Unarmed.Truck_SKP_11_Mobile_ATC
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
             LUV_UAZ_469_Jeep = vehicles.Unarmed.LUV_UAZ_469_Jeep
-            Truck_Ural_ATsP_6_Firefighter = vehicles.Unarmed.Truck_Ural_ATsP_6_Firefighter
+            Firefighter_Ural_ATsP_6 = vehicles.Unarmed.Firefighter_Ural_ATsP_6
             Truck_Ural_375_Mobile_C2 = vehicles.Unarmed.Truck_Ural_375_Mobile_C2
             Truck_Ural_375 = vehicles.Unarmed.Truck_Ural_375
-            GPU_APA_5D = vehicles.Unarmed.GPU_APA_5D
+            GPU_APA_5D_on_Ural_4320 = vehicles.Unarmed.GPU_APA_5D_on_Ural_4320
             Truck_Ural_4320_31_Arm_d = vehicles.Unarmed.Truck_Ural_4320_31_Arm_d
             Truck_Ural_4320T = vehicles.Unarmed.Truck_Ural_4320T
             Car_VAZ_2109 = vehicles.Unarmed.Car_VAZ_2109
@@ -26076,25 +26227,27 @@ class UnitedNationsPeacekeepers(Country):
             Truck_ZIL_131__C2 = vehicles.Unarmed.Truck_ZIL_131__C2
             Truck_ZIL_4331 = vehicles.Unarmed.Truck_ZIL_4331
             Car_Willys_Jeep = vehicles.Unarmed.Car_Willys_Jeep
+            Refueler_ATZ_5 = vehicles.Unarmed.Refueler_ATZ_5
+            Fire_Fight_Vehicle_AA_7_2_60 = vehicles.Unarmed.Fire_Fight_Vehicle_AA_7_2_60
             Truck_Bedford = vehicles.Unarmed.Truck_Bedford
             Truck_GMC_Jimmy_6x6_Truck = vehicles.Unarmed.Truck_GMC_Jimmy_6x6_Truck
             Carrier_M30_Cargo = vehicles.Unarmed.Carrier_M30_Cargo
             Tractor_M4_Hi_Speed = vehicles.Unarmed.Tractor_M4_Hi_Speed
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_KrAZ_6322_6x6 = vehicles.Unarmed.Truck_KrAZ_6322_6x6
             Truck_GAZ_3308 = vehicles.Unarmed.Truck_GAZ_3308
             Truck_MAZ_6303 = vehicles.Unarmed.Truck_MAZ_6303
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
             Truck_Land_Rover_101_FC = vehicles.Unarmed.Truck_Land_Rover_101_FC
             LUV_Land_Rover_109 = vehicles.Unarmed.LUV_Land_Rover_109
             MCC_Predator_UAV_CP__GCS = vehicles.Unarmed.MCC_Predator_UAV_CP__GCS
             MCC_COMM_Predator_UAV_CL = vehicles.Unarmed.MCC_COMM_Predator_UAV_CL
-            APC_Tigr = vehicles.Unarmed.APC_Tigr
+            LUV_Tigr = vehicles.Unarmed.LUV_Tigr
 
         class Armor:
-            MT_PzIV_H = vehicles.Armor.MT_PzIV_H
+            Tk_PzIV_H = vehicles.Armor.Tk_PzIV_H
             APC_Sd_Kfz_251_Halftrack = vehicles.Armor.APC_Sd_Kfz_251_Halftrack
             HT_Pz_Kpfw_VI_Tiger_I = vehicles.Armor.HT_Pz_Kpfw_VI_Tiger_I
             HT_Pz_Kpfw_VI_Ausf__B_Tiger_II = vehicles.Armor.HT_Pz_Kpfw_VI_Ausf__B_Tiger_II
@@ -26102,6 +26255,7 @@ class UnitedNationsPeacekeepers(Country):
             SPG_Jagdpanther_G1 = vehicles.Armor.SPG_Jagdpanther_G1
             SPG_Jagdpanzer_IV = vehicles.Armor.SPG_Jagdpanzer_IV
             SPG_StuG_IV = vehicles.Armor.SPG_StuG_IV
+            SPG_Sturmpanzer_IV_Brummbar = vehicles.Armor.SPG_Sturmpanzer_IV_Brummbar
             IFV_Sd_Kfz_234_2_Puma = vehicles.Armor.IFV_Sd_Kfz_234_2_Puma
             SPG_StuG_III_Ausf__G = vehicles.Armor.SPG_StuG_III_Ausf__G
             SPG_Sd_Kfz_184_Elefant = vehicles.Armor.SPG_Sd_Kfz_184_Elefant
@@ -26109,7 +26263,7 @@ class UnitedNationsPeacekeepers(Country):
             IFV_BMP_1 = vehicles.Armor.IFV_BMP_1
             IFV_BMP_2 = vehicles.Armor.IFV_BMP_2
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
             APC_BTR_RD = vehicles.Armor.APC_BTR_RD
             APC_BTR_80 = vehicles.Armor.APC_BTR_80
             APC_MTLB = vehicles.Armor.APC_MTLB
@@ -26119,14 +26273,15 @@ class UnitedNationsPeacekeepers(Country):
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
             CT_Cromwell_IV = vehicles.Armor.CT_Cromwell_IV
             CT_Centaur_IV = vehicles.Armor.CT_Centaur_IV
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             SPG_M10_GMC = vehicles.Armor.SPG_M10_GMC
             LT_Mk_VII_Tetrarch = vehicles.Armor.LT_Mk_VII_Tetrarch
+            LT_PT_76 = vehicles.Armor.LT_PT_76
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
             HIT_Churchill_VII = vehicles.Armor.HIT_Churchill_VII
             Car_Daimler_Armored = vehicles.Armor.Car_Daimler_Armored
             Car_M8_Greyhound_Armored = vehicles.Armor.Car_M8_Greyhound_Armored
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             MBT_M60A3_Patton = vehicles.Armor.MBT_M60A3_Patton
             MBT_M1A2_Abrams = vehicles.Armor.MBT_M1A2_Abrams
@@ -26134,23 +26289,28 @@ class UnitedNationsPeacekeepers(Country):
             MBT_T_90 = vehicles.Armor.MBT_T_90
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
             MBT_Leopard_1A3 = vehicles.Armor.MBT_Leopard_1A3
-            MBT_Leopard_2 = vehicles.Armor.MBT_Leopard_2
+            MBT_Leopard_2A6M = vehicles.Armor.MBT_Leopard_2A6M
             MBT_T_72B3 = vehicles.Armor.MBT_T_72B3
-            APC_BTR_82A = vehicles.Armor.APC_BTR_82A
+            IFV_BTR_82A = vehicles.Armor.IFV_BTR_82A
             IFV_M2A2_Bradley = vehicles.Armor.IFV_M2A2_Bradley
             APC_TPz_Fuchs = vehicles.Armor.APC_TPz_Fuchs
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
             IFV_LAV_25 = vehicles.Armor.IFV_LAV_25
+            ATGM_VAB_Mephisto = vehicles.Armor.ATGM_VAB_Mephisto
             MBT_Merkava_IV = vehicles.Armor.MBT_Merkava_IV
+            MBT_Leopard_2A5 = vehicles.Armor.MBT_Leopard_2A5
             IFV_Marder = vehicles.Armor.IFV_Marder
+            MBT_Leopard_2A4 = vehicles.Armor.MBT_Leopard_2A4
             MBT_Leclerc = vehicles.Armor.MBT_Leclerc
             ZBD_04A = vehicles.Armor.ZBD_04A
             ZTZ_96B = vehicles.Armor.ZTZ_96B
+            MBT_Leopard_2A4_Trs = vehicles.Armor.MBT_Leopard_2A4_Trs
             MBT_Challenger_II = vehicles.Armor.MBT_Challenger_II
             IFV_M1126_Stryker_ICV = vehicles.Armor.IFV_M1126_Stryker_ICV
             SPG_Stryker_MGS = vehicles.Armor.SPG_Stryker_MGS
             ATGM_Stryker = vehicles.Armor.ATGM_Stryker
             IFV_Warrior = vehicles.Armor.IFV_Warrior
+            MBT_Chieftain_Mk_3 = vehicles.Armor.MBT_Chieftain_Mk_3
 
         class MissilesSS:
             SSM_V_1_Launcher = vehicles.MissilesSS.SSM_V_1_Launcher
@@ -26176,6 +26336,8 @@ class UnitedNationsPeacekeepers(Country):
             Well_Car = vehicles.Carriage.Well_Car
             DR_50_ton_flat_wagon = vehicles.Carriage.DR_50_ton_flat_wagon
             Wagon_G10__Germany = vehicles.Carriage.Wagon_G10__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
+            Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
             Tank_Car__Germany = vehicles.Carriage.Tank_Car__Germany
@@ -26448,9 +26610,11 @@ class UnitedNationsPeacekeepers(Country):
         LS_Samuel_Chase = ships.LS_Samuel_Chase
         Boat_LCVP_Higgins = ships.Boat_LCVP_Higgins
         Bulker_Handy_Wind = ships.Bulker_Handy_Wind
+        Tanker_Seawise_Giant = ships.Tanker_Seawise_Giant
         FFG_Oliver_Hazzard_Perry = ships.FFG_Oliver_Hazzard_Perry
         Battlecruiser_1144_2_Pyotr_Velikiy = ships.Battlecruiser_1144_2_Pyotr_Velikiy
         CV_1143_5_Admiral_Kuznetsov_2017 = ships.CV_1143_5_Admiral_Kuznetsov_2017
+        FAC_La_Combattante_IIa = ships.FAC_La_Combattante_IIa
         Type_052B_Destroyer = ships.Type_052B_Destroyer
         Type_052C_Destroyer = ships.Type_052C_Destroyer
         Type_054A_Frigate = ships.Type_054A_Frigate
@@ -26596,7 +26760,7 @@ class Argentina(Country):
     class Vehicle:
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_Roland_ADS = vehicles.AirDefence.SAM_Roland_ADS
             SAM_Roland_EWR = vehicles.AirDefence.SAM_Roland_EWR
 
@@ -26611,17 +26775,17 @@ class Argentina(Country):
             Beacon_TACAN_Portable_TTS_3030 = vehicles.Fortification.Beacon_TACAN_Portable_TTS_3030
 
         class Unarmed:
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Bus_ZIU_9_Trolley = vehicles.Unarmed.Bus_ZIU_9_Trolley
 
         class Armor:
             APC_AAV_7_Amphibious = vehicles.Armor.APC_AAV_7_Amphibious
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_M113 = vehicles.Armor.APC_M113
             APC_M2A1_Halftrack = vehicles.Armor.APC_M2A1_Halftrack
-            MT_M4_Sherman = vehicles.Armor.MT_M4_Sherman
+            Tk_M4_Sherman = vehicles.Armor.Tk_M4_Sherman
             MT_M4A4_Sherman_Firefly = vehicles.Armor.MT_M4A4_Sherman_Firefly
 
         class Locomotive:
@@ -26880,7 +27044,7 @@ class Cyprus(Country):
             Infantry_M4 = vehicles.Infantry.Infantry_M4
 
         class AirDefence:
-            AAA_40mm_Bofors = vehicles.AirDefence.AAA_40mm_Bofors
+            AAA_Bofors_40mm = vehicles.AirDefence.AAA_Bofors_40mm
             SAM_SA_10_S_300_Grumble_Flap_Lid_TR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR
             SAM_SA_10_S_300_Grumble_Clam_Shell_SR = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR
             SAM_SA_10_S_300_Grumble_C2 = vehicles.AirDefence.SAM_SA_10_S_300_Grumble_C2
@@ -26910,7 +27074,7 @@ class Cyprus(Country):
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
             Truck_KAMAZ_43101 = vehicles.Unarmed.Truck_KAMAZ_43101
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
 
         class Armor:
             IFV_BMP_3 = vehicles.Armor.IFV_BMP_3
@@ -27182,14 +27346,14 @@ class Slovenia(Country):
 
         class Unarmed:
             Truck_M818_6x6 = vehicles.Unarmed.Truck_M818_6x6
-            Truck_HEMMT_TFFT_Fire = vehicles.Unarmed.Truck_HEMMT_TFFT_Fire
-            APC_HMMWV_Jeep = vehicles.Unarmed.APC_HMMWV_Jeep
+            Firefighter_HEMMT_TFFT = vehicles.Unarmed.Firefighter_HEMMT_TFFT
+            LUV_HMMWV_Jeep = vehicles.Unarmed.LUV_HMMWV_Jeep
             Refueler_M978_HEMTT = vehicles.Unarmed.Refueler_M978_HEMTT
 
         class Armor:
-            IFV_BRDM_2 = vehicles.Armor.IFV_BRDM_2
-            APC_Cobra__Scout = vehicles.Armor.APC_Cobra__Scout
-            APC_HMMWV__Scout = vehicles.Armor.APC_HMMWV__Scout
+            Scout_BRDM_2 = vehicles.Armor.Scout_BRDM_2
+            Scout_Cobra = vehicles.Armor.Scout_Cobra
+            Scout_HMMWV = vehicles.Armor.Scout_HMMWV
             ATGM_HMMWV = vehicles.Armor.ATGM_HMMWV
             APC_MTLB = vehicles.Armor.APC_MTLB
             MBT_T_55 = vehicles.Armor.MBT_T_55

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -25,7 +25,6 @@ class Tornado_GR4(PlaneType):
     eplrs = True
 
     class Liveries:
-
         class UK(Enum):
             bb_of_14_squadron_raf_lossiemouth = "bb of 14 squadron raf lossiemouth"
             no__12_squadron_raf_lossiemouth_ab__morayshire = "no. 12 squadron raf lossiemouth ab (morayshire)"
@@ -110,7 +109,6 @@ class Tornado_IDS(PlaneType):
     eplrs = True
 
     class Liveries:
-
         class Italy(Enum):
             ITA_Tornado__Sesto_Stormo_Diavoli_Rossi = "ITA Tornado (Sesto Stormo Diavoli Rossi)"
             ITA_Tornado_Black = "ITA Tornado Black"
@@ -129,7 +127,8 @@ class Tornado_IDS(PlaneType):
         Sky_Shadow_ECM_Pod = (1, Weapons.Sky_Shadow_ECM_Pod)
 
     class Pylon2:
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         Kormoran___ASM = (2, Weapons.Kormoran___ASM)
         TORNADO_Fuel_tank = (2, Weapons.TORNADO_Fuel_tank)
 
@@ -142,7 +141,8 @@ class Tornado_IDS(PlaneType):
 
     class Pylon4:
         GBU_16___1000lb_Laser_Guided_Bomb = (4, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (4, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        4, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         Kormoran___ASM = (4, Weapons.Kormoran___ASM)
 
     class Pylon5:
@@ -159,7 +159,8 @@ class Tornado_IDS(PlaneType):
 
     class Pylon9:
         GBU_16___1000lb_Laser_Guided_Bomb = (9, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (9, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        9, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         Kormoran___ASM = (9, Weapons.Kormoran___ASM)
 
     class Pylon10:
@@ -170,7 +171,8 @@ class Tornado_IDS(PlaneType):
         AIM_9L_Sidewinder_IR_AAM = (10, Weapons.AIM_9L_Sidewinder_IR_AAM)
 
     class Pylon11:
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (11, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        11, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         Kormoran___ASM = (11, Weapons.Kormoran___ASM)
         TORNADO_Fuel_tank = (11, Weapons.TORNADO_Fuel_tank)
 
@@ -196,10 +198,9 @@ class F_A_18A(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USA(Enum):
             vfa_125__rough_riders__mc__lemoore = "vfa-125 `rough riders` mc (lemoore)"
             vfa_131__wildcats__navy__cecil_field = "vfa-131 `wildcats` navy (cecil field)"
@@ -229,18 +230,22 @@ class F_A_18A(PlaneType):
 
     class Pylon2:
         AIM_7M_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (2, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (2, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (2, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (2, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (2, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (2, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        2, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         AIM_9M_Sidewinder_IR_AAM = (2, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (2, Weapons.AIM_9P_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (2, Weapons.AIM_9P5_Sidewinder_IR_AAM)
@@ -249,42 +254,50 @@ class F_A_18A(PlaneType):
     class Pylon3:
         AIM_7M_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (3, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Fuel_tank_330_gal = (3, Weapons.Fuel_tank_330_gal)
 
     class Pylon4:
         AIM_7M_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-#ERRR {6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}
+
+    # ERRR {6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}
 
     class Pylon5:
         Fuel_tank_330_gal = (5, Weapons.Fuel_tank_330_gal)
 
     class Pylon6:
         AIM_7M_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_ = (6, Weapons.AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_)
+        AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_ = (
+        6, Weapons.AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_)
 
     class Pylon7:
         AIM_7M_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (7, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Fuel_tank_330_gal = (7, Weapons.Fuel_tank_330_gal)
 
     class Pylon8:
         AIM_7M_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (8, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (8, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (8, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (8, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         AIM_9M_Sidewinder_IR_AAM = (8, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (8, Weapons.AIM_9P_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (8, Weapons.AIM_9P5_Sidewinder_IR_AAM)
@@ -299,7 +312,8 @@ class F_A_18A(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -317,7 +331,7 @@ class F_A_18C(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     panel_radio = {
@@ -372,7 +386,6 @@ class F_A_18C(PlaneType):
     }
 
     class Liveries:
-
         class Australia(Enum):
             Australia_75_Sqn_RAAF = "Australia 75 Sqn RAAF"
 
@@ -397,32 +410,46 @@ class F_A_18C(PlaneType):
         AIM_7F_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (2, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (2, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (2, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        2, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         AGM_154C___JSOW_Unitary_BROACH = (2, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (2, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+        2, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
         GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (2, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (2, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (2, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        2, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (2, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (2, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (2, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (2, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        2, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (2, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         LAU_117_AGM_65G = (2, Weapons.LAU_117_AGM_65G)
@@ -436,30 +463,41 @@ class F_A_18C(PlaneType):
         AIM_7MH_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (3, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (3, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        3, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Fuel_tank_330_gal_ = (3, Weapons.Fuel_tank_330_gal_)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (3, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (3, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        3, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
 
     class Pylon4:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (4, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -468,7 +506,8 @@ class F_A_18C(PlaneType):
         AIM_7F_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
-#ERRR {6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}
+
+    # ERRR {6C0D552F-570B-42ff-9F6D-F10D9C1D4E1C}
 
     class Pylon5:
         Fuel_tank_330_gal_ = (5, Weapons.Fuel_tank_330_gal_)
@@ -481,7 +520,8 @@ class F_A_18C(PlaneType):
         AIM_7F_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
-        AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_ = (6, Weapons.AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_)
+        AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_ = (
+        6, Weapons.AN_ASQ_173_Laser_Spot_Tracker_Strike_CAMera__LST_SCAM_)
 
     class Pylon7:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (7, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -491,30 +531,41 @@ class F_A_18C(PlaneType):
         AIM_7MH_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (7, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
         AGM_84A_Harpoon_ASM = (7, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (7, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        7, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Fuel_tank_330_gal_ = (7, Weapons.Fuel_tank_330_gal_)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_10___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (7, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         Mk_84___2000lb_GP_Bomb_LD = (7, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (7, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        7, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
 
     class Pylon8:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (8, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -523,35 +574,49 @@ class F_A_18C(PlaneType):
         AIM_7F_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7F_Sparrow_Semi_Active_Radar)
         AIM_7MH_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7MH_Sparrow_Semi_Active_Radar)
         AIM_7E_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7E_Sparrow_Semi_Active_Radar)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         AGM_84A_Harpoon_ASM = (8, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (8, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        8, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         AGM_154C___JSOW_Unitary_BROACH = (8, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (8, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+        8, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (8, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.MER2_with_2_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (8, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         LAU_117_AGM_65G = (8, Weapons.LAU_117_AGM_65G)
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         LAU_115_2_LAU_127_AIM_9M = (8, Weapons.LAU_115_2_LAU_127_AIM_9M)
 
     class Pylon9:
@@ -564,7 +629,8 @@ class F_A_18C(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -581,10 +647,9 @@ class F_14A(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USA(Enum):
             black_demo_scheme = "black demo scheme"
             vf_1__wolfpack = "vf-1 `wolfpack`"
@@ -664,7 +729,6 @@ class Tu_22M3(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Ukraine(Enum):
             af_standard = "af standard"
 
@@ -672,14 +736,16 @@ class Tu_22M3(PlaneType):
             af_standard = "af standard"
 
     class Pylon1:
-        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (1, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
+        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (
+        1, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
         MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD = (1, Weapons.MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD)
 
     class Pylon2:
         MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD = (2, Weapons.MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD)
 
     class Pylon3:
-        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (3, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
+        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (
+        3, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
         _33_x_FAB_500_M_62___500kg_GP_Bombs_LD = (3, Weapons._33_x_FAB_500_M_62___500kg_GP_Bombs_LD)
         _33_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons._33_x_FAB_250___250kg_GP_Bombs_LD)
 
@@ -687,7 +753,8 @@ class Tu_22M3(PlaneType):
         MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD = (4, Weapons.MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD)
 
     class Pylon5:
-        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (5, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
+        Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (
+        5, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
         MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD = (5, Weapons.MBD3_U9M_with_9_x_FAB_250___250kg_GP_Bombs_LD)
 
     pylons = {1, 2, 3, 4, 5}
@@ -708,10 +775,9 @@ class F_4E(PlaneType):
     charge_total = 120
     chaff_charge_size = 1
     flare_charge_size = 2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Iran(Enum):
             IRIAF_Asia_Minor = "IRIAF Asia Minor"
 
@@ -724,13 +790,17 @@ class F_4E(PlaneType):
     class Pylon1:
         GBU_10___2000lb_Laser_Guided_Bomb = (1, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (1, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        1, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons.MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (1, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (1, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        1, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (1, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (1, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (1, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        1, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        1, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         F_4_Fuel_tank_W = (1, Weapons.F_4_Fuel_tank_W)
         LAU_118a_with_AGM_45B_Shrike_ARM__Imp_ = (1, Weapons.LAU_118a_with_AGM_45B_Shrike_ARM__Imp_)
         AGM_45A_Shrike_ARM = (1, Weapons.AGM_45A_Shrike_ARM)
@@ -741,14 +811,18 @@ class F_4E(PlaneType):
         LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM = (2, Weapons.LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (2, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        2, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (2, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (2, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (2, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
+        LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+        2, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_ = (2, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_118a_with_AGM_45B_Shrike_ARM__Imp_ = (2, Weapons.LAU_118a_with_AGM_45B_Shrike_ARM__Imp_)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        2, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_7_with_AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (2, Weapons.LAU_7_with_AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
         AGM_45A_Shrike_ARM = (2, Weapons.AGM_45A_Shrike_ARM)
 
@@ -778,33 +852,42 @@ class F_4E(PlaneType):
         LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM = (8, Weapons.LAU_7_with_2_x_AIM_9P_Sidewinder_IR_AAM)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (8, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        8, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (8, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__ = (8, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__)
+        LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__ = (
+        8, Weapons.LAU_88_with_2_x_AGM_65K___Maverick_K__CCD_Imp_ASM__)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__ = (8, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__)
         LAU_118a_with_AGM_45B_Shrike_ARM__Imp_ = (8, Weapons.LAU_118a_with_AGM_45B_Shrike_ARM__Imp_)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        8, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         AGM_45A_Shrike_ARM = (8, Weapons.AGM_45A_Shrike_ARM)
 
     class Pylon9:
         GBU_10___2000lb_Laser_Guided_Bomb = (9, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (9, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        9, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.MER6_with_6_x_Mk_82___500lb_GP_Bombs_LD)
         Mk_84___2000lb_GP_Bomb_LD = (9, Weapons.Mk_84___2000lb_GP_Bomb_LD)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (9, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        9, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        _3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        9, Weapons._3_x_LAU_61_pods___57_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
         F_4_Fuel_tank_W = (9, Weapons.F_4_Fuel_tank_W)
         LAU_118a_with_AGM_45B_Shrike_ARM__Imp_ = (9, Weapons.LAU_118a_with_AGM_45B_Shrike_ARM__Imp_)
         AGM_45A_Shrike_ARM = (9, Weapons.AGM_45A_Shrike_ARM)
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.GroundAttack, task.CAS, task.PinpointStrike, task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.GroundAttack, task.CAS, task.PinpointStrike,
+             task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -824,13 +907,13 @@ class B_52H(PlaneType):
     eplrs = True
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
     class Pylon1:
         MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons.MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD)
-        HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (1, Weapons.HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        1, Weapons.HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         HSAB_with_9_x_Mk_83___1000lb_GP_Bombs_LD = (1, Weapons.HSAB_with_9_x_Mk_83___1000lb_GP_Bombs_LD)
         _6_x_AGM_86C_ALCM_on_MER = (1, Weapons._6_x_AGM_86C_ALCM_on_MER)
 
@@ -841,10 +924,12 @@ class B_52H(PlaneType):
 
     class Pylon3:
         MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD)
-        HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (3, Weapons.HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        3, Weapons.HSAB_with_9_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         HSAB_with_9_x_Mk_83___1000lb_GP_Bombs_LD = (3, Weapons.HSAB_with_9_x_Mk_83___1000lb_GP_Bombs_LD)
         _6_x_AGM_86C_ALCM_on_MER = (3, Weapons._6_x_AGM_86C_ALCM_on_MER)
-#ERRR {HSAB*9 GBU-31}
+
+    # ERRR {HSAB*9 GBU-31}
 
     pylons = {1, 2, 3}
 
@@ -866,7 +951,6 @@ class MiG_27K(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -877,20 +961,28 @@ class MiG_27K(PlaneType):
             Algerian_Air_Force = "Algerian Air Force"
 
     class Pylon2:
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (2, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (2, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
@@ -901,12 +993,14 @@ class MiG_27K(PlaneType):
 
     class Pylon3:
         R_60M__AA_8_Aphid____Infra_Red = (3, Weapons.R_60M__AA_8_Aphid____Infra_Red)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
 
     class Pylon4:
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
 
     class Pylon5:
@@ -914,29 +1008,39 @@ class MiG_27K(PlaneType):
 
     class Pylon6:
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
 
     class Pylon7:
         R_60M__AA_8_Aphid____Infra_Red = (7, Weapons.R_60M__AA_8_Aphid____Infra_Red)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (7, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
 
     class Pylon8:
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (8, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
@@ -964,11 +1068,10 @@ class Su_27(PlaneType):
     charge_total = 192
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     class Liveries:
-
         class USSR(Enum):
             Air_Force_Standard = "Air Force Standard"
             Air_Force_Standard_Early = "Air Force Standard Early"
@@ -1045,17 +1148,21 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
@@ -1066,11 +1173,16 @@ class Su_27(PlaneType):
         Smoke_Generator___white = (3, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (3, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (3, Weapons.Smoke_Generator___orange)
-        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (3, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (3, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
+        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (
+        3, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
+        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        3, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
+        3, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
+        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (
+        3, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
 
     class Pylon4:
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (4, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
@@ -1078,10 +1190,13 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
@@ -1102,10 +1217,13 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
@@ -1124,10 +1242,13 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
@@ -1142,10 +1263,13 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
@@ -1170,17 +1294,21 @@ class Su_27(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
@@ -1191,11 +1319,16 @@ class Su_27(PlaneType):
         Smoke_Generator___white = (8, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (8, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (8, Weapons.Smoke_Generator___orange)
-        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (8, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (8, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
+        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (
+        8, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
+        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        8, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
+        8, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
+        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (
+        8, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
 
     class Pylon9:
         R_73__AA_11_Archer____Infra_Red = (9, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -1218,7 +1351,8 @@ class Su_27(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Intercept, task.Escort, task.FighterSweep, task.AFAC, task.GroundAttack, task.RunwayAttack, task.AntishipStrike, task.CAS]
+    tasks = [task.CAP, task.Intercept, task.Escort, task.FighterSweep, task.AFAC, task.GroundAttack, task.RunwayAttack,
+             task.AntishipStrike, task.CAS]
     task_default = task.CAP
 
 
@@ -1234,10 +1368,9 @@ class MiG_23MLD(PlaneType):
     charge_total = 120
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
             af_standard_1 = "af standard-1"
@@ -1256,30 +1389,39 @@ class MiG_23MLD(PlaneType):
     class Pylon2:
         R_24R__AA_7_Apex_SA____Semi_Act_Rdr = (2, Weapons.R_24R__AA_7_Apex_SA____Semi_Act_Rdr)
         R_24T__AA_7_Apex_IR____Infra_Red = (2, Weapons.R_24T__AA_7_Apex_IR____Infra_Red)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         FAB_100___100kg_GP_Bomb_LD = (2, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (2, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
 
     class Pylon3:
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (3, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (
+        3, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
         R_60M__AA_8_Aphid____Infra_Red = (3, Weapons.R_60M__AA_8_Aphid____Infra_Red)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         FAB_100___100kg_GP_Bomb_LD = (3, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -1288,16 +1430,21 @@ class MiG_23MLD(PlaneType):
         Fuel_tank_800L = (4, Weapons.Fuel_tank_800L)
 
     class Pylon5:
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (5, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (
+        5, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
         R_60M__AA_8_Aphid____Infra_Red = (5, Weapons.R_60M__AA_8_Aphid____Infra_Red)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         FAB_100___100kg_GP_Bomb_LD = (5, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -1305,15 +1452,19 @@ class MiG_23MLD(PlaneType):
     class Pylon6:
         R_24R__AA_7_Apex_SA____Semi_Act_Rdr = (6, Weapons.R_24R__AA_7_Apex_SA____Semi_Act_Rdr)
         R_24T__AA_7_Apex_IR____Infra_Red = (6, Weapons.R_24T__AA_7_Apex_IR____Infra_Red)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         FAB_100___100kg_GP_Bomb_LD = (6, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (6, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -1340,7 +1491,6 @@ class Su_25(PlaneType):
     radio_frequency = 124
 
     class Liveries:
-
         class USSR(Enum):
             field_camo_scheme__1__native = "field camo scheme #1 (native)"
 
@@ -1388,20 +1538,26 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (2, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (2, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (2, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (2, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -1412,22 +1568,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (3, Weapons.Fuel_tank_800L_Wing)
@@ -1438,22 +1601,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (4, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (4, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (4, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1464,22 +1634,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (5, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (5, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (5, Weapons.Fuel_tank_800L_Wing)
@@ -1491,22 +1668,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (6, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (6, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (6, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (6, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        6, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (6, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (6, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (6, Weapons.Fuel_tank_800L_Wing)
@@ -1518,22 +1702,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (7, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (7, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (7, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (7, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (7, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (7, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1544,22 +1735,29 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (8, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (8, Weapons.Fuel_tank_800L_Wing)
@@ -1571,20 +1769,26 @@ class Su_25(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (9, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (9, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (9, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (9, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (9, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (9, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (9, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (9, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (9, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (9, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (9, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -1618,7 +1822,6 @@ class Su_25TM(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Russia(Enum):
             Flight_Research_Institute__VVS = "Flight Research Institute  VVS"
 
@@ -1638,20 +1841,26 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (2, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (2, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (2, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (2, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -1664,23 +1873,31 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (3, Weapons.Fuel_tank_800L_Wing)
@@ -1692,24 +1909,32 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         APU_8___8_9A4172_Vikhr = (4, Weapons.APU_8___8_9A4172_Vikhr)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (4, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (4, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (4, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1721,28 +1946,37 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (5, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (
+        5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (
+        5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr_ = (5, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr_)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (5, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (5, Weapons.Fuel_tank_800L_Wing)
@@ -1759,28 +1993,37 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (7, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (7, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_ = (
+        7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr_)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_ = (
+        7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr_)
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr_ = (7, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr_)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (7, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (7, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (7, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (7, Weapons.Fuel_tank_800L_Wing)
@@ -1792,24 +2035,32 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (8, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         APU_8___8_9A4172_Vikhr = (8, Weapons.APU_8___8_9A4172_Vikhr)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (8, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -1821,23 +2072,31 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (9, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (9, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (9, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (9, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (9, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (9, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (9, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (9, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (9, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (9, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (9, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (9, Weapons.Fuel_tank_800L_Wing)
@@ -1849,20 +2108,29 @@ class Su_25TM(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (10, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (10, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (10, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (10, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
+        10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (10, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (10, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (10, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        10, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (10, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (10, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (10, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
+        10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        10, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        10, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (10, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (10, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (10, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -1880,7 +2148,8 @@ class Su_25TM(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
-    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.SEAD, task.AFAC, task.AntishipStrike]
+    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.SEAD, task.AFAC,
+             task.AntishipStrike]
     task_default = task.CAS
 
 
@@ -1900,7 +2169,6 @@ class Su_25T(PlaneType):
     radio_frequency = 124
 
     class Liveries:
-
         class USSR(Enum):
             af_standard_1 = "af standard 1"
             af_standard_2 = "af standard 2"
@@ -1939,20 +2207,26 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (2, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (2, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (2, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (2, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -1964,23 +2238,31 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (3, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (3, Weapons.Fuel_tank_800L_Wing)
@@ -1992,24 +2274,32 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         APU_8___8_9A4172_Vikhr = (4, Weapons.APU_8___8_9A4172_Vikhr)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (4, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        4, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (4, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        4, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (4, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (4, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (4, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -2021,25 +2311,32 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (5, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (5, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (5, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        5, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (5, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (5, Weapons.Fuel_tank_800L_Wing)
@@ -2055,25 +2352,32 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (7, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (7, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_ = (
+        7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser_)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_ = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided_)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_ = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (7, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (7, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (7, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (7, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (7, Weapons.Fuel_tank_800L_Wing)
@@ -2085,24 +2389,32 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (8, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         APU_8___8_9A4172_Vikhr = (8, Weapons.APU_8___8_9A4172_Vikhr)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (8, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (8, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
@@ -2114,23 +2426,31 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (9, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (9, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (9, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (9, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (9, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (9, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (9, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        9, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_ = (
+        9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr_)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (
+        9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (9, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        9, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (9, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        9, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (9, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (9, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         Fuel_tank_800L_Wing = (9, Weapons.Fuel_tank_800L_Wing)
@@ -2142,20 +2462,29 @@ class Su_25T(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (10, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = (10, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_)
         FAB_250___250kg_GP_Bomb_LD = (10, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (10, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
+        10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (10, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (10, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (10, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        10, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (10, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (10, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (10, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
+        10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        10, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        10, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (10, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (10, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         S_25L___320Kg__340mm_Laser_Guided_Rkt = (10, Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt)
@@ -2173,7 +2502,8 @@ class Su_25T(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
-    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.SEAD, task.AFAC, task.AntishipStrike]
+    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.SEAD, task.AFAC,
+             task.AntishipStrike]
     task_default = task.CAS
 
 
@@ -2190,11 +2520,10 @@ class Su_33(PlaneType):
     charge_total = 96
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     class Liveries:
-
         class USSR(Enum):
             t_10k_1_test_paint_scheme = "t-10k-1 test paint scheme"
 
@@ -2245,14 +2574,17 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         Smoke_Generator___red = (3, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (3, Weapons.Smoke_Generator___green)
@@ -2263,11 +2595,16 @@ class Su_33(PlaneType):
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (3, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (3, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
+        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (
+        3, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
+        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        3, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
+        3, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
+        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (
+        3, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_3_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_3_x_FAB_250___250kg_GP_Bombs_LD)
 
@@ -2278,14 +2615,17 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (4, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (4, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         Smoke_Generator___red = (4, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (4, Weapons.Smoke_Generator___green)
@@ -2304,10 +2644,12 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         Smoke_Generator___red = (5, Weapons.Smoke_Generator___red)
@@ -2325,10 +2667,12 @@ class Su_33(PlaneType):
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (6, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         Smoke_Generator___red = (6, Weapons.Smoke_Generator___red)
@@ -2348,10 +2692,12 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (7, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
@@ -2365,10 +2711,12 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         Smoke_Generator___red = (8, Weapons.Smoke_Generator___red)
@@ -2388,14 +2736,17 @@ class Su_33(PlaneType):
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (9, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (9, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (9, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (9, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (9, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (9, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (9, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (9, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         Smoke_Generator___red = (9, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (9, Weapons.Smoke_Generator___green)
@@ -2412,19 +2763,26 @@ class Su_33(PlaneType):
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (10, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
         R_27T__AA_10_Alamo_B____Infra_Red = (10, Weapons.R_27T__AA_10_Alamo_B____Infra_Red)
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (10, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
-        R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (10, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
+        R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (
+        10, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         FAB_250___250kg_GP_Bomb_LD = (10, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (10, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (10, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
+        10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (10, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (10, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
+        10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (10, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         Smoke_Generator___red = (10, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (10, Weapons.Smoke_Generator___green)
@@ -2435,11 +2793,16 @@ class Su_33(PlaneType):
         B_8M1___20_S_8OFP2 = (10, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (10, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SAB_100___100kg_flare_illumination_Bomb = (10, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (10, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
-        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (10, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (10, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (10, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (10, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
+        _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = (
+        10, Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator)
+        _2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        10, Weapons._2_x_B_13L_pods___10_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        _2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        10, Weapons._2_x_B_8M1_pods___40_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        _2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk = (
+        10, Weapons._2_x_B_8V20A_pods___40_x_S_8TsM__80mm_UnGd_Rkts__Smk)
+        _2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP = (
+        10, Weapons._2_x_B_8V20A_pods___40_x_S_8OFP2__80mm_UnGd_Rkts__HE_Frag_AP)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (10, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_3_x_FAB_250___250kg_GP_Bombs_LD = (10, Weapons.MBD3_U6_68_with_3_x_FAB_250___250kg_GP_Bombs_LD)
 
@@ -2466,7 +2829,8 @@ class Su_33(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.CAS, task.GroundAttack, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -2482,10 +2846,9 @@ class MiG_25PD(PlaneType):
     charge_total = 128
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -2528,7 +2891,6 @@ class MiG_25RBT(PlaneType):
     max_speed = 3000
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -2544,36 +2906,45 @@ class MiG_25RBT(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (1, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         FAB_250___250kg_GP_Bomb_LD = (1, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (1, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (1, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        1, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (1, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (1, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (1, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        1, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
 
     class Pylon2:
         FAB_100___100kg_GP_Bomb_LD = (2, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (2, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
 
     class Pylon3:
         FAB_100___100kg_GP_Bomb_LD = (3, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
 
     class Pylon4:
         R_60M__AA_8_Aphid____Infra_Red = (4, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -2581,12 +2952,15 @@ class MiG_25RBT(PlaneType):
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
 
     pylons = {1, 2, 3, 4}
 
@@ -2606,10 +2980,9 @@ class Su_30(PlaneType):
     charge_total = 192
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USSR(Enum):
             af_standard_early = "af standard early"
 
@@ -2647,29 +3020,35 @@ class Su_30(PlaneType):
         R_77__AA_12_Adder____Active_Rdr = (3, Weapons.R_77__AA_12_Adder____Active_Rdr)
         R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (3, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (3, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg_GPS_Guided_Bomb = (3, Weapons.KAB_500S___500kg_GPS_Guided_Bomb)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (3, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (3, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (3, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        3, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (3, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
 
@@ -2679,16 +3058,20 @@ class Su_30(PlaneType):
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (4, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
         R_77__AA_12_Adder____Active_Rdr = (4, Weapons.R_77__AA_12_Adder____Active_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (4, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (4, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (4, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -2702,17 +3085,20 @@ class Su_30(PlaneType):
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (5, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (5, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (5, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg_GPS_Guided_Bomb = (5, Weapons.KAB_500S___500kg_GPS_Guided_Bomb)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (5, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (5, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        5, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (5, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD_ = (5, Weapons.MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD_)
 
@@ -2723,11 +3109,13 @@ class Su_30(PlaneType):
         Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (6, Weapons.Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (6, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -2740,16 +3128,20 @@ class Su_30(PlaneType):
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (7, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
         R_77__AA_12_Adder____Active_Rdr = (7, Weapons.R_77__AA_12_Adder____Active_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (7, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
@@ -2764,29 +3156,35 @@ class Su_30(PlaneType):
         R_77__AA_12_Adder____Active_Rdr = (8, Weapons.R_77__AA_12_Adder____Active_Rdr)
         R_73__AA_11_Archer____Infra_Red = (8, Weapons.R_73__AA_11_Archer____Infra_Red)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (8, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KAB_500LG___500kg_Laser_Guided_Bomb = (8, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (8, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KAB_500S___500kg_GPS_Guided_Bomb = (8, Weapons.KAB_500S___500kg_GPS_Guided_Bomb)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (8, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (8, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (8, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        8, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (8, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
 
@@ -2806,7 +3204,8 @@ class Su_30(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.SEAD, task.AntishipStrike, task.CAS, task.PinpointStrike, task.GroundAttack, task.RunwayAttack]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.SEAD, task.AntishipStrike,
+             task.CAS, task.PinpointStrike, task.GroundAttack, task.RunwayAttack]
     task_default = task.CAP
 
 
@@ -2824,7 +3223,6 @@ class Su_17M4(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class USSR(Enum):
             af_standard__RUS = "af standard (RUS)"
 
@@ -2842,27 +3240,36 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (1, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (1, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (1, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        1, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (1, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (1, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (1, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (1, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (1, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        1, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (1, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Fuel_tank_1150L = (1, Weapons.Fuel_tank_1150L)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (1, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        1, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (1, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (1, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        1, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (1, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (1, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (1, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (1, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
@@ -2874,32 +3281,42 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (3, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (3, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        3, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (3, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (3, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
         SPS_141___ECM_Jamming_Pod = (3, Weapons.SPS_141___ECM_Jamming_Pod)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (3, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
@@ -2907,18 +3324,21 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (4, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (4, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (4, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (4, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (4, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         Fuel_tank_1150L = (4, Weapons.Fuel_tank_1150L)
         Fuel_tank_800L = (4, Weapons.Fuel_tank_800L)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         Kh_28__AS_9_Kyle____720kg__ARM__Pas_Rdr = (4, Weapons.Kh_28__AS_9_Kyle____720kg__ARM__Pas_Rdr)
 
@@ -2926,18 +3346,21 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (5, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (5, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (5, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (5, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         Fuel_tank_1150L = (5, Weapons.Fuel_tank_1150L)
         Fuel_tank_800L = (5, Weapons.Fuel_tank_800L)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
 
     class Pylon6:
@@ -2945,30 +3368,40 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (6, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (6, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (6, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_4_x_FAB_250___250kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (6, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (6, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (6, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        6, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        6, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        6, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        6, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (6, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (6, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (6, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        6, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (6, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (6, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod = (6, Weapons.SPPU_22_1___2_x_23mm__GSh_23L_Autocannon_Pod)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (6, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
@@ -2980,33 +3413,43 @@ class Su_17M4(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (8, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (8, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (8, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U4T_with_4_x_FAB_250___250kg_GP_Bombs_LD)
         MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_2_x_FAB_250___250kg_GP_Bombs_LD)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Fuel_tank_1150L = (8, Weapons.Fuel_tank_1150L)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (8, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8}
 
-    tasks = [task.GroundAttack, task.CAS, task.PinpointStrike, task.SEAD, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.GroundAttack, task.CAS, task.PinpointStrike, task.SEAD, task.AFAC, task.RunwayAttack,
+             task.AntishipStrike]
     task_default = task.GroundAttack
 
 
@@ -3017,10 +3460,9 @@ class MiG_31(PlaneType):
     length = 22.7
     fuel_max = 15500
     max_speed = 3000
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -3032,7 +3474,8 @@ class MiG_31(PlaneType):
     class Pylon1:
         R_40R__AA_6_Acrid____Semi_Act_Rdr = (1, Weapons.R_40R__AA_6_Acrid____Semi_Act_Rdr)
         R_40T__AA_6_Acrid____Infra_Red = (1, Weapons.R_40T__AA_6_Acrid____Infra_Red)
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (
+        1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
 
     class Pylon2:
         R_33__AA_9_Amos____Semi_Act_Rdr = (2, Weapons.R_33__AA_9_Amos____Semi_Act_Rdr)
@@ -3049,7 +3492,8 @@ class MiG_31(PlaneType):
     class Pylon6:
         R_40R__AA_6_Acrid____Semi_Act_Rdr = (6, Weapons.R_40R__AA_6_Acrid____Semi_Act_Rdr)
         R_40T__AA_6_Acrid____Infra_Red = (6, Weapons.R_40T__AA_6_Acrid____Infra_Red)
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (6, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (
+        6, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
 
     pylons = {1, 2, 3, 4, 5, 6}
 
@@ -3072,7 +3516,6 @@ class Tu_95MS(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Ukraine(Enum):
             af_standard = "af standard"
 
@@ -3102,7 +3545,6 @@ class Su_24M(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -3122,54 +3564,74 @@ class Su_24M(PlaneType):
             Algerian_AF_KX_12 = "Algerian AF KX-12"
 
     class Pylon1:
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (
+        1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (1, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (1, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (1, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        1, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (1, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (1, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (1, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        1, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        1, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (1, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        1, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (1, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
     class Pylon2:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (2, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        2, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (2, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (2, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        2, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (2, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        2, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        2, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (2, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (2, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (2, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        2, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (2, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (2, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (2, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        2, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (2, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (2, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         Fuel_tank_3000L = (2, Weapons.Fuel_tank_3000L)
@@ -3177,30 +3639,37 @@ class Su_24M(PlaneType):
 
     class Pylon3:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (3, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (3, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
 
     class Pylon4:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (4, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (4, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (4, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        4, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (4, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (4, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
 
@@ -3208,84 +3677,111 @@ class Su_24M(PlaneType):
         Fuel_tank_2000L = (5, Weapons.Fuel_tank_2000L)
         L_081_Fantasmagoria_ELINT_pod = (5, Weapons.L_081_Fantasmagoria_ELINT_pod)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
 
     class Pylon6:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (6, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (6, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         SAB_100___100kg_flare_illumination_Bomb = (6, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        6, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
 
     class Pylon7:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (7, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser = (
+        7, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided = (7, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr = (
+        7, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr)
         Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr)
         Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_58U__AS_11_Kilter____640kg__ARM__IN__Pas_Rdr)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (7, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (7, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (7, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        7, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        7, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        7, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         KAB_500LG___500kg_Laser_Guided_Bomb = (7, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
         KAB_500Kr___500kg_TV_Guided_Bomb = (7, Weapons.KAB_500Kr___500kg_TV_Guided_Bomb)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (7, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (7, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         SAB_100___100kg_flare_illumination_Bomb = (7, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (7, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        7, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        7, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (7, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (7, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (7, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        7, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (7, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (7, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         Fuel_tank_3000L = (7, Weapons.Fuel_tank_3000L)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (7, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
     class Pylon8:
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (8, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_ = (
+        8, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red_)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        8, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        8, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
-        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
+        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser = (
+        8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser)
+        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (
+        8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
+        Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (
+        8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (8, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8}
 
-    tasks = [task.GroundAttack, task.CAS, task.AntishipStrike, task.SEAD, task.PinpointStrike, task.AFAC, task.RunwayAttack]
+    tasks = [task.GroundAttack, task.CAS, task.AntishipStrike, task.SEAD, task.PinpointStrike, task.AFAC,
+             task.RunwayAttack]
     task_default = task.GroundAttack
 
 
@@ -3303,7 +3799,6 @@ class Su_24MR(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class USSR(Enum):
             af_standard = "af standard"
 
@@ -3314,7 +3809,8 @@ class Su_24MR(PlaneType):
             Algerian_AF_KG_93 = "Algerian AF KG-93"
 
     class Pylon1:
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (
+        1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
 
     class Pylon2:
         Fuel_tank_3000L = (2, Weapons.Fuel_tank_3000L)
@@ -3352,7 +3848,6 @@ class Tu_160(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Russia(Enum):
             af_standard = "af standard"
 
@@ -3377,7 +3872,6 @@ class F_117A(PlaneType):
     max_speed = 1000
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
@@ -3413,7 +3907,6 @@ class B_1B(PlaneType):
     eplrs = True
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
@@ -3466,24 +3959,26 @@ class S_3B(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
     class Pylon1:
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (1, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        1, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (1, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_84___2000lb_GP_Bomb_LD = (1, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (1, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (1, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (1, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         AGM_84A_Harpoon_ASM = (1, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (1, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (1, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        1, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        1, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         Fuel_tank_S_3 = (1, Weapons.Fuel_tank_S_3)
 
     class Pylon2:
@@ -3504,15 +3999,18 @@ class S_3B(PlaneType):
 
     class Pylon6:
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (6, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (6, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        6, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_84___2000lb_GP_Bomb_LD = (6, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (6, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (6, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (6, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         AGM_84A_Harpoon_ASM = (6, Weapons.AGM_84A_Harpoon_ASM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (6, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (6, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        6, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        6, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         Fuel_tank_S_3 = (6, Weapons.Fuel_tank_S_3)
 
     pylons = {1, 2, 3, 4, 5, 6}
@@ -3535,10 +4033,9 @@ class S_3B_Tanker(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     tacan = True
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
@@ -3561,10 +4058,9 @@ class Mirage_2000_5(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Greece(Enum):
             Hellenic_Airforce = "Hellenic Airforce"
 
@@ -3633,11 +4129,10 @@ class F_15C(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     class Liveries:
-
         class Israel(Enum):
             _106th_SQN__8th_Airbase = "106th SQN (8th Airbase)"
 
@@ -3766,10 +4261,9 @@ class F_15E(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Israel(Enum):
             IDF_No_69_Hammers_Squadron = "IDF No 69 Hammers Squadron"
 
@@ -3798,16 +4292,18 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (2, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (2, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (2, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (2, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (2, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (2, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (2, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65H = (2, Weapons.LAU_117_AGM_65H)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (2, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         AGM_154C___JSOW_Unitary_BROACH = (2, Weapons.AGM_154C___JSOW_Unitary_BROACH)
         LAU_117_AGM_65G = (2, Weapons.LAU_117_AGM_65G)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
 
     class Pylon3:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (3, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -3824,9 +4320,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (4, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon5:
         Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3835,9 +4331,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (5, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (5, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (5, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (5, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (5, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon6:
         Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3846,9 +4342,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (6, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (6, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (6, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (6, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (6, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (6, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (6, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon7:
         Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3861,10 +4357,11 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (7, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
 
     class Pylon8:
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3873,9 +4370,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (8, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (8, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon9:
         Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3888,10 +4385,11 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (9, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (9, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (9, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
 
     class Pylon10:
         Fuel_tank_610_gal = (10, Weapons.Fuel_tank_610_gal)
@@ -3900,13 +4398,14 @@ class F_15E(PlaneType):
         GBU_12___500lb_Laser_Guided_Bomb = (10, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (10, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (10, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (10, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        10, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (10, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (10, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (10, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (10, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (10, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (10, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (10, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (10, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         Mk_84___2000lb_GP_Bomb_LD = (10, Weapons.Mk_84___2000lb_GP_Bomb_LD)
 
     class Pylon11:
@@ -3920,10 +4419,11 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (11, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (11, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (11, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (11, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (11, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (11, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (11, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (11, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        11, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
 
     class Pylon12:
         Mk_82___500lb_GP_Bomb_LD = (12, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3932,9 +4432,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (12, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (12, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (12, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (12, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (12, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (12, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (12, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (12, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon13:
         Mk_82___500lb_GP_Bomb_LD = (13, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3947,10 +4447,11 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (13, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (13, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (13, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (13, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (13, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (13, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (13, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (13, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (13, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        13, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
 
     class Pylon14:
         Mk_82___500lb_GP_Bomb_LD = (14, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3959,9 +4460,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (14, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (14, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (14, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (14, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (14, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (14, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (14, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (14, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon15:
         Mk_82___500lb_GP_Bomb_LD = (15, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3970,9 +4471,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (15, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (15, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (15, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (15, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (15, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (15, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (15, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (15, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon16:
         Mk_82___500lb_GP_Bomb_LD = (16, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -3981,9 +4482,9 @@ class F_15E(PlaneType):
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (16, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (16, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (16, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (16, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (16, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (16, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (16, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (16, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
 
     class Pylon17:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (17, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -4002,15 +4503,17 @@ class F_15E(PlaneType):
         GBU_12___500lb_Laser_Guided_Bomb = (18, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (18, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (18, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (18, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        18, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (18, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (18, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         CBU_87___202_x_CEM_Cluster_Bomb = (18, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (18, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (18, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (18, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (18, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (18, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (18, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (18, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        18, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65H = (18, Weapons.LAU_117_AGM_65H)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (18, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         AGM_154C___JSOW_Unitary_BROACH = (18, Weapons.AGM_154C___JSOW_Unitary_BROACH)
@@ -4027,7 +4530,8 @@ class F_15E(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.AFAC, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.AFAC, task.Reconnaissance]
     task_default = task.GroundAttack
 
 
@@ -4044,11 +4548,10 @@ class MiG_29A(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     class Liveries:
-
         class USSR(Enum):
             Air_Force_Standard = "Air Force Standard"
 
@@ -4087,7 +4590,8 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon2:
         R_60M__AA_8_Aphid____Infra_Red = (2, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -4098,19 +4602,23 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (2, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
 
@@ -4123,19 +4631,23 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (3, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (3, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (3, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (3, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
@@ -4162,19 +4674,23 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (5, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (5, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (5, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (5, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (5, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
@@ -4192,19 +4708,23 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (6, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (6, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (6, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (6, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (6, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
 
@@ -4217,11 +4737,13 @@ class MiG_29A(PlaneType):
         Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.GroundAttack, task.CAS, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.GroundAttack, task.CAS,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -4238,11 +4760,10 @@ class MiG_29G(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     class Liveries:
-
         class Germany(Enum):
             luftwaffe_gray_1 = "luftwaffe gray-1"
 
@@ -4255,7 +4776,8 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon2:
         R_60M__AA_8_Aphid____Infra_Red = (2, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -4266,19 +4788,23 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (2, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
 
@@ -4291,19 +4817,23 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (3, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (3, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (3, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (3, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
@@ -4330,19 +4860,23 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (5, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (5, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (5, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (5, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (5, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
@@ -4360,19 +4894,23 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (6, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (6, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (6, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (6, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (6, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
 
@@ -4385,7 +4923,8 @@ class MiG_29G(PlaneType):
         Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
@@ -4406,11 +4945,10 @@ class MiG_29S(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     class Liveries:
-
         class Ukraine(Enum):
             Air_Force_Ukraine_Standard = "Air Force Ukraine Standard"
 
@@ -4447,7 +4985,7 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         R_77__AA_12_Adder____Active_Rdr = (1, Weapons.R_77__AA_12_Adder____Active_Rdr)
 
     class Pylon2:
@@ -4459,19 +4997,23 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (2, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (2, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (2, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (2, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (2, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (2, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (2, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (2, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        2, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (2, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (2, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_77__AA_12_Adder____Active_Rdr = (2, Weapons.R_77__AA_12_Adder____Active_Rdr)
@@ -4485,19 +5027,23 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (3, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (3, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (3, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (3, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (3, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_77__AA_12_Adder____Active_Rdr = (3, Weapons.R_77__AA_12_Adder____Active_Rdr)
@@ -4525,19 +5071,23 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (5, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (5, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (5, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (5, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (5, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (5, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (5, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (5, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_77__AA_12_Adder____Active_Rdr = (5, Weapons.R_77__AA_12_Adder____Active_Rdr)
@@ -4556,19 +5106,23 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (6, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (6, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (6, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (6, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
         KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (6, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (6, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
+        S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (
+        6, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_S_8OFP2 = (6, Weapons.B_8M1___20_S_8OFP2)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (6, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
         R_77__AA_12_Adder____Active_Rdr = (6, Weapons.R_77__AA_12_Adder____Active_Rdr)
@@ -4582,12 +5136,13 @@ class MiG_29S(PlaneType):
         Smoke_Generator___white = (7, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (7, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (7, Weapons.Smoke_Generator___orange)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         R_77__AA_12_Adder____Active_Rdr = (7, Weapons.R_77__AA_12_Adder____Active_Rdr)
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.GroundAttack, task.CAS, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.AFAC, task.GroundAttack, task.CAS,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -4606,12 +5161,12 @@ class Tu_142(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Russia(Enum):
             af_standard = "af standard"
 
     class Pylon1:
-        _6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (1, Weapons._6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
+        _6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (
+        1, Weapons._6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
 
     pylons = {1}
 
@@ -4634,7 +5189,6 @@ class C_130(PlaneType):
     flare_charge_size = 2
 
     class Liveries:
-
         class Israel(Enum):
             Israel_Defence_Force = "Israel Defence Force"
 
@@ -4701,7 +5255,6 @@ class An_26B(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class USSR(Enum):
             Aeroflot = "Aeroflot"
 
@@ -4743,7 +5296,6 @@ class An_30M(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Ukraine(Enum):
             _15th_Transport_AB = "15th Transport AB"
 
@@ -4774,7 +5326,6 @@ class C_17A(PlaneType):
     flare_charge_size = 2
 
     class Liveries:
-
         class USA(Enum):
             usaf_standard = "usaf standard"
 
@@ -4797,10 +5348,9 @@ class A_50(PlaneType):
     charge_total = 384
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
+    category = "AWACS"  # {D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     class Liveries:
-
         class Russia(Enum):
             RF_Air_Force = "RF Air Force"
             RF_Air_Force_new = "RF Air Force new"
@@ -4825,10 +5375,9 @@ class E_3A(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
+    category = "AWACS"  # {D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     class Liveries:
-
         class UK(Enum):
             nato = "nato"
 
@@ -4858,10 +5407,9 @@ class IL_78M(PlaneType):
     charge_total = 192
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USSR(Enum):
             RF_Air_Force = "RF Air Force"
             RF_Air_Force_aeroflot = "RF Air Force aeroflot"
@@ -4897,10 +5445,9 @@ class E_2C(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
+    category = "AWACS"  # {D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     class Liveries:
-
         class USA(Enum):
             E_2D_Demo = "E-2D Demo"
             VAW_125_Tigertails = "VAW-125 Tigertails"
@@ -4926,7 +5473,6 @@ class IL_76MD(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Ukraine(Enum):
             Ukrainian_AF = "Ukrainian AF"
             Ukrainian_AF_aeroflot = "Ukrainian AF aeroflot"
@@ -4962,10 +5508,9 @@ class F_16C_bl_50(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Greece(Enum):
             HAF___330sqn = "HAF - 330sqn"
             HAF___341sqn = "HAF - 341sqn"
@@ -5004,7 +5549,8 @@ class F_16C_bl_50(PlaneType):
         AIM_120C_5_AMRAAM___Active_Rdr_AAM = (3, Weapons.AIM_120C_5_AMRAAM___Active_Rdr_AAM)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
-        LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
+        LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+        3, Weapons.LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
@@ -5019,18 +5565,21 @@ class F_16C_bl_50(PlaneType):
         LAU_117_AGM_65G = (3, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         _2xGBU_12___500lb_Laser_Guided_Bomb = (3, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (3, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154C___JSOW_Unitary_BROACH = (3, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         AIM_9M_Sidewinder_IR_AAM = (3, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (3, Weapons.AIM_9P_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (3, Weapons.AIM_9P5_Sidewinder_IR_AAM)
@@ -5048,14 +5597,16 @@ class F_16C_bl_50(PlaneType):
         LAU_117_AGM_65G = (4, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (4, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (4, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
 
     class Pylon5:
@@ -5078,21 +5629,24 @@ class F_16C_bl_50(PlaneType):
         LAU_117_AGM_65G = (7, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (7, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (7, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
 
     class Pylon8:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (8, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
         AIM_120C_5_AMRAAM___Active_Rdr_AAM = (8, Weapons.AIM_120C_5_AMRAAM___Active_Rdr_AAM)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
-        LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
+        LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (
+        8, Weapons.LAU_88_with_3_x_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_ = (8, Weapons.LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
@@ -5107,18 +5661,21 @@ class F_16C_bl_50(PlaneType):
         LAU_117_AGM_65G = (8, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (8, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         _2xGBU_12___500lb_Laser_Guided_Bomb_ = (8, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb_)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (8, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154C___JSOW_Unitary_BROACH = (8, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         AIM_9M_Sidewinder_IR_AAM = (8, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (8, Weapons.AIM_9P_Sidewinder_IR_AAM)
         AIM_9P5_Sidewinder_IR_AAM = (8, Weapons.AIM_9P5_Sidewinder_IR_AAM)
@@ -5143,7 +5700,8 @@ class F_16C_bl_50(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.AFAC, task.Reconnaissance, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.AFAC, task.Reconnaissance, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -5160,10 +5718,9 @@ class F_16C_bl_52d(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Israel(Enum):
             idf_af_f16c_standard = "idf_af f16c standard"
 
@@ -5219,18 +5776,21 @@ class F_16C_bl_52d(PlaneType):
         LAU_117_AGM_65G = (3, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         _2xGBU_12___500lb_Laser_Guided_Bomb = (3, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (3, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154C___JSOW_Unitary_BROACH = (3, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         AGM_154A___JSOW_CEB__CBU_type_ = (3, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154B___JSOW_Anti_Armour = (3, Weapons.AGM_154B___JSOW_Anti_Armour)
         AIM_9M_Sidewinder_IR_AAM = (3, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -5251,14 +5811,16 @@ class F_16C_bl_52d(PlaneType):
         LAU_117_AGM_65G = (4, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (4, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (4, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (4, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154B___JSOW_Anti_Armour = (4, Weapons.AGM_154B___JSOW_Anti_Armour)
@@ -5285,14 +5847,16 @@ class F_16C_bl_52d(PlaneType):
         LAU_117_AGM_65G = (7, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (7, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (7, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (7, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154B___JSOW_Anti_Armour = (7, Weapons.AGM_154B___JSOW_Anti_Armour)
@@ -5314,18 +5878,21 @@ class F_16C_bl_52d(PlaneType):
         LAU_117_AGM_65G = (8, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (8, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         _2xGBU_12___500lb_Laser_Guided_Bomb_ = (8, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb_)
         GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = (8, Weapons.GBU_27___2000lb_Laser_Guided_Penetrator_Bomb)
         AGM_154C___JSOW_Unitary_BROACH = (8, Weapons.AGM_154C___JSOW_Unitary_BROACH)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         AGM_154A___JSOW_CEB__CBU_type_ = (8, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154B___JSOW_Anti_Armour = (8, Weapons.AGM_154B___JSOW_Anti_Armour)
         AIM_9M_Sidewinder_IR_AAM = (8, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -5352,7 +5919,8 @@ class F_16C_bl_52d(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -5368,10 +5936,9 @@ class F_16A(PlaneType):
     charge_total = 120
     chaff_charge_size = 1
     flare_charge_size = 2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class Denmark(Enum):
             standard_denmark = "standard_denmark"
 
@@ -5397,7 +5964,8 @@ class F_16A(PlaneType):
         AIM_120B_AMRAAM___Active_Rdr_AAM = (3, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (3, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        3, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
@@ -5406,7 +5974,8 @@ class F_16A(PlaneType):
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_)
         AIM_7M_Sparrow_Semi_Active_Radar = (3, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         AGM_119B_Penguin_ASM = (3, Weapons.AGM_119B_Penguin_ASM)
         AIM_9M_Sidewinder_IR_AAM = (3, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (3, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -5416,7 +5985,8 @@ class F_16A(PlaneType):
     class Pylon4:
         Fuel_tank_370_gal = (4, Weapons.Fuel_tank_370_gal)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (4, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (4, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        4, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (4, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
@@ -5431,7 +6001,8 @@ class F_16A(PlaneType):
     class Pylon7:
         Fuel_tank_370_gal = (7, Weapons.Fuel_tank_370_gal)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (7, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (7, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        7, Weapons.BRU_42_with_3_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (7, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
@@ -5442,7 +6013,8 @@ class F_16A(PlaneType):
         AIM_120B_AMRAAM___Active_Rdr_AAM = (8, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (8, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (8, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
+        MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets = (
+        8, Weapons.MER2_with_2_x_Mk_20_Rockeye___490lbs_CBUs__247_x_HEAT_Bomblets)
         Mk_84___2000lb_GP_Bomb_LD = (8, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
@@ -5451,7 +6023,8 @@ class F_16A(PlaneType):
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__ = (8, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__)
         AIM_7M_Sparrow_Semi_Active_Radar = (8, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         AGM_119B_Penguin_ASM = (8, Weapons.AGM_119B_Penguin_ASM)
         AIM_9M_Sidewinder_IR_AAM = (8, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9P_Sidewinder_IR_AAM = (8, Weapons.AIM_9P_Sidewinder_IR_AAM)
@@ -5475,7 +6048,8 @@ class F_16A(PlaneType):
 
     pylons = {1, 2, 3, 4, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.Reconnaissance, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -5492,10 +6066,9 @@ class F_16A_MLU(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     class Liveries:
-
         class USSR(Enum):
             CMD_extended_skins = "CMD extended skins"
 
@@ -5784,7 +6357,8 @@ class F_16A_MLU(PlaneType):
         LAU_117_AGM_65G = (3, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         _2xGBU_12___500lb_Laser_Guided_Bomb = (3, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb)
@@ -5807,7 +6381,8 @@ class F_16A_MLU(PlaneType):
         LAU_117_AGM_65G = (4, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (4, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
 
@@ -5832,7 +6407,8 @@ class F_16A_MLU(PlaneType):
         LAU_117_AGM_65G = (7, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (7, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
 
@@ -5854,7 +6430,8 @@ class F_16A_MLU(PlaneType):
         LAU_117_AGM_65G = (8, Weapons.LAU_117_AGM_65G)
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (8, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
         _2xGBU_12___500lb_Laser_Guided_Bomb_ = (8, Weapons._2xGBU_12___500lb_Laser_Guided_Bomb_)
@@ -5883,7 +6460,8 @@ class F_16A_MLU(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.AFAC, task.Reconnaissance, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.AFAC, task.Reconnaissance, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -5899,7 +6477,6 @@ class RQ_1A_Predator(PlaneType):
     radio_frequency = 127.5
 
     class Liveries:
-
         class USA(Enum):
             USAF_Standard = "USAF Standard"
 
@@ -5925,7 +6502,6 @@ class Yak_40(PlaneType):
     max_speed = 570
 
     class Liveries:
-
         class USSR(Enum):
             Aeroflot = "Aeroflot"
 
@@ -5959,10 +6535,9 @@ class KC_135(PlaneType):
     fuel_max = 90700
     max_speed = 980
     tacan = True
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USA(Enum):
             Standard_USAF = "Standard USAF"
 
@@ -5983,7 +6558,7 @@ class FW_190D9(PlaneType):
     length = 12.13
     fuel_max = 388
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 38.4
 
     panel_radio = {
@@ -6003,7 +6578,6 @@ class FW_190D9(PlaneType):
     }
 
     class Properties:
-
         class FW_MW50TankContents:
             id = "FW_MW50TankContents"
 
@@ -6013,7 +6587,6 @@ class FW_190D9(PlaneType):
                 B_4_Gasoline = 2
 
     class Liveries:
-
         class USSR(Enum):
             FW_190D9_USSR = "FW-190D9_USSR"
 
@@ -6057,7 +6630,8 @@ class FW_190D9(PlaneType):
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -6069,7 +6643,7 @@ class FW_190A8(PlaneType):
     length = 12.13
     fuel_max = 409
     max_speed = 900
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 38.4
 
     panel_radio = {
@@ -6089,7 +6663,6 @@ class FW_190A8(PlaneType):
     }
 
     class Properties:
-
         class FW_MW50TankContents:
             id = "FW_MW50TankContents"
 
@@ -6098,7 +6671,6 @@ class FW_190A8(PlaneType):
                 Additional_fuel = 2
 
     class Liveries:
-
         class USSR(Enum):
             Captured_RA = "Captured_RA"
             FW_190A8 = "FW-190A8"
@@ -6382,7 +6954,8 @@ class FW_190A8(PlaneType):
 
         class Thailand(Enum):
             FW_190A8 = "FW-190A8"
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon1:
         ER_4_SC50 = (1, Weapons.ER_4_SC50)
@@ -6392,9 +6965,12 @@ class FW_190A8(PlaneType):
         SC_500_L2___500kg_GP_Bomb_LD = (1, Weapons.SC_500_L2___500kg_GP_Bomb_LD)
         SD_250_Stg___250kg_GP_Bomb_LD = (1, Weapons.SD_250_Stg___250kg_GP_Bomb_LD)
         SD_500_A___500kg_GP_Bomb_LD = (1, Weapons.SD_500_A___500kg_GP_Bomb_LD)
-        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (1, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
-        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (1, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
-        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (1, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
+        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (
+        1, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
+        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (
+        1, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
+        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (
+        1, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
         BF109K_4_FUEL_TANK = (1, Weapons.BF109K_4_FUEL_TANK)
 
     class Pylon2:
@@ -6405,7 +6981,8 @@ class FW_190A8(PlaneType):
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -6417,7 +6994,7 @@ class Bf_109K_4(PlaneType):
     length = 12.13
     fuel_max = 296
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 40
 
     panel_radio = {
@@ -6438,7 +7015,6 @@ class Bf_109K_4(PlaneType):
     }
 
     class Properties:
-
         class MW50TankContents:
             id = "MW50TankContents"
 
@@ -6455,7 +7031,6 @@ class Bf_109K_4(PlaneType):
                 Flare_Gun = 1
 
     class Liveries:
-
         class USSR(Enum):
             Bf_109_K4_Dogfight_BLUE = "Bf-109 K4 Dogfight BLUE"
             Green = "Green"
@@ -6916,7 +7491,8 @@ class Bf_109K_4(PlaneType):
 
     pylons = {1}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -6928,7 +7504,7 @@ class SpitfireLFMkIX(PlaneType):
     length = 12.13
     fuel_max = 247
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     panel_radio = {
@@ -6944,7 +7520,6 @@ class SpitfireLFMkIX(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             USSR_26th_GvIAP__PVO = "USSR 26th GvIAP, PVO"
             USSR_3rd_AE_57th_GvIAP = "USSR_3rd_AE_57th_GvIAP"
@@ -6973,23 +7548,27 @@ class SpitfireLFMkIX(PlaneType):
             _441_9G_Q = "441 9G-Q"
 
     class Pylon1:
-        British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
+        British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (
+        1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
         Beer_Bomb__L__on_LH_Spitfire_Wing_Carrier = (1, Weapons.Beer_Bomb__L__on_LH_Spitfire_Wing_Carrier)
         Beer_Bomb__D__on_LH_Spitfire_Wing_Carrier = (1, Weapons.Beer_Bomb__D__on_LH_Spitfire_Wing_Carrier)
 
     class Pylon2:
         SPITFIRE_45GAL_SLIPPER_TANK = (2, Weapons.SPITFIRE_45GAL_SLIPPER_TANK)
         SPITFIRE_45GAL_TORPEDO_TANK = (2, Weapons.SPITFIRE_45GAL_TORPEDO_TANK)
-        British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = (2, Weapons.British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3)
+        British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = (
+        2, Weapons.British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3)
 
     class Pylon3:
-        British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = (3, Weapons.British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier)
+        British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = (
+        3, Weapons.British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier)
         Beer_Bomb__L__on_RH_Spitfire_Wing_Carrier = (3, Weapons.Beer_Bomb__L__on_RH_Spitfire_Wing_Carrier)
         Beer_Bomb__D__on_RH_Spitfire_Wing_Carrier = (3, Weapons.Beer_Bomb__D__on_RH_Spitfire_Wing_Carrier)
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -7001,7 +7580,7 @@ class SpitfireLFMkIXCW(PlaneType):
     length = 12.13
     fuel_max = 247
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     panel_radio = {
@@ -7017,7 +7596,6 @@ class SpitfireLFMkIXCW(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             USSR_26th_GvIAP__PVO = "USSR 26th GvIAP, PVO"
             USSR_3rd_AE_57th_GvIAP = "USSR_3rd_AE_57th_GvIAP"
@@ -7044,23 +7622,27 @@ class SpitfireLFMkIXCW(PlaneType):
             _421_RCAF_AU_H = "421 RCAF AU-H"
 
     class Pylon1:
-        British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
+        British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (
+        1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
         Beer_Bomb__L__on_LH_Spitfire_Wing_Carrier = (1, Weapons.Beer_Bomb__L__on_LH_Spitfire_Wing_Carrier)
         Beer_Bomb__D__on_LH_Spitfire_Wing_Carrier = (1, Weapons.Beer_Bomb__D__on_LH_Spitfire_Wing_Carrier)
 
     class Pylon2:
         SPITFIRE_45GAL_SLIPPER_TANK = (2, Weapons.SPITFIRE_45GAL_SLIPPER_TANK)
         SPITFIRE_45GAL_TORPEDO_TANK = (2, Weapons.SPITFIRE_45GAL_TORPEDO_TANK)
-        British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = (2, Weapons.British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3)
+        British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3 = (
+        2, Weapons.British_GP_500LBS_Bomb_MK4_on_British_UniversalBC_MK3)
 
     class Pylon3:
-        British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = (3, Weapons.British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier)
+        British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier = (
+        3, Weapons.British_GP_250LBS_Bomb_MK4_on_RH_Spitfire_Wing_Carrier)
         Beer_Bomb__L__on_RH_Spitfire_Wing_Carrier = (3, Weapons.Beer_Bomb__L__on_RH_Spitfire_Wing_Carrier)
         Beer_Bomb__D__on_RH_Spitfire_Wing_Carrier = (3, Weapons.Beer_Bomb__D__on_RH_Spitfire_Wing_Carrier)
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -7086,7 +7668,6 @@ class P_51D(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             Bare_Metal = "Bare Metal"
             Dogfight_Blue = "Dogfight Blue"
@@ -7579,7 +8160,8 @@ class P_51D(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack,
+             task.AntishipStrike]
     task_default = task.CAS
 
 
@@ -7642,7 +8224,8 @@ class P_51D_30_NA(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack,
+             task.AntishipStrike]
     task_default = task.CAS
 
 
@@ -7652,9 +8235,9 @@ class P_47D_30(PlaneType):
     height = 4.77
     width = 12.42
     length = 11
-    fuel_max = 830
+    fuel_max = 1007
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 105
 
     panel_radio = {
@@ -7678,7 +8261,6 @@ class P_47D_30(PlaneType):
     }
 
     class Properties:
-
         class WaterTankContents:
             id = "WaterTankContents"
 
@@ -7687,7 +8269,6 @@ class P_47D_30(PlaneType):
                 Water = 1
 
     class Liveries:
-
         class USSR(Enum):
             _1st_Brazilian_Ftr_Sq_Jambock_A1_Menezes = "1st Brazilian Ftr Sq-Jambock A1-Menezes"
             USAAF_509th_FS__405th_FG__ETO_1944__Chief_Ski_U_Mah_D40 = "USAAF 509th FS, 405th FG, ETO 1944, Chief Ski-U-Mah D40"
@@ -8204,7 +8785,8 @@ class P_47D_30(PlaneType):
         AN_M64___500lb_GP_Bomb_LD = (1, Weapons.AN_M64___500lb_GP_Bomb_LD)
         _108_US_gal__Paper_Fuel_Tank = (1, Weapons._108_US_gal__Paper_Fuel_Tank)
         _110_US_gal__Fuel_Tank = (1, Weapons._110_US_gal__Fuel_Tank)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon2:
         AN_M30A1___100lb_GP_Bomb_LD = (2, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8220,7 +8802,8 @@ class P_47D_30(PlaneType):
         M10_Smoke_Tank___green = (2, Weapons.M10_Smoke_Tank___green)
         M10_Smoke_Tank___blue = (2, Weapons.M10_Smoke_Tank___blue)
         M10_Smoke_Tank___white = (2, Weapons.M10_Smoke_Tank___white)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon3:
         AN_M30A1___100lb_GP_Bomb_LD = (3, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8239,7 +8822,8 @@ class P_47D_30(PlaneType):
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -8249,9 +8833,9 @@ class P_47D_30bl1(PlaneType):
     height = 4.77
     width = 12.42
     length = 11
-    fuel_max = 830
+    fuel_max = 1007
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 105
 
     panel_radio = {
@@ -8275,7 +8859,6 @@ class P_47D_30bl1(PlaneType):
     }
 
     class Properties:
-
         class WaterTankContents:
             id = "WaterTankContents"
 
@@ -8289,7 +8872,8 @@ class P_47D_30bl1(PlaneType):
         AN_M64___500lb_GP_Bomb_LD = (1, Weapons.AN_M64___500lb_GP_Bomb_LD)
         _108_US_gal__Paper_Fuel_Tank = (1, Weapons._108_US_gal__Paper_Fuel_Tank)
         _110_US_gal__Fuel_Tank = (1, Weapons._110_US_gal__Fuel_Tank)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon2:
         AN_M30A1___100lb_GP_Bomb_LD = (2, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8298,7 +8882,8 @@ class P_47D_30bl1(PlaneType):
         _108_US_gal__Paper_Fuel_Tank = (2, Weapons._108_US_gal__Paper_Fuel_Tank)
         _110_US_gal__Fuel_Tank = (2, Weapons._110_US_gal__Fuel_Tank)
         _150_US_gal__Fuel_Tank = (2, Weapons._150_US_gal__Fuel_Tank)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon3:
         AN_M30A1___100lb_GP_Bomb_LD = (3, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8310,7 +8895,8 @@ class P_47D_30bl1(PlaneType):
 
     pylons = {1, 2, 3}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -8320,9 +8906,9 @@ class P_47D_40(PlaneType):
     height = 4.77
     width = 12.42
     length = 11
-    fuel_max = 830
+    fuel_max = 1007
     max_speed = 828
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 105
 
     panel_radio = {
@@ -8346,7 +8932,6 @@ class P_47D_40(PlaneType):
     }
 
     class Properties:
-
         class WaterTankContents:
             id = "WaterTankContents"
 
@@ -8360,7 +8945,8 @@ class P_47D_40(PlaneType):
         AN_M64___500lb_GP_Bomb_LD = (1, Weapons.AN_M64___500lb_GP_Bomb_LD)
         _108_US_gal__Paper_Fuel_Tank = (1, Weapons._108_US_gal__Paper_Fuel_Tank)
         _110_US_gal__Fuel_Tank = (1, Weapons._110_US_gal__Fuel_Tank)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon2:
         AN_M30A1___100lb_GP_Bomb_LD = (2, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8376,7 +8962,8 @@ class P_47D_40(PlaneType):
         M10_Smoke_Tank___green = (2, Weapons.M10_Smoke_Tank___green)
         M10_Smoke_Tank___blue = (2, Weapons.M10_Smoke_Tank___blue)
         M10_Smoke_Tank___white = (2, Weapons.M10_Smoke_Tank___white)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon3:
         AN_M30A1___100lb_GP_Bomb_LD = (3, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -8403,7 +8990,8 @@ class P_47D_40(PlaneType):
 
     pylons = {1, 2, 3, 4, 5}
 
-    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -8419,7 +9007,6 @@ class A_20G(PlaneType):
     }
 
     class Liveries:
-
         class UK(Enum):
             _107_Sqn = "107 Sqn"
 
@@ -8468,7 +9055,6 @@ class A_10A(PlaneType):
     }
 
     class Liveries:
-
         class Georgia(Enum):
             Fictional_Georgian_Grey = "Fictional Georgian Grey"
             Fictional_Georgian_Olive = "Fictional Georgian Olive"
@@ -8570,7 +9156,7 @@ class A_10A(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (1, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (1, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (1, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
-        CBU_97___10_x_CEM_Cluster_Bomb = (1, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (1, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_82___500lb_GP_Bomb_LD = (1, Weapons.Mk_82___500lb_GP_Bomb_LD)
         LAU_105_AIS_ASQ_T50_L = (1, Weapons.LAU_105_AIS_ASQ_T50_L)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (1, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
@@ -8582,23 +9168,36 @@ class A_10A(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (2, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        CBU_97___10_x_CEM_Cluster_Bomb = (2, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        CBU_97___10_x_SFW_Cluster_Bomb = (2, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (2, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon3:
@@ -8618,24 +9217,38 @@ class A_10A(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (3, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon4:
@@ -8647,25 +9260,39 @@ class A_10A(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (4, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (4, Weapons.BRU_42_3_BDU_33)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         Fuel_Tank_FT600 = (4, Weapons.Fuel_Tank_FT600)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (4, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon5:
@@ -8676,7 +9303,7 @@ class A_10A(PlaneType):
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (5, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (5, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (5, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (5, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (5, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon6:
@@ -8688,7 +9315,7 @@ class A_10A(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (6, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (6, Weapons.BRU_42_3_BDU_33)
         Fuel_Tank_FT600 = (6, Weapons.Fuel_Tank_FT600)
-        CBU_97___10_x_CEM_Cluster_Bomb = (6, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (6, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon7:
@@ -8699,7 +9326,7 @@ class A_10A(PlaneType):
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (7, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (7, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (7, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (7, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon8:
@@ -8711,25 +9338,39 @@ class A_10A(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (8, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (8, Weapons.BRU_42_3_BDU_33)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         Fuel_Tank_FT600 = (8, Weapons.Fuel_Tank_FT600)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (8, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon9:
@@ -8749,24 +9390,38 @@ class A_10A(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (9, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BRU_42_3_BDU_33 = (9, Weapons.BRU_42_3_BDU_33)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        CBU_97___10_x_CEM_Cluster_Bomb = (9, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (9, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon10:
@@ -8776,23 +9431,38 @@ class A_10A(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (10, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (10, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (10, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        CBU_97___10_x_CEM_Cluster_Bomb = (10, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        CBU_97___10_x_SFW_Cluster_Bomb = (10, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (10, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
 
     class Pylon11:
@@ -8814,7 +9484,7 @@ class A_10A(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (11, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (11, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
-        CBU_97___10_x_CEM_Cluster_Bomb = (11, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (11, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         Mk_82___500lb_GP_Bomb_LD = (11, Weapons.Mk_82___500lb_GP_Bomb_LD)
         LAU_105_AIS_ASQ_T50_R = (11, Weapons.LAU_105_AIS_ASQ_T50_R)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (11, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
@@ -8853,7 +9523,6 @@ class A_10C(PlaneType):
     }
 
     class Liveries:
-
         class Georgia(Enum):
             Fictional_Georgian_Grey = "Fictional Georgian Grey"
             Fictional_Georgian_Olive = "Fictional Georgian Olive"
@@ -8952,12 +9621,13 @@ class A_10C(PlaneType):
         Smokewinder___orange = (1, Weapons.Smokewinder___orange)
         GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (1, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (1, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        1, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (1, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (1, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (1, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         ALQ_184 = (1, Weapons.ALQ_184)
-        CBU_97___10_x_CEM_Cluster_Bomb = (1, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (1, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_105_AIS_ASQ_T50_L = (1, Weapons.LAU_105_AIS_ASQ_T50_L)
         LAU_105_2_AIM_9L = (1, Weapons.LAU_105_2_AIM_9L)
         LAU_105_1_AIM_9L_L = (1, Weapons.LAU_105_1_AIM_9L_L)
@@ -8970,26 +9640,40 @@ class A_10C(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (2, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (2, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        CBU_97___10_x_CEM_Cluster_Bomb = (2, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        CBU_97___10_x_SFW_Cluster_Bomb = (2, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
 
     class Pylon3:
@@ -9008,35 +9692,57 @@ class A_10C(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (3, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (3, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (3, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9045,7 +9751,7 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (3, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (3, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (3, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BRU_42_LS = (3, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
@@ -9059,13 +9765,16 @@ class A_10C(PlaneType):
         LAU_117_TGM_65H = (3, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (3, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (3, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
 
     class Pylon4:
         Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -9077,36 +9786,58 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (4, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (4, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (4, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9115,16 +9846,18 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (4, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (4, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (4, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (4, Weapons.MXU_648_TP)
         BRU_42_LS = (4, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (4, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (4, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
 
     class Pylon5:
@@ -9136,18 +9869,21 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (5, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (5, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        5, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (5, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (5, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         MXU_648_TP = (5, Weapons.MXU_648_TP)
         BRU_42_LS = (5, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (5, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (5, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (5, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (5, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
 
     class Pylon6:
         Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -9161,8 +9897,9 @@ class A_10C(PlaneType):
         MXU_648_TP = (6, Weapons.MXU_648_TP)
         BRU_42_LS = (6, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (6, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (6, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         Fuel_Tank_FT600 = (6, Weapons.Fuel_Tank_FT600)
 
     class Pylon7:
@@ -9174,18 +9911,21 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         MXU_648_TP = (7, Weapons.MXU_648_TP)
         BRU_42_LS = (7, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (7, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
 
     class Pylon8:
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -9197,36 +9937,58 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (8, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (8, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (8, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (8, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9235,16 +9997,18 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (8, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (8, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (8, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (8, Weapons.MXU_648_TP)
         BRU_42_LS = (8, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (8, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (8, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
 
     class Pylon9:
@@ -9262,36 +10026,58 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (9, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (9, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (9, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (9, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (9, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (9, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (9, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (9, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9300,7 +10086,7 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (9, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (9, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (9, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (9, Weapons.MXU_648_TP)
         BRU_42_LS = (9, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (9, Weapons.BRU_42_3_BDU_33)
@@ -9314,13 +10100,16 @@ class A_10C(PlaneType):
         LAU_117_TGM_65H = (9, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (9, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (9, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (9, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
 
     class Pylon10:
         Mk_82___500lb_GP_Bomb_LD = (10, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -9331,26 +10120,42 @@ class A_10C(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (10, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (10, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (10, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        CBU_97___10_x_CEM_Cluster_Bomb = (10, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (10, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        CBU_97___10_x_SFW_Cluster_Bomb = (10, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        10, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
 
     class Pylon11:
         LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM = (11, Weapons.LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM)
@@ -9367,8 +10172,9 @@ class A_10C(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (11, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_82___500lb_GP_Bomb_LD = (11, Weapons.Mk_82___500lb_GP_Bomb_LD)
         CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (11, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        CBU_97___10_x_CEM_Cluster_Bomb = (11, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        11, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (11, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_105_1_AIM_9M_R = (11, Weapons.LAU_105_1_AIM_9M_R)
         LAU_105 = (11, Weapons.LAU_105)
         ALQ_184 = (11, Weapons.ALQ_184)
@@ -9427,12 +10233,13 @@ class A_10C_2(PlaneType):
         Smokewinder___orange = (1, Weapons.Smokewinder___orange)
         GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (1, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (1, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        1, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (1, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (1, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (1, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         ALQ_184 = (1, Weapons.ALQ_184)
-        CBU_97___10_x_CEM_Cluster_Bomb = (1, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (1, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_105_AIS_ASQ_T50_L = (1, Weapons.LAU_105_AIS_ASQ_T50_L)
         LAU_105_2_AIM_9L = (1, Weapons.LAU_105_2_AIM_9L)
         LAU_105_1_AIM_9L_L = (1, Weapons.LAU_105_1_AIM_9L_L)
@@ -9445,29 +10252,45 @@ class A_10C_2(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (2, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (2, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        CBU_97___10_x_CEM_Cluster_Bomb = (2, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        CBU_97___10_x_SFW_Cluster_Bomb = (2, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
 
     class Pylon3:
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (3, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
@@ -9486,35 +10309,57 @@ class A_10C_2(PlaneType):
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (3, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (3, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (3, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9523,7 +10368,7 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (3, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (3, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (3, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BRU_42_LS = (3, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
@@ -9537,17 +10382,24 @@ class A_10C_2(PlaneType):
         LAU_117_TGM_65H = (3, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (3, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (3, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (3, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon4:
@@ -9560,36 +10412,58 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (4, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        4, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (4, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        4, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (4, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (4, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (4, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9598,21 +10472,27 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (4, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (4, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (4, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (4, Weapons.MXU_648_TP)
         BRU_42_LS = (4, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (4, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (4, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (4, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon5:
@@ -9624,18 +10504,21 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (5, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (5, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (5, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        5, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (5, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (5, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         MXU_648_TP = (5, Weapons.MXU_648_TP)
         BRU_42_LS = (5, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (5, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (5, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (5, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (5, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (5, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (5, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon6:
@@ -9650,8 +10533,9 @@ class A_10C_2(PlaneType):
         MXU_648_TP = (6, Weapons.MXU_648_TP)
         BRU_42_LS = (6, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (6, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (6, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         Fuel_Tank_FT600 = (6, Weapons.Fuel_Tank_FT600)
 
     class Pylon7:
@@ -9663,18 +10547,21 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
         MXU_648_TP = (7, Weapons.MXU_648_TP)
         BRU_42_LS = (7, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (7, Weapons.BRU_42_3_BDU_33)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (7, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (7, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon8:
@@ -9687,36 +10574,58 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (8, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        8, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (8, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (8, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (8, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9725,21 +10634,27 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (8, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (8, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (8, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (8, Weapons.MXU_648_TP)
         BRU_42_LS = (8, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (8, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (8, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (8, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (8, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon9:
@@ -9758,36 +10673,58 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (9, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_10___2000lb_Laser_Guided_Bomb = (9, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (9, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        9, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (9, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (9, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-#ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        9, Weapons.BRU_42_with_3_x_LAU_68_pods___21_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        # ERRR {B2DC636E-5E45-42db-81D9-38F3E059107C}
         LAU_131x3_HYDRA_70_MK1 = (9, Weapons.LAU_131x3_HYDRA_70_MK1)
         LAU_131x3_HYDRA_70_MK5 = (9, Weapons.LAU_131x3_HYDRA_70_MK5)
         LAU_131x3_HYDRA_70_MK61 = (9, Weapons.LAU_131x3_HYDRA_70_MK61)
@@ -9796,7 +10733,7 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_WTU1B = (9, Weapons.LAU_131x3_HYDRA_70_WTU1B)
         LAU_131x3_HYDRA_70_M257 = (9, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (9, Weapons.LAU_131x3_HYDRA_70_M274)
-#ERRR LAU_131x3_HYDRA_70_M278
+        # ERRR LAU_131x3_HYDRA_70_M278
         MXU_648_TP = (9, Weapons.MXU_648_TP)
         BRU_42_LS = (9, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (9, Weapons.BRU_42_3_BDU_33)
@@ -9810,17 +10747,24 @@ class A_10C_2(PlaneType):
         LAU_117_TGM_65H = (9, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (9, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (9, Weapons.BRU_42_3_GBU_12)
-        CBU_97___10_x_CEM_Cluster_Bomb = (9, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        CBU_105___10_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_CEM__CBU_with_WCMD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        CBU_105___10_x_SFW__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (
+        9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (9, Weapons.GBU_54B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon10:
@@ -9832,28 +10776,46 @@ class A_10C_2(PlaneType):
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (10, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (10, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         CBU_87___202_x_CEM_Cluster_Bomb = (10, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
-        CBU_97___10_x_CEM_Cluster_Bomb = (10, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (10, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (10, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {1FE353C6-5EB6-4d22-9CFD-6DB384EC7296}
+        CBU_97___10_x_SFW_Cluster_Bomb = (10, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        10, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        10, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
 
     class Pylon11:
         LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM = (11, Weapons.LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM)
@@ -9870,8 +10832,9 @@ class A_10C_2(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (11, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_82___500lb_GP_Bomb_LD = (11, Weapons.Mk_82___500lb_GP_Bomb_LD)
         CBU_87___202_x_CEM_Cluster_Bomb = (11, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (11, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
-        CBU_97___10_x_CEM_Cluster_Bomb = (11, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        11, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        CBU_97___10_x_SFW_Cluster_Bomb = (11, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_105_1_AIM_9M_R = (11, Weapons.LAU_105_1_AIM_9M_R)
         LAU_105 = (11, Weapons.LAU_105)
         ALQ_184 = (11, Weapons.ALQ_184)
@@ -9900,7 +10863,7 @@ class AJS37(PlaneType):
     charge_total = 280
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     panel_radio = {
@@ -9925,7 +10888,6 @@ class AJS37(PlaneType):
     }
 
     class Properties:
-
         class Rb04GroupTarget:
             id = "Rb04GroupTarget"
 
@@ -9961,7 +10923,6 @@ class AJS37(PlaneType):
                 Disallow_cartridge_switching = 3
 
     class Liveries:
-
         class USSR(Enum):
             _37 = "37"
             BareMetal = "BareMetal"
@@ -10462,7 +11423,8 @@ class AJS37(PlaneType):
         Rb_74__AIM_9L__Sidewinder_IR_AAM = (2, Weapons.Rb_74__AIM_9L__Sidewinder_IR_AAM)
         Rb_24J__AIM_9P__Sidewinder_IR_AAM = (2, Weapons.Rb_24J__AIM_9P__Sidewinder_IR_AAM)
         Rb_24__AIM_9B__Sidewinder_IR_AAM = (2, Weapons.Rb_24__AIM_9B__Sidewinder_IR_AAM)
-        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (2, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
+        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (
+        2, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_ = (2, Weapons.BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_ = (2, Weapons.BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_)
         AKAN_M_55_Gunpod__150_rnds_MINGR55_HE = (2, Weapons.AKAN_M_55_Gunpod__150_rnds_MINGR55_HE)
@@ -10476,7 +11438,7 @@ class AJS37(PlaneType):
         _2x_80kg_LYSB_71_Illumination_Bomb = (2, Weapons._2x_80kg_LYSB_71_Illumination_Bomb)
         _4x_SB_M_71_120kg_GP_Bomb_Low_drag = (2, Weapons._4x_SB_M_71_120kg_GP_Bomb_Low_drag)
         _4x_SB_M_71_120kg_GP_Bomb_High_drag = (2, Weapons._4x_SB_M_71_120kg_GP_Bomb_High_drag)
-#ERRR {MERPYLON}
+        # ERRR {MERPYLON}
         Rb_75A__AGM_65A_Maverick___TV_ASM_ = (2, Weapons.Rb_75A__AGM_65A_Maverick___TV_ASM_)
         Rb_75B__AGM_65B_Maverick___TV_ASM_ = (2, Weapons.Rb_75B__AGM_65B_Maverick___TV_ASM_)
         Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_ = (2, Weapons.Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_)
@@ -10485,7 +11447,8 @@ class AJS37(PlaneType):
         Rb_74__AIM_9L__Sidewinder_IR_AAM = (3, Weapons.Rb_74__AIM_9L__Sidewinder_IR_AAM)
         Rb_24J__AIM_9P__Sidewinder_IR_AAM = (3, Weapons.Rb_24J__AIM_9P__Sidewinder_IR_AAM)
         Rb_24__AIM_9B__Sidewinder_IR_AAM = (3, Weapons.Rb_24__AIM_9B__Sidewinder_IR_AAM)
-        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (3, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
+        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (
+        3, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_ = (3, Weapons.BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_ = (3, Weapons.BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_)
         ARAK_M_70B_HE_6x_135mm_UnGd_Rkts__Shu70_HE_FRAG = (3, Weapons.ARAK_M_70B_HE_6x_135mm_UnGd_Rkts__Shu70_HE_FRAG)
@@ -10494,7 +11457,7 @@ class AJS37(PlaneType):
         _2x_80kg_LYSB_71_Illumination_Bomb = (3, Weapons._2x_80kg_LYSB_71_Illumination_Bomb)
         _4x_SB_M_71_120kg_GP_Bomb_Low_drag = (3, Weapons._4x_SB_M_71_120kg_GP_Bomb_Low_drag)
         _4x_SB_M_71_120kg_GP_Bomb_High_drag = (3, Weapons._4x_SB_M_71_120kg_GP_Bomb_High_drag)
-#ERRR {MERPYLON}
+        # ERRR {MERPYLON}
         Rb_75A__AGM_65A_Maverick___TV_ASM_ = (3, Weapons.Rb_75A__AGM_65A_Maverick___TV_ASM_)
         Rb_75B__AGM_65B_Maverick___TV_ASM_ = (3, Weapons.Rb_75B__AGM_65B_Maverick___TV_ASM_)
         Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_ = (3, Weapons.Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_)
@@ -10506,7 +11469,8 @@ class AJS37(PlaneType):
         Rb_74__AIM_9L__Sidewinder_IR_AAM = (5, Weapons.Rb_74__AIM_9L__Sidewinder_IR_AAM)
         Rb_24J__AIM_9P__Sidewinder_IR_AAM = (5, Weapons.Rb_24J__AIM_9P__Sidewinder_IR_AAM)
         Rb_24__AIM_9B__Sidewinder_IR_AAM = (5, Weapons.Rb_24__AIM_9B__Sidewinder_IR_AAM)
-        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (5, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
+        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (
+        5, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_ = (5, Weapons.BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_ = (5, Weapons.BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_)
         ARAK_M_70B_HE_6x_135mm_UnGd_Rkts__Shu70_HE_FRAG = (5, Weapons.ARAK_M_70B_HE_6x_135mm_UnGd_Rkts__Shu70_HE_FRAG)
@@ -10518,13 +11482,15 @@ class AJS37(PlaneType):
         Rb_75A__AGM_65A_Maverick___TV_ASM_ = (5, Weapons.Rb_75A__AGM_65A_Maverick___TV_ASM_)
         Rb_75B__AGM_65B_Maverick___TV_ASM_ = (5, Weapons.Rb_75B__AGM_65B_Maverick___TV_ASM_)
         Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_ = (5, Weapons.Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_)
-#ERRR {MERPYLON}
+
+    # ERRR {MERPYLON}
 
     class Pylon6:
         Rb_74__AIM_9L__Sidewinder_IR_AAM = (6, Weapons.Rb_74__AIM_9L__Sidewinder_IR_AAM)
         Rb_24J__AIM_9P__Sidewinder_IR_AAM = (6, Weapons.Rb_24J__AIM_9P__Sidewinder_IR_AAM)
         Rb_24__AIM_9B__Sidewinder_IR_AAM = (6, Weapons.Rb_24__AIM_9B__Sidewinder_IR_AAM)
-        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (6, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
+        BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_ = (
+        6, Weapons.BK_90_MJ12__12x_MJ2_HEAT___36x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_ = (6, Weapons.BK_90_MJ1__72_x_MJ1_HE_FRAG_Bomblets_)
         BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_ = (6, Weapons.BK_90_MJ2__24_x_MJ2_HEAT_Bomblets_)
         AKAN_M_55_Gunpod__150_rnds_MINGR55_HE = (6, Weapons.AKAN_M_55_Gunpod__150_rnds_MINGR55_HE)
@@ -10540,7 +11506,7 @@ class AJS37(PlaneType):
         _2x_80kg_LYSB_71_Illumination_Bomb = (6, Weapons._2x_80kg_LYSB_71_Illumination_Bomb)
         _4x_SB_M_71_120kg_GP_Bomb_Low_drag = (6, Weapons._4x_SB_M_71_120kg_GP_Bomb_Low_drag)
         _4x_SB_M_71_120kg_GP_Bomb_High_drag = (6, Weapons._4x_SB_M_71_120kg_GP_Bomb_High_drag)
-#ERRR {MERPYLON}
+        # ERRR {MERPYLON}
         Rb_75A__AGM_65A_Maverick___TV_ASM_ = (6, Weapons.Rb_75A__AGM_65A_Maverick___TV_ASM_)
         Rb_75B__AGM_65B_Maverick___TV_ASM_ = (6, Weapons.Rb_75B__AGM_65B_Maverick___TV_ASM_)
         Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_ = (6, Weapons.Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_Whd_)
@@ -10551,7 +11517,8 @@ class AJS37(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
-    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.AFAC, task.CAP, task.Escort, task.SEAD, task.FighterSweep, task.Intercept, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.AFAC, task.CAP, task.Escort,
+             task.SEAD, task.FighterSweep, task.Intercept, task.AntishipStrike, task.Reconnaissance]
     task_default = task.GroundAttack
 
 
@@ -10569,7 +11536,7 @@ class AV8BNA(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     tacan = True
-    category = "Air"  #{C168A850-3C0B-436a-95B5-C4A015552560}
+    category = "Air"  # {C168A850-3C0B-436a-95B5-C4A015552560}
     radio_frequency = 243
 
     panel_radio = {
@@ -10688,7 +11655,6 @@ class AV8BNA(PlaneType):
     }
 
     class Properties:
-
         class MountNVG:
             id = "MountNVG"
 
@@ -10767,7 +11733,6 @@ class AV8BNA(PlaneType):
             id = "AAR_Zone3"
 
     class Liveries:
-
         class USSR(Enum):
             default = "default"
             VMA_211 = "VMA-211"
@@ -12293,20 +13258,29 @@ class AV8BNA(PlaneType):
         _3_GBU_54_V_1_B = (2, Weapons._3_GBU_54_V_1_B)
         BDU_33___25lb_Practice_Bomb_LD = (2, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BRU_42_3_BDU_33 = (2, Weapons.BRU_42_3_BDU_33)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (2, Weapons.LAU_117_AGM_65F)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        2, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
         Smokewinder___red = (2, Weapons.Smokewinder___red)
         Smokewinder___green = (2, Weapons.Smokewinder___green)
         Smokewinder___blue = (2, Weapons.Smokewinder___blue)
@@ -12339,18 +13313,26 @@ class AV8BNA(PlaneType):
         _2_GBU_54_V_1_B = (3, Weapons._2_GBU_54_V_1_B)
         BDU_33___25lb_Practice_Bomb_LD = (3, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (3, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        3, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (3, Weapons.LAU_117_AGM_65F)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        3, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         AN_AAQ_28_LITENING___Targeting_Pod = (3, Weapons.AN_AAQ_28_LITENING___Targeting_Pod)
         AERO_1D_300_Gallons_Fuel_Tank_ = (3, Weapons.AERO_1D_300_Gallons_Fuel_Tank_)
         AERO_1D_300_Gallons_Fuel_Tank__Empty_ = (3, Weapons.AERO_1D_300_Gallons_Fuel_Tank__Empty_)
@@ -12385,18 +13367,26 @@ class AV8BNA(PlaneType):
         _2_GBU_54_V_1_B_ = (6, Weapons._2_GBU_54_V_1_B_)
         BDU_33___25lb_Practice_Bomb_LD = (6, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BRU_42_3_BDU_33 = (6, Weapons.BRU_42_3_BDU_33)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (6, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        6, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (6, Weapons.LAU_117_AGM_65F)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (6, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        6, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (6, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (6, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        6, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        6, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         AN_AAQ_28_LITENING___Targeting_Pod = (6, Weapons.AN_AAQ_28_LITENING___Targeting_Pod)
         AERO_1D_300_Gallons_Fuel_Tank_ = (6, Weapons.AERO_1D_300_Gallons_Fuel_Tank_)
         AERO_1D_300_Gallons_Fuel_Tank__Empty_ = (6, Weapons.AERO_1D_300_Gallons_Fuel_Tank__Empty_)
@@ -12431,20 +13421,29 @@ class AV8BNA(PlaneType):
         _3_GBU_54_V_1_B = (7, Weapons._3_GBU_54_V_1_B)
         BDU_33___25lb_Practice_Bomb_LD = (7, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BRU_42_3_BDU_33 = (7, Weapons.BRU_42_3_BDU_33)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (7, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        7, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (7, Weapons.LAU_117_AGM_65F)
-        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (7, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        7, Weapons.LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-#ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (7, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
-        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (7, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        7, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        # ERRR {9115A5AF-6D5C-4b6b-BEA9-31D48B5C6001}
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (
+        7, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (
+        7, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (7, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
-        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (7, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (
+        7, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
         Smokewinder___red = (7, Weapons.Smokewinder___red)
         Smokewinder___green = (7, Weapons.Smokewinder___green)
         Smokewinder___blue = (7, Weapons.Smokewinder___blue)
@@ -12475,7 +13474,8 @@ class AV8BNA(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8}
 
-    tasks = [task.GroundAttack, task.PinpointStrike, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike, task.SEAD, task.Escort]
+    tasks = [task.GroundAttack, task.PinpointStrike, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike,
+             task.SEAD, task.Escort]
     task_default = task.CAS
 
 
@@ -12493,10 +13493,9 @@ class KC130(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     tacan = True
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USA(Enum):
             default = "default"
 
@@ -12520,10 +13519,9 @@ class KC135MPRS(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 2
     tacan = True
-    category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
+    category = "Tankers"  # {8A302789-A55D-4897-B647-66493FA6826F}
 
     class Liveries:
-
         class USA(Enum):
             _100th_ARW = "100th ARW"
             _22nd_ARW = "22nd ARW"
@@ -12542,7 +13540,7 @@ class C_101EB(PlaneType):
     length = 12.25
     fuel_max = 1796
     max_speed = 925.2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 225
 
     panel_radio = {
@@ -12581,7 +13579,6 @@ class C_101EB(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -12609,7 +13606,6 @@ class C_101EB(PlaneType):
             id = "SmokeOnGround"
 
     class Liveries:
-
         class USSR(Enum):
             default = "default"
 
@@ -12857,7 +13853,7 @@ class C_101CC(PlaneType):
     length = 12.25
     fuel_max = 1796
     max_speed = 925.2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 225
 
     panel_radio = {
@@ -12898,7 +13894,6 @@ class C_101CC(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -12929,7 +13924,6 @@ class C_101CC(PlaneType):
                 Rear_seat = 2
 
     class Liveries:
-
         class USSR(Enum):
             AVIODEV_Skin = "AVIODEV Skin"
 
@@ -13165,9 +14159,12 @@ class C_101CC(PlaneType):
         Mk_82___500lb_GP_Bomb_LD = (2, Weapons.Mk_82___500lb_GP_Bomb_LD)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (2, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_100___100kg_GP_Bomb_LD = (2, Weapons.FAB_100___100kg_GP_Bomb_LD)
@@ -13177,9 +14174,12 @@ class C_101CC(PlaneType):
 
     class Pylon3:
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (3, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
@@ -13196,9 +14196,12 @@ class C_101CC(PlaneType):
 
     class Pylon5:
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (5, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        5, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (5, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
@@ -13214,9 +14217,12 @@ class C_101CC(PlaneType):
         Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (6, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        6, Weapons.LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (6, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_100___100kg_GP_Bomb_LD = (6, Weapons.FAB_100___100kg_GP_Bomb_LD)
@@ -13231,7 +14237,8 @@ class C_101CC(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
-    tasks = [task.CAP, task.CAS, task.Escort, task.FighterSweep, task.GroundAttack, task.Intercept, task.AntishipStrike, task.RunwayAttack, task.AFAC, task.Reconnaissance]
+    tasks = [task.CAP, task.CAS, task.Escort, task.FighterSweep, task.GroundAttack, task.Intercept, task.AntishipStrike,
+             task.RunwayAttack, task.AFAC, task.Reconnaissance]
     task_default = task.CAS
 
 
@@ -13248,11 +14255,10 @@ class J_11A(PlaneType):
     charge_total = 192
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     class Liveries:
-
         class China(Enum):
             PLAAF_14th_AD = "PLAAF 14th AD"
             PLAAF_14th_AD__Reworked = "PLAAF 14th AD (Reworked)"
@@ -13305,18 +14311,22 @@ class J_11A(PlaneType):
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (3, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
         R_77__AA_12_Adder____Active_Rdr = (3, Weapons.R_77__AA_12_Adder____Active_Rdr)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (3, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (3, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (3, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
@@ -13338,10 +14348,12 @@ class J_11A(PlaneType):
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (4, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
@@ -13353,10 +14365,12 @@ class J_11A(PlaneType):
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        5, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (5, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
@@ -13374,11 +14388,13 @@ class J_11A(PlaneType):
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        6, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (6, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (6, Weapons.SAB_100___100kg_flare_illumination_Bomb)
@@ -13396,10 +14412,12 @@ class J_11A(PlaneType):
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        7, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (7, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         SAB_100___100kg_flare_illumination_Bomb = (7, Weapons.SAB_100___100kg_flare_illumination_Bomb)
@@ -13412,18 +14430,22 @@ class J_11A(PlaneType):
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (8, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
         R_77__AA_12_Adder____Active_Rdr = (8, Weapons.R_77__AA_12_Adder____Active_Rdr)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        8, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
         SAB_100___100kg_flare_illumination_Bomb = (8, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        8, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = (8, Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (8, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
         B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk = (8, Weapons.B_8M1_pod___20_x_S_8TsM__80mm_UnGd_Rkts__Smk)
@@ -13459,7 +14481,8 @@ class J_11A(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Intercept, task.Escort, task.FighterSweep, task.AFAC, task.CAS, task.GroundAttack, task.RunwayAttack, task.AntishipStrike]
+    tasks = [task.CAP, task.Intercept, task.Escort, task.FighterSweep, task.AFAC, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
 
 
@@ -13477,7 +14500,7 @@ class JF_17(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 243
 
     panel_radio = {
@@ -13515,7 +14538,6 @@ class JF_17(PlaneType):
     }
 
     class Properties:
-
         class LaserCode100:
             id = "LaserCode100"
 
@@ -13529,7 +14551,6 @@ class JF_17(PlaneType):
             id = "AARProbe"
 
     class Liveries:
-
         class USSR(Enum):
             _Splinter__Camo_for_Blue_Side__Fictional = "'Splinter' Camo for Blue Side (Fictional)"
 
@@ -13917,7 +14938,8 @@ class JF_17(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7}
 
-    tasks = [task.Intercept, task.CAP, task.AFAC, task.Reconnaissance, task.Escort, task.FighterSweep, task.SEAD, task.AntishipStrike, task.CAS, task.GroundAttack, task.PinpointStrike, task.RunwayAttack]
+    tasks = [task.Intercept, task.CAP, task.AFAC, task.Reconnaissance, task.Escort, task.FighterSweep, task.SEAD,
+             task.AntishipStrike, task.CAS, task.GroundAttack, task.PinpointStrike, task.RunwayAttack]
     task_default = task.CAP
 
 
@@ -13929,10 +14951,9 @@ class KJ_2000(PlaneType):
     length = 46.59
     fuel_max = 70000
     max_speed = 849.996
-    category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
+    category = "AWACS"  # {D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     class Liveries:
-
         class China(Enum):
             China_Air_Force_KJ_2000__Parade_93 = "China Air Force KJ-2000 (Parade 93)"
             China_Air_Force_KJ_2000 = "China Air Force KJ-2000"
@@ -13955,7 +14976,6 @@ class WingLoong_I(PlaneType):
     radio_frequency = 127.5
 
     class Liveries:
-
         class China(Enum):
             PLAAF = "PLAAF"
 
@@ -14034,7 +15054,6 @@ class Christen_Eagle_II(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -14048,7 +15067,6 @@ class Christen_Eagle_II(PlaneType):
                 Equally_Responsible = -2
 
     class Liveries:
-
         class USSR(Enum):
             C_FTIJ = "C-FTIJ"
             G_KLAW = "G-KLAW"
@@ -16450,7 +17468,7 @@ class F_16C_50(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     panel_radio = {
@@ -16513,7 +17531,6 @@ class F_16C_50(PlaneType):
     }
 
     class Properties:
-
         class LAU3ROF:
             id = "LAU3ROF"
 
@@ -16539,7 +17556,6 @@ class F_16C_50(PlaneType):
                 NVG = 2
 
     class Liveries:
-
         class Israel(Enum):
             IAF_101st_squadron = "IAF_101st_squadron"
             IAF_110th_Squadron = "IAF_110th_Squadron"
@@ -16626,7 +17642,8 @@ class F_16C_50(PlaneType):
         AIM_120C_5_AMRAAM___Active_Rdr_AAM = (2, Weapons.AIM_120C_5_AMRAAM___Active_Rdr_AAM)
         CATM_9M = (2, Weapons.CATM_9M)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (2, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon3:
         AIM_9M_Sidewinder_IR_AAM = (3, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -16646,12 +17663,13 @@ class F_16C_50(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        3, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (3, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (3, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD = (3, Weapons.TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_AGM_65G = (3, Weapons.LAU_117_AGM_65G)
@@ -16661,15 +17679,17 @@ class F_16C_50(PlaneType):
         LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_88_AGM_65H = (3, Weapons.LAU_88_AGM_65H)
         LAU_88_AGM_65H_3 = (3, Weapons.LAU_88_AGM_65H_3)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MXU_648_TP = (3, Weapons.MXU_648_TP)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        3, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
-        TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (3, Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
-        TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (3, Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
+        TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb = (3, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb)
+        TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_88_AGM_65H_2_L = (3, Weapons.LAU_88_AGM_65H_2_L)
 
@@ -16684,29 +17704,33 @@ class F_16C_50(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        4, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_84___2000lb_GP_Bomb_LD = (4, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (4, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (4, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
-        TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb)
+        TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD = (4, Weapons.TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD)
         Fuel_tank_370_gal = (4, Weapons.Fuel_tank_370_gal)
         MXU_648_TP = (4, Weapons.MXU_648_TP)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (4, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-#ERRR <CLEAN>
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        4, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        # ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (4, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
-        TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
-        TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
+        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        4, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb)
+        TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb)
 
     class Pylon5:
         Fuel_tank_300_gal = (5, Weapons.Fuel_tank_300_gal)
         MXU_648_TP = (5, Weapons.MXU_648_TP)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon6:
         LAU3_WP156 = (6, Weapons.LAU3_WP156)
@@ -16719,24 +17743,28 @@ class F_16C_50(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (6, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (6, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (6, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (6, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        6, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_84___2000lb_GP_Bomb_LD = (6, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (6, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (6, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (6, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (6, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
-        TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (6, Weapons.TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
-        TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = (6, Weapons.TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
+        TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb = (6, Weapons.TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb)
+        TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb = (6, Weapons.TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD = (6, Weapons.TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD)
         Fuel_tank_370_gal = (6, Weapons.Fuel_tank_370_gal)
         MXU_648_TP = (6, Weapons.MXU_648_TP)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (6, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-#ERRR <CLEAN>
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        6, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        # ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (6, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
-        TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_ = (6, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_)
-        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (6, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
-        TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_)
-        TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_)
+        TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_ = (
+        6, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_)
+        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (
+        6, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_)
+        TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_)
 
     class Pylon7:
         AIM_9M_Sidewinder_IR_AAM = (7, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -16756,12 +17784,13 @@ class F_16C_50(PlaneType):
         Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = (7, Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (7, Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (
+        7, Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         Mk_84___2000lb_GP_Bomb_LD = (7, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (7, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
         GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_87___202_x_CEM_Cluster_Bomb = (7, Weapons.CBU_87___202_x_CEM_Cluster_Bomb)
-        CBU_97___10_x_CEM_Cluster_Bomb = (7, Weapons.CBU_97___10_x_CEM_Cluster_Bomb)
+        CBU_97___10_x_SFW_Cluster_Bomb = (7, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD = (7, Weapons.TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD)
         LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_ = (7, Weapons.LAU_117_with_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_117_AGM_65G = (7, Weapons.LAU_117_AGM_65G)
@@ -16771,15 +17800,19 @@ class F_16C_50(PlaneType):
         LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_ = (7, Weapons.LAU_88_with_3_x_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_88_AGM_65H = (7, Weapons.LAU_88_AGM_65H)
         LAU_88_AGM_65H_3 = (7, Weapons.LAU_88_AGM_65H_3)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
         MXU_648_TP = (7, Weapons.MXU_648_TP)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (7, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
-        TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_ = (7, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_)
-        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (7, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
-        TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (7, Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
-        TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = (7, Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_)
-        TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = (7, Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_)
+        TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_ = (
+        7, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_)
+        TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (
+        7, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (
+        7, Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
+        TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_ = (7, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_)
+        TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = (7, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__ = (7, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__)
         LAU_88_AGM_65H_2_R = (7, Weapons.LAU_88_AGM_65H_2_R)
 
@@ -16791,7 +17824,8 @@ class F_16C_50(PlaneType):
         AIM_120C_5_AMRAAM___Active_Rdr_AAM = (8, Weapons.AIM_120C_5_AMRAAM___Active_Rdr_AAM)
         CATM_9M = (8, Weapons.CATM_9M)
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (8, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon9:
         AIM_9M_Sidewinder_IR_AAM = (9, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -16807,7 +17841,8 @@ class F_16C_50(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 11}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -16823,11 +17858,10 @@ class F_5E(PlaneType):
     charge_total = 0
     chaff_charge_size = 0
     flare_charge_size = 0
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     class Liveries:
-
         class Georgia(Enum):
             USA_standard = "USA standard"
 
@@ -17018,15 +18052,22 @@ class F_5E(PlaneType):
         M117___750lb_GP_Bomb_LD = (2, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (2, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (2, Weapons.LAU3_WP156)
@@ -17034,13 +18075,15 @@ class F_5E(PlaneType):
         LAU3_WP61 = (2, Weapons.LAU3_WP61)
         LAU3_HE5 = (2, Weapons.LAU3_HE5)
         LAU3_HE151 = (2, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BDU_33___25lb_Practice_Bomb_LD = (2, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon3:
@@ -17050,15 +18093,22 @@ class F_5E(PlaneType):
         M117___750lb_GP_Bomb_LD = (3, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (3, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (3, Weapons.LAU3_WP156)
@@ -17066,7 +18116,8 @@ class F_5E(PlaneType):
         LAU3_WP61 = (3, Weapons.LAU3_WP61)
         LAU3_HE5 = (3, Weapons.LAU3_HE5)
         LAU3_HE151 = (3, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         F_5_275Gal_Fuel_tank = (3, Weapons.F_5_275Gal_Fuel_tank)
@@ -17074,7 +18125,8 @@ class F_5E(PlaneType):
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BDU_33___25lb_Practice_Bomb_LD = (3, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (3, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon4:
@@ -17100,15 +18152,22 @@ class F_5E(PlaneType):
         M117___750lb_GP_Bomb_LD = (5, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (5, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (5, Weapons.LAU3_WP156)
@@ -17116,7 +18175,8 @@ class F_5E(PlaneType):
         LAU3_WP61 = (5, Weapons.LAU3_WP61)
         LAU3_HE5 = (5, Weapons.LAU3_HE5)
         LAU3_HE151 = (5, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         F_5_275Gal_Fuel_tank = (5, Weapons.F_5_275Gal_Fuel_tank)
@@ -17124,7 +18184,8 @@ class F_5E(PlaneType):
         MXU_648_TP = (5, Weapons.MXU_648_TP)
         BDU_33___25lb_Practice_Bomb_LD = (5, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (5, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon6:
@@ -17133,15 +18194,22 @@ class F_5E(PlaneType):
         M117___750lb_GP_Bomb_LD = (6, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (6, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (6, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (6, Weapons.LAU3_WP156)
@@ -17149,13 +18217,15 @@ class F_5E(PlaneType):
         LAU3_WP61 = (6, Weapons.LAU3_WP61)
         LAU3_HE5 = (6, Weapons.LAU3_HE5)
         LAU3_HE151 = (6, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (6, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BDU_33___25lb_Practice_Bomb_LD = (6, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (6, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon7:
@@ -17190,7 +18260,7 @@ class F_5E_3(PlaneType):
     charge_total = 60
     chaff_charge_size = 1
     flare_charge_size = 2
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     panel_radio = {
@@ -17235,7 +18305,6 @@ class F_5E_3(PlaneType):
     }
 
     class Properties:
-
         class LAU3ROF:
             id = "LAU3ROF"
 
@@ -17324,7 +18393,6 @@ class F_5E_3(PlaneType):
                 _10s = 4
 
     class Liveries:
-
         class Georgia(Enum):
             USA_standard = "USA standard"
 
@@ -17587,15 +18655,22 @@ class F_5E_3(PlaneType):
         M117___750lb_GP_Bomb_LD = (2, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (2, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        2, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (2, Weapons.LAU3_WP156)
@@ -17603,13 +18678,15 @@ class F_5E_3(PlaneType):
         LAU3_WP61 = (2, Weapons.LAU3_WP61)
         LAU3_HE5 = (2, Weapons.LAU3_HE5)
         LAU3_HE151 = (2, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (2, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (2, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BDU_33___25lb_Practice_Bomb_LD = (2, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon3:
@@ -17619,15 +18696,22 @@ class F_5E_3(PlaneType):
         M117___750lb_GP_Bomb_LD = (3, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (3, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        3, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (3, Weapons.LAU3_WP156)
@@ -17635,7 +18719,8 @@ class F_5E_3(PlaneType):
         LAU3_WP61 = (3, Weapons.LAU3_WP61)
         LAU3_HE5 = (3, Weapons.LAU3_HE5)
         LAU3_HE151 = (3, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (3, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         F_5_275Gal_Fuel_tank = (3, Weapons.F_5_275Gal_Fuel_tank)
@@ -17643,7 +18728,8 @@ class F_5E_3(PlaneType):
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BDU_33___25lb_Practice_Bomb_LD = (3, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (3, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon4:
@@ -17669,15 +18755,22 @@ class F_5E_3(PlaneType):
         M117___750lb_GP_Bomb_LD = (5, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (5, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (5, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        5, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (5, Weapons.LAU3_WP156)
@@ -17685,7 +18778,8 @@ class F_5E_3(PlaneType):
         LAU3_WP61 = (5, Weapons.LAU3_WP61)
         LAU3_HE5 = (5, Weapons.LAU3_HE5)
         LAU3_HE151 = (5, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (5, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         F_5_275Gal_Fuel_tank = (5, Weapons.F_5_275Gal_Fuel_tank)
@@ -17693,7 +18787,8 @@ class F_5E_3(PlaneType):
         MXU_648_TP = (5, Weapons.MXU_648_TP)
         BDU_33___25lb_Practice_Bomb_LD = (5, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (5, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon6:
@@ -17702,15 +18797,22 @@ class F_5E_3(PlaneType):
         M117___750lb_GP_Bomb_LD = (6, Weapons.M117___750lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (6, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         CBU_52B___220_x_HE_Frag_bomblets = (6, Weapons.CBU_52B___220_x_HE_Frag_bomblets)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
         LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
-        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
-        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (
+        6, Weapons.LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_68_pod___7_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         LAU3_WP156 = (6, Weapons.LAU3_WP156)
@@ -17718,13 +18820,15 @@ class F_5E_3(PlaneType):
         LAU3_WP61 = (6, Weapons.LAU3_WP61)
         LAU3_HE5 = (6, Weapons.LAU3_HE5)
         LAU3_HE151 = (6, Weapons.LAU3_HE151)
-        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
+        LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos = (
+        6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_M156__Wht_Phos)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk1__HE)
         LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT = (6, Weapons.LAU_3_pod___19_x_2_75_FFAR__UnGd_Rkts_Mk5__HEAT)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (6, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BDU_33___25lb_Practice_Bomb_LD = (6, Weapons.BDU_33___25lb_Practice_Bomb_LD)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
-        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
+        BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (
+        6, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (6, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
 
     class Pylon7:
@@ -17754,7 +18858,7 @@ class F_86F_Sabre(PlaneType):
     length = 11.43
     fuel_max = 1282
     max_speed = 964.8
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 225
 
     panel_radio = {
@@ -17783,7 +18887,6 @@ class F_86F_Sabre(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             default_livery = "default livery"
 
@@ -18170,7 +19273,6 @@ class F_14B(PlaneType):
     }
 
     class Properties:
-
         class M61BURST:
             id = "M61BURST"
 
@@ -18227,7 +19329,6 @@ class F_14B(PlaneType):
             id = "LGB1"
 
     class Liveries:
-
         class USSR(Enum):
             VF_102_Diamondbacks = "VF-102 Diamondbacks"
             Santa = "Santa"
@@ -20319,7 +21420,7 @@ class F_14B(PlaneType):
         AIM_7M_ = (4, Weapons.AIM_7M_)
         AIM_7F_ = (4, Weapons.AIM_7F_)
         AIM_7MH_ = (4, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (4, Weapons.Mk_82)
         Mk_82AIR = (4, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (4, Weapons.Mk_82_SnakeEye)
@@ -20348,7 +21449,7 @@ class F_14B(PlaneType):
         AIM_7M_ = (5, Weapons.AIM_7M_)
         AIM_7F_ = (5, Weapons.AIM_7F_)
         AIM_7MH_ = (5, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (5, Weapons.Mk_82)
         Mk_82AIR = (5, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (5, Weapons.Mk_82_SnakeEye)
@@ -20375,7 +21476,7 @@ class F_14B(PlaneType):
         AIM_7M_ = (6, Weapons.AIM_7M_)
         AIM_7F_ = (6, Weapons.AIM_7F_)
         AIM_7MH_ = (6, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (6, Weapons.Mk_82)
         Mk_82AIR = (6, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (6, Weapons.Mk_82_SnakeEye)
@@ -20403,7 +21504,7 @@ class F_14B(PlaneType):
         AIM_7M_ = (7, Weapons.AIM_7M_)
         AIM_7F_ = (7, Weapons.AIM_7F_)
         AIM_7MH_ = (7, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (7, Weapons.Mk_82)
         Mk_82AIR = (7, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (7, Weapons.Mk_82_SnakeEye)
@@ -20461,7 +21562,8 @@ class F_14B(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.AntishipStrike, task.CAS]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack,
+             task.RunwayAttack, task.PinpointStrike, task.AntishipStrike, task.CAS]
     task_default = task.Intercept
 
 
@@ -20557,7 +21659,6 @@ class F_14A_135_GR(PlaneType):
     }
 
     class Properties:
-
         class M61BURST:
             id = "M61BURST"
 
@@ -20614,7 +21715,6 @@ class F_14A_135_GR(PlaneType):
             id = "LGB1"
 
     class Liveries:
-
         class USSR(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_11_Red_Rippers_106 = "VF-11 Red Rippers 106"
@@ -21312,7 +22412,7 @@ class F_14A_135_GR(PlaneType):
         AIM_7M_ = (4, Weapons.AIM_7M_)
         AIM_7F_ = (4, Weapons.AIM_7F_)
         AIM_7MH_ = (4, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (4, Weapons.Mk_82)
         Mk_82AIR = (4, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (4, Weapons.Mk_82_SnakeEye)
@@ -21341,7 +22441,7 @@ class F_14A_135_GR(PlaneType):
         AIM_7M_ = (5, Weapons.AIM_7M_)
         AIM_7F_ = (5, Weapons.AIM_7F_)
         AIM_7MH_ = (5, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (5, Weapons.Mk_82)
         Mk_82AIR = (5, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (5, Weapons.Mk_82_SnakeEye)
@@ -21368,7 +22468,7 @@ class F_14A_135_GR(PlaneType):
         AIM_7M_ = (6, Weapons.AIM_7M_)
         AIM_7F_ = (6, Weapons.AIM_7F_)
         AIM_7MH_ = (6, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (6, Weapons.Mk_82)
         Mk_82AIR = (6, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (6, Weapons.Mk_82_SnakeEye)
@@ -21396,7 +22496,7 @@ class F_14A_135_GR(PlaneType):
         AIM_7M_ = (7, Weapons.AIM_7M_)
         AIM_7F_ = (7, Weapons.AIM_7F_)
         AIM_7MH_ = (7, Weapons.AIM_7MH_)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         Mk_82 = (7, Weapons.Mk_82)
         Mk_82AIR = (7, Weapons.Mk_82AIR)
         Mk_82_SnakeEye = (7, Weapons.Mk_82_SnakeEye)
@@ -21454,7 +22554,8 @@ class F_14A_135_GR(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.AntishipStrike, task.CAS]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.Reconnaissance, task.GroundAttack,
+             task.RunwayAttack, task.PinpointStrike, task.AntishipStrike, task.CAS]
     task_default = task.Intercept
 
 
@@ -21467,12 +22568,12 @@ class FA_18C_hornet(PlaneType):
     fuel_max = 4900
     max_speed = 1950.12
     chaff = 60
-    flare = 30
+    flare = 60
     charge_total = 120
     chaff_charge_size = 1
-    flare_charge_size = 2
+    flare_charge_size = 1
     eplrs = True
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 305
 
     panel_radio = {
@@ -21533,7 +22634,6 @@ class FA_18C_hornet(PlaneType):
     }
 
     class Properties:
-
         class OuterBoard:
             id = "OuterBoard"
 
@@ -21557,7 +22657,6 @@ class FA_18C_hornet(PlaneType):
                 NVG = 2
 
     class Liveries:
-
         class USSR(Enum):
             default_livery = "default livery"
 
@@ -21878,17 +22977,27 @@ class FA_18C_hornet(PlaneType):
         LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar = (2, Weapons.LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar)
         LAU_115_2_LAU_127_AIM_120B = (2, Weapons.LAU_115_2_LAU_127_AIM_120B)
         LAU_115_2_LAU_127_AIM_120C = (2, Weapons.LAU_115_2_LAU_127_AIM_120C)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        2, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (2, Weapons.LAU_117_AGM_65F)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (2, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (2, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (2, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        2, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        2, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        2, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        2, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        2, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        2, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        2, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        2, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         Mk_82___500lb_GP_Bomb_LD = (2, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (2, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82Y___500lb_GP_Chute_Retarded_HD = (2, Weapons.Mk_82Y___500lb_GP_Chute_Retarded_HD)
@@ -21898,10 +23007,12 @@ class FA_18C_hornet(PlaneType):
         BDU_45B = (2, Weapons.BDU_45B)
         BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (2, Weapons.BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (2, Weapons.BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (2, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
+        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (
+        2, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
         BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb = (2, Weapons.BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb)
         BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb = (2, Weapons.BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb)
-        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (2, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+        2, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (2, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD = (2, Weapons.BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (2, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
@@ -21909,31 +23020,40 @@ class FA_18C_hornet(PlaneType):
         GBU_16___1000lb_Laser_Guided_Bomb = (2, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         CBU_99___490lbs__247_x_HEAT_Bomblets = (2, Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (2, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (2, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (
+        2, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (2, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (2, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BRU_55_with_2_x_AGM_154A___JSOW_CEB__CBU_type_ = (2, Weapons.BRU_55_with_2_x_AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154C___JSOW_Unitary_BROACH = (2, Weapons.AGM_154C___JSOW_Unitary_BROACH)
         BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH = (2, Weapons.BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (2, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (2, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        2, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (2, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
         GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = (2, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
+        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
+        2, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_84D_Harpoon_AShM = (2, Weapons.AGM_84D_Harpoon_AShM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (2, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (2, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        2, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84H_SLAM_ER__Expanded_Response_ = (2, Weapons.AGM_84H_SLAM_ER__Expanded_Response_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+        2, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
         AWW_13_DATALINK_POD = (2, Weapons.AWW_13_DATALINK_POD)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         LAU_115_LAU_127_AIM_9X = (2, Weapons.LAU_115_LAU_127_AIM_9X)
         LAU_115_LAU_127_AIM_9L = (2, Weapons.LAU_115_LAU_127_AIM_9L)
         LAU_115_LAU_127_AIM_9M = (2, Weapons.LAU_115_LAU_127_AIM_9M)
         LAU_115_LAU_127_CATM_9M = (2, Weapons.LAU_115_LAU_127_CATM_9M)
-        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM = (2, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM)
-        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM = (2, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM)
+        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM = (
+        2, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM)
+        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM = (
+        2, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM)
 
     class Pylon3:
         LAU_115_with_AIM_7M_Sparrow_Semi_Active_Radar = (3, Weapons.LAU_115_with_AIM_7M_Sparrow_Semi_Active_Radar)
@@ -21941,17 +23061,27 @@ class FA_18C_hornet(PlaneType):
         LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar = (3, Weapons.LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar)
         LAU_115_2_LAU_127_AIM_120B = (3, Weapons.LAU_115_2_LAU_127_AIM_120B)
         LAU_115_2_LAU_127_AIM_120C = (3, Weapons.LAU_115_2_LAU_127_AIM_120C)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (3, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        3, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (3, Weapons.LAU_117_AGM_65F)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (3, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        3, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        3, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        3, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        3, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        3, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82Y___500lb_GP_Chute_Retarded_HD = (3, Weapons.Mk_82Y___500lb_GP_Chute_Retarded_HD)
@@ -21961,10 +23091,12 @@ class FA_18C_hornet(PlaneType):
         BDU_45B = (3, Weapons.BDU_45B)
         BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (3, Weapons.BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (3, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
+        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (
+        3, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
         BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb = (3, Weapons.BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb)
         BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb = (3, Weapons.BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb)
-        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+        3, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD = (3, Weapons.BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD)
         FPU_8A_Fuel_Tank_330_gallons = (3, Weapons.FPU_8A_Fuel_Tank_330_gallons)
@@ -21972,7 +23104,8 @@ class FA_18C_hornet(PlaneType):
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (3, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         CBU_99___490lbs__247_x_HEAT_Bomblets = (3, Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets)
-        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (3, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (
+        3, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (3, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (3, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
@@ -21980,19 +23113,26 @@ class FA_18C_hornet(PlaneType):
         AGM_154C___JSOW_Unitary_BROACH = (3, Weapons.AGM_154C___JSOW_Unitary_BROACH)
         BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH = (3, Weapons.BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (3, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (3, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        3, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (3, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
         GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = (3, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (3, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
+        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
+        3, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_84D_Harpoon_AShM = (3, Weapons.AGM_84D_Harpoon_AShM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (3, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        3, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84H_SLAM_ER__Expanded_Response_ = (3, Weapons.AGM_84H_SLAM_ER__Expanded_Response_)
         AWW_13_DATALINK_POD = (3, Weapons.AWW_13_DATALINK_POD)
-#ERRR <CLEAN>
-        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM = (3, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM)
-        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM = (3, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM)
+        # ERRR <CLEAN>
+        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM = (
+        3, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM)
+        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM = (
+        3, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM)
 
     class Pylon4:
         AIM_7M_Sparrow_Semi_Active_Radar = (4, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
@@ -22014,16 +23154,20 @@ class FA_18C_hornet(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (5, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (5, Weapons.BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (5, Weapons.BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (5, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
+        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (
+        5, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
         BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb = (5, Weapons.BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb)
         BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb = (5, Weapons.BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb)
-        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (5, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+        5, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         CBU_99___490lbs__247_x_HEAT_Bomblets = (5, Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets)
-        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (5, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (
+        5, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (5, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         AN_AAQ_28_LITENING___Targeting_Pod = (5, Weapons.AN_AAQ_28_LITENING___Targeting_Pod)
         AWW_13_DATALINK_POD = (5, Weapons.AWW_13_DATALINK_POD)
-#ERRR <CLEAN>
+
+    # ERRR <CLEAN>
 
     class Pylon6:
         AIM_7M_Sparrow_Semi_Active_Radar = (6, Weapons.AIM_7M_Sparrow_Semi_Active_Radar)
@@ -22038,17 +23182,27 @@ class FA_18C_hornet(PlaneType):
         LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar = (7, Weapons.LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar)
         LAU_115_2_LAU_127_AIM_120B = (7, Weapons.LAU_115_2_LAU_127_AIM_120B)
         LAU_115_2_LAU_127_AIM_120C = (7, Weapons.LAU_115_2_LAU_127_AIM_120C)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (7, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        7, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (7, Weapons.LAU_117_AGM_65F)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (7, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (7, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (7, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (7, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (7, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        7, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        7, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        7, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        7, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        7, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        7, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        7, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        7, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        7, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         Mk_82___500lb_GP_Bomb_LD = (7, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (7, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82Y___500lb_GP_Chute_Retarded_HD = (7, Weapons.Mk_82Y___500lb_GP_Chute_Retarded_HD)
@@ -22058,10 +23212,12 @@ class FA_18C_hornet(PlaneType):
         BDU_45B = (7, Weapons.BDU_45B)
         BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (7, Weapons.BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (7, Weapons.BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (7, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
+        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (
+        7, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
         BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb = (7, Weapons.BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb)
         BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb = (7, Weapons.BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb)
-        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (7, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+        7, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (7, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD = (7, Weapons.BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD)
         FPU_8A_Fuel_Tank_330_gallons = (7, Weapons.FPU_8A_Fuel_Tank_330_gallons)
@@ -22069,7 +23225,8 @@ class FA_18C_hornet(PlaneType):
         GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         GBU_16___1000lb_Laser_Guided_Bomb = (7, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         CBU_99___490lbs__247_x_HEAT_Bomblets = (7, Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets)
-        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (7, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (
+        7, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (7, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (7, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (7, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
@@ -22077,19 +23234,26 @@ class FA_18C_hornet(PlaneType):
         AGM_154C___JSOW_Unitary_BROACH = (7, Weapons.AGM_154C___JSOW_Unitary_BROACH)
         BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH = (7, Weapons.BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (7, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (7, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        7, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (7, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
         GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = (7, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (7, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
+        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
+        7, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_84D_Harpoon_AShM = (7, Weapons.AGM_84D_Harpoon_AShM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (7, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        7, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84H_SLAM_ER__Expanded_Response_ = (7, Weapons.AGM_84H_SLAM_ER__Expanded_Response_)
         AWW_13_DATALINK_POD = (7, Weapons.AWW_13_DATALINK_POD)
-#ERRR <CLEAN>
-        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_ = (7, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_)
-        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_ = (7, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_)
+        # ERRR <CLEAN>
+        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_ = (
+        7, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_)
+        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_ = (
+        7, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_)
 
     class Pylon8:
         LAU_115_2_LAU_127_AIM_9M = (8, Weapons.LAU_115_2_LAU_127_AIM_9M)
@@ -22101,17 +23265,27 @@ class FA_18C_hornet(PlaneType):
         LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar = (8, Weapons.LAU_115C_with_AIM_7MH_Sparrow_Semi_Active_Radar)
         LAU_115_2_LAU_127_AIM_120B = (8, Weapons.LAU_115_2_LAU_127_AIM_120B)
         LAU_115_2_LAU_127_AIM_120C = (8, Weapons.LAU_115_2_LAU_127_AIM_120C)
-        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
+        LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_ = (
+        8, Weapons.LAU_117_with_AGM_65E___Maverick_E__Laser_ASM___Lg_Whd_)
         LAU_117_AGM_65F = (8, Weapons.LAU_117_AGM_65F)
-        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (8, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
-        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (8, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
-        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
-        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (8, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_ = (
+        8, Weapons.AGM_88C_HARM___High_Speed_Anti_Radiation_Missile_)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.BRU_33_with_1_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (
+        8, Weapons.BRU_33_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        8, Weapons.BRU_33_with_1_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG = (
+        8, Weapons.BRU_33_with_2_x_LAU_10_pod___4_x_127mm_ZUNI__UnGd_Rkts_Mk71__HE_FRAG)
+        BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_33_with_1_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (
+        8, Weapons.BRU_33_with_2_x_LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (8, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82Y___500lb_GP_Chute_Retarded_HD = (8, Weapons.Mk_82Y___500lb_GP_Chute_Retarded_HD)
@@ -22121,10 +23295,12 @@ class FA_18C_hornet(PlaneType):
         BDU_45B = (8, Weapons.BDU_45B)
         BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (8, Weapons.BRU_33_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (8, Weapons.BRU_33_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
-        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (8, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
+        BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD = (
+        8, Weapons.BRU_33_with_2_x_Mk_82Y___500lb_GP_Chute_Retarded_HD)
         BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb = (8, Weapons.BRU_33_with_2_x_BDU_45___500lb_Practice_Bomb)
         BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb = (8, Weapons.BRU_33_with_2_x_BDU_45B___500lb_Practice_Bomb)
-        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (8, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (
+        8, Weapons.BRU_33_with_2_x_Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD = (8, Weapons.BRU_33_with_2_x_Mk_83___1000lb_GP_Bomb_LD)
         BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD = (8, Weapons.BRU_41A_with_6_x_BDU_33___25lb_Practice_Bomb_LD)
         GBU_10___2000lb_Laser_Guided_Bomb = (8, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
@@ -22132,31 +23308,40 @@ class FA_18C_hornet(PlaneType):
         GBU_16___1000lb_Laser_Guided_Bomb = (8, Weapons.GBU_16___1000lb_Laser_Guided_Bomb)
         CBU_99___490lbs__247_x_HEAT_Bomblets = (8, Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets)
         Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets = (8, Weapons.Mk_20_Rockeye___490lbs_CBU__247_x_HEAT_Bomblets)
-        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (8, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
+        BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets = (
+        8, Weapons.BRU_33_with_2_x_CBU_99___490lbs__247_x_HEAT_Bomblets)
         BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.BRU_33_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
         AGM_154A___JSOW_CEB__CBU_type_ = (8, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BRU_55_with_2_x_AGM_154A___JSOW_CEB__CBU_type_ = (8, Weapons.BRU_55_with_2_x_AGM_154A___JSOW_CEB__CBU_type_)
         AGM_154C___JSOW_Unitary_BROACH = (8, Weapons.AGM_154C___JSOW_Unitary_BROACH)
         BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH = (8, Weapons.BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH)
         GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_1_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb = (8, Weapons.GBU_31_V_2_B___JDAM__2000lb_GPS_Guided_Bomb)
-        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
+        GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (
+        8, Weapons.GBU_31_V_4_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb = (8, Weapons.GBU_32_V_2_B___JDAM__1000lb_GPS_Guided_Bomb)
         GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = (8, Weapons.GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_)
         GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38___JDAM__500lb_GPS_Guided_Bomb)
-        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
+        BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = (
+        8, Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb)
         AGM_84D_Harpoon_AShM = (8, Weapons.AGM_84D_Harpoon_AShM)
-        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (8, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
-        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (8, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
+        AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_ = (
+        8, Weapons.AGM_84E_Harpoon_SLAM__Stand_Off_Land_Attack_Missile_)
+        AGM_84H_SLAM_ER__Expanded_Response_ = (8, Weapons.AGM_84H_SLAM_ER__Expanded_Response_)
+        AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_ = (
+        8, Weapons.AGM_62_Walleye_II___Guided_Weapon_Mk_5__TV_Guided_)
         AWW_13_DATALINK_POD = (8, Weapons.AWW_13_DATALINK_POD)
-#ERRR <CLEAN>
+        # ERRR <CLEAN>
         LAU_115_LAU_127_AIM_9X_R = (8, Weapons.LAU_115_LAU_127_AIM_9X_R)
         LAU_115_LAU_127_AIM_9L_R = (8, Weapons.LAU_115_LAU_127_AIM_9L_R)
         LAU_115_LAU_127_AIM_9M_R = (8, Weapons.LAU_115_LAU_127_AIM_9M_R)
         LAU_115_LAU_127_CATM_9M_R = (8, Weapons.LAU_115_LAU_127_CATM_9M_R)
-        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_ = (8, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_)
-        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_ = (8, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_)
+        LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_ = (
+        8, Weapons.LAU_115_with_1_x_LAU_127_AIM_120B_AMRAAM___Active_Rdr_AAM_)
+        LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_ = (
+        8, Weapons.LAU_115_with_1_x_LAU_127_AIM_120C_5_AMRAAM___Active_Rdr_AAM_)
 
     class Pylon9:
         AIM_9M_Sidewinder_IR_AAM = (9, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -22175,7 +23360,8 @@ class FA_18C_hornet(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack, task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
+    tasks = [task.CAP, task.Escort, task.FighterSweep, task.Intercept, task.PinpointStrike, task.CAS, task.GroundAttack,
+             task.RunwayAttack, task.SEAD, task.AFAC, task.AntishipStrike, task.Reconnaissance]
     task_default = task.CAP
 
 
@@ -22187,7 +23373,7 @@ class Hawk(PlaneType):
     length = 11.98
     fuel_max = 1272
     max_speed = 2880
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 127.5
 
     panel_radio = {
@@ -22216,7 +23402,6 @@ class Hawk(PlaneType):
     }
 
     class Liveries:
-
         class Georgia(Enum):
             XX189___100Sqn = "XX189 - 100Sqn"
             USAF_Aggressor_269 = "USAF Aggressor 269"
@@ -22464,7 +23649,7 @@ class I_16(PlaneType):
     length = 6.13
     fuel_max = 191
     max_speed = 464.4
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     panel_radio = {
@@ -22483,12 +23668,10 @@ class I_16(PlaneType):
     }
 
     class Properties:
-
         class landingTorch:
             id = "landingTorch"
 
     class Liveries:
-
         class Georgia(Enum):
             Red_Army_Standard = "Red Army Standard"
             Finnish_AF = "Finnish AF"
@@ -23122,7 +24305,6 @@ class L_39C(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -23145,7 +24327,6 @@ class L_39C(PlaneType):
             id = "DismountGunSight"
 
     class Liveries:
-
         class Ukraine(Enum):
             Ukraine_Air_Force_UKHW = "Ukraine Air Force UKHW"
 
@@ -23156,6 +24337,10 @@ class L_39C(PlaneType):
             Czech_Air_Force = "Czech Air Force"
             Czech_Air_Force_CLV = "Czech Air Force CLV"
             Czechoslovakia_Air_Force = "Czechoslovakia Air Force"
+
+        class GDR(Enum):
+            DDR_Luftwaffe = "DDR Luftwaffe"
+            DDR_Luftwaffe_Early = "DDR Luftwaffe Early"
 
         class France(Enum):
             France_EC24_Fictional = "France EC24 Fictional"
@@ -23180,7 +24365,8 @@ class L_39C(PlaneType):
     class Pylon1:
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (1, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (1, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        1, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         P_50T___50kg_Practice_Bomb_LD = (1, Weapons.P_50T___50kg_Practice_Bomb_LD)
         Fuel_Tank_150_liters = (1, Weapons.Fuel_Tank_150_liters)
         R_3S = (1, Weapons.R_3S)
@@ -23202,7 +24388,8 @@ class L_39C(PlaneType):
     class Pylon3:
         FAB_100___100kg_GP_Bomb_LD = (3, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100___100kg_flare_illumination_Bomb = (3, Weapons.SAB_100___100kg_flare_illumination_Bomb)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        3, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         P_50T___50kg_Practice_Bomb_LD = (3, Weapons.P_50T___50kg_Practice_Bomb_LD)
         Fuel_Tank_150_liters = (3, Weapons.Fuel_Tank_150_liters)
         R_3S = (3, Weapons.R_3S)
@@ -23269,7 +24456,6 @@ class L_39ZA(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -23289,7 +24475,6 @@ class L_39ZA(PlaneType):
             id = "DismountIFRHood"
 
     class Liveries:
-
         class USSR(Enum):
             Splinter_camo_desert = "Splinter camo desert"
             Splinter_camo_woodland = "Splinter camo woodland"
@@ -23631,7 +24816,8 @@ class L_39ZA(PlaneType):
         OFAB_100_Jupiter___100kg_GP_Bomb_LD = (1, Weapons.OFAB_100_Jupiter___100kg_GP_Bomb_LD)
         P_50T___50kg_Practice_Bomb_LD = (1, Weapons.P_50T___50kg_Practice_Bomb_LD)
         _2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD = (1, Weapons._2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (1, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        1, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         PK_3___7_62mm_GPMG = (1, Weapons.PK_3___7_62mm_GPMG)
         R_3S = (1, Weapons.R_3S)
         APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red)
@@ -23649,7 +24835,8 @@ class L_39ZA(PlaneType):
         OFAB_100_Jupiter___100kg_GP_Bomb_LD = (2, Weapons.OFAB_100_Jupiter___100kg_GP_Bomb_LD)
         P_50T___50kg_Practice_Bomb_LD = (2, Weapons.P_50T___50kg_Practice_Bomb_LD)
         _2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD = (2, Weapons._2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (2, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        2, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         PK_3___7_62mm_GPMG = (2, Weapons.PK_3___7_62mm_GPMG)
         Fuel_Tank_150_liters = (2, Weapons.Fuel_Tank_150_liters)
         Fuel_Tank_350_liters = (2, Weapons.Fuel_Tank_350_liters)
@@ -23669,7 +24856,8 @@ class L_39ZA(PlaneType):
         OFAB_100_Jupiter___100kg_GP_Bomb_LD = (4, Weapons.OFAB_100_Jupiter___100kg_GP_Bomb_LD)
         P_50T___50kg_Practice_Bomb_LD = (4, Weapons.P_50T___50kg_Practice_Bomb_LD)
         _2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD = (4, Weapons._2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (4, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        4, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         PK_3___7_62mm_GPMG = (4, Weapons.PK_3___7_62mm_GPMG)
         Fuel_Tank_150_liters = (4, Weapons.Fuel_Tank_150_liters)
         Fuel_Tank_350_liters = (4, Weapons.Fuel_Tank_350_liters)
@@ -23681,7 +24869,8 @@ class L_39ZA(PlaneType):
         OFAB_100_Jupiter___100kg_GP_Bomb_LD = (5, Weapons.OFAB_100_Jupiter___100kg_GP_Bomb_LD)
         P_50T___50kg_Practice_Bomb_LD = (5, Weapons.P_50T___50kg_Practice_Bomb_LD)
         _2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD = (5, Weapons._2_x_OFAB_100_Jupiter___100kg_GP_Bombs_LD)
-        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
+        UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (
+        5, Weapons.UB_16UM_pod___16_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         PK_3___7_62mm_GPMG = (5, Weapons.PK_3___7_62mm_GPMG)
         R_3S = (5, Weapons.R_3S)
         APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red = (5, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red)
@@ -23711,7 +24900,7 @@ class M_2000C(PlaneType):
     charge_total = 162
     chaff_charge_size = 1
     flare_charge_size = 1
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     panel_radio = {
         1: {
@@ -23723,7 +24912,7 @@ class M_2000C(PlaneType):
                 16: 261,
                 17: 267,
                 9: 255,
-                18: 251,
+                18: 252,
                 5: 254,
                 10: 262,
                 20: 266,
@@ -23777,7 +24966,6 @@ class M_2000C(PlaneType):
     }
 
     class Properties:
-
         class NoDDMSensor:
             id = "NoDDMSensor"
 
@@ -23816,7 +25004,6 @@ class M_2000C(PlaneType):
             id = "LoadNVGCase"
 
     class Liveries:
-
         class Greece(Enum):
             Greek_Air_Force = "Greek Air Force"
 
@@ -23927,7 +25114,8 @@ class M_2000C(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.AFAC, task.CAP, task.Escort, task.FighterSweep, task.Intercept]
+    tasks = [task.GroundAttack, task.RunwayAttack, task.PinpointStrike, task.CAS, task.AFAC, task.CAP, task.Escort,
+             task.FighterSweep, task.Intercept]
     task_default = task.CAP
 
 
@@ -23942,7 +25130,6 @@ class MQ_9_Reaper(PlaneType):
     eplrs = True
 
     class Liveries:
-
         class UK(Enum):
             standard_UK = "standard UK"
 
@@ -23992,11 +25179,10 @@ class MiG_15bis(PlaneType):
     length = 10.11
     fuel_max = 1172
     max_speed = 992
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 3.75
 
     class Liveries:
-
         class USSR(Enum):
             USSR_Air_Forces_Old = "USSR_Air Forces Old"
             USSR_Air_Forces = "USSR_Air Forces"
@@ -24272,7 +25458,7 @@ class MiG_19P(PlaneType):
     length = 13.025
     fuel_max = 1800
     max_speed = 992
-    category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+    category = "Interceptor"  # {78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
     radio_frequency = 124
 
     panel_radio = {
@@ -24298,7 +25484,6 @@ class MiG_19P(PlaneType):
     }
 
     class Properties:
-
         class MountSIRENA:
             id = "MountSIRENA"
 
@@ -24322,7 +25507,6 @@ class MiG_19P(PlaneType):
                 NEAR = 2
 
     class Liveries:
-
         class USSR(Enum):
             default = "default"
             IAP = "IAP"
@@ -24912,7 +26096,6 @@ class MiG_21Bis(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             Afghanistan__1 = "Afghanistan (1)"
             Afghanistan__2 = "Afghanistan (2)"
@@ -24960,6 +26143,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25028,6 +26212,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25096,6 +26281,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25164,6 +26350,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25232,6 +26419,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25300,6 +26488,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25368,6 +26557,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25436,6 +26626,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25504,6 +26695,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25572,6 +26764,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25640,6 +26833,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25708,6 +26902,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25776,6 +26971,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25844,6 +27040,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25912,6 +27109,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -25980,6 +27178,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26048,6 +27247,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26116,6 +27316,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26184,6 +27385,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26252,6 +27454,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26320,6 +27523,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26388,6 +27592,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26456,6 +27661,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26524,6 +27730,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26592,6 +27799,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26660,6 +27868,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26728,6 +27937,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26796,6 +28006,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26864,6 +28075,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -26932,6 +28144,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27000,6 +28213,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27068,6 +28282,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27136,6 +28351,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27204,6 +28420,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27272,6 +28489,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27340,6 +28558,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27408,6 +28627,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27476,6 +28696,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27544,6 +28765,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27612,6 +28834,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27680,6 +28903,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27748,6 +28972,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27816,6 +29041,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27884,6 +29110,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -27952,6 +29179,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28020,6 +29248,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28088,6 +29317,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28156,6 +29386,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28224,6 +29455,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28292,6 +29524,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28360,6 +29593,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28428,6 +29662,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28496,6 +29731,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28564,6 +29800,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28632,6 +29869,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28700,6 +29938,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28768,6 +30007,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28836,6 +30076,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28904,6 +30145,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -28972,6 +30214,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29040,6 +30283,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29108,6 +30352,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29176,6 +30421,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29244,6 +30490,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29312,6 +30559,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29380,6 +30628,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29448,6 +30697,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29516,6 +30766,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29584,6 +30835,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29652,6 +30904,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29720,6 +30973,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29788,6 +31042,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29856,6 +31111,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29924,6 +31180,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -29992,6 +31249,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30060,6 +31318,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30128,6 +31387,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30196,6 +31456,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30264,6 +31525,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30332,6 +31594,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30400,6 +31663,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30468,6 +31732,7 @@ class MiG_21Bis(PlaneType):
             Romania___Gray = "Romania - Gray"
             Romania___Lancer_A = "Romania - Lancer A"
             Romania___Lancer_C = "Romania - Lancer C"
+            Serbia___101st_LAE = "Serbia - 101st LAE"
             Slovakia___1998 = "Slovakia - 1998"
             Southeria = "Southeria"
             Sweden___16th_Air_Wing = "Sweden - 16th Air Wing"
@@ -30495,7 +31760,8 @@ class MiG_21Bis(PlaneType):
         S_24A__21_ = (1, Weapons.S_24A__21_)
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (1, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         FAB_250_M54_TU = (1, Weapons.FAB_250_M54_TU)
         SAB_100___100kg_flare_illumination_Bomb = (1, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         R_13M = (1, Weapons.R_13M)
@@ -30519,9 +31785,12 @@ class MiG_21Bis(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (2, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (2, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (2, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        2, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        2, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        2, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (2, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         SAB_100___100kg_flare_illumination_Bomb = (2, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         Kh_66_Grom__21__APU_68 = (2, Weapons.Kh_66_Grom__21__APU_68)
@@ -30554,9 +31823,12 @@ class MiG_21Bis(PlaneType):
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (
+        4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         BL_755_CBU___450kg__147_Frag_Pen_bomblets = (4, Weapons.BL_755_CBU___450kg__147_Frag_Pen_bomblets)
         SAB_100___100kg_flare_illumination_Bomb = (4, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         Kh_66_Grom__21__APU_68 = (4, Weapons.Kh_66_Grom__21__APU_68)
@@ -30578,8 +31850,9 @@ class MiG_21Bis(PlaneType):
         S_24A__21_ = (5, Weapons.S_24A__21_)
         FAB_100___100kg_GP_Bomb_LD = (5, Weapons.FAB_100___100kg_GP_Bomb_LD)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
-#ERRR {40A24F07-CD7D-4F83-89A2-39B2258B62C6}
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        # ERRR {40A24F07-CD7D-4F83-89A2-39B2258B62C6}
         FAB_250_M54_TU = (5, Weapons.FAB_250_M54_TU)
         SAB_100___100kg_flare_illumination_Bomb = (5, Weapons.SAB_100___100kg_flare_illumination_Bomb)
         R_13M = (5, Weapons.R_13M)
@@ -30620,7 +31893,6 @@ class Su_34(PlaneType):
     flare_charge_size = 1
 
     class Liveries:
-
         class Russia(Enum):
             Russian_Air_Force = "Russian Air Force"
             Russian_Air_Force_Old = "Russian Air Force Old"
@@ -30636,19 +31908,22 @@ class Su_34(PlaneType):
 
     class Pylon3:
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (3, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (3, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (3, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (3, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
-        Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided = (3, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        3, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        3, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        3, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (3, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        3, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (3, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        3, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (3, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        3, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (3, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30670,19 +31945,22 @@ class Su_34(PlaneType):
 
     class Pylon4:
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (4, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (4, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (4, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (4, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
-        Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided = (4, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        4, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        4, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        4, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (4, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        4, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        4, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (4, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (4, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        4, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (4, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30702,7 +31980,8 @@ class Su_34(PlaneType):
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (4, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (4, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (4, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (4, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        4, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (4, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (4, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
 
@@ -30712,14 +31991,19 @@ class Su_34(PlaneType):
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (5, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (5, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (5, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        5, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        5, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        5, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (5, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        5, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (5, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        5, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (5, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30732,10 +32016,12 @@ class Su_34(PlaneType):
 
     class Pylon6:
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (6, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        6, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (6, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (6, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        6, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (6, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (6, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (6, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30750,10 +32036,12 @@ class Su_34(PlaneType):
 
     class Pylon7:
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (7, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        7, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (7, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (7, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        7, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (7, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (7, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (7, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30766,7 +32054,8 @@ class Su_34(PlaneType):
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (7, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (7, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (7, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (7, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        7, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (7, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD = (7, Weapons.MBD3_U6_68_with_6_x_FAB_250___250kg_GP_Bombs_LD)
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (7, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
@@ -30777,14 +32066,19 @@ class Su_34(PlaneType):
         R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (8, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (8, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (8, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        8, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        8, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        8, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (8, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (8, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        8, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (8, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (8, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (8, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30797,19 +32091,22 @@ class Su_34(PlaneType):
 
     class Pylon9:
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (9, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (9, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (9, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (9, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (9, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (9, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
-        Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided = (9, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        9, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        9, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        9, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
         B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (9, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        9, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (9, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        9, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (9, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (9, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        9, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (9, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (9, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (9, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
@@ -30829,26 +32126,32 @@ class Su_34(PlaneType):
         FAB_1500_M_54___1500kg_GP_Bomb_LD = (9, Weapons.FAB_1500_M_54___1500kg_GP_Bomb_LD)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (9, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
         KAB_1500L___1500kg_Laser_Guided_Bomb = (9, Weapons.KAB_1500L___1500kg_Laser_Guided_Bomb)
-        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (9, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
+        KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb = (
+        9, Weapons.KAB_1500LG_Pr___1500kg_Laser_Guided_Penetrator_Bomb)
         KAB_1500Kr___1500kg_TV_Guided_Bomb = (9, Weapons.KAB_1500Kr___1500kg_TV_Guided_Bomb)
         Kh_59M__AS_18_Kazoo____930kg__ASM__IN = (9, Weapons.Kh_59M__AS_18_Kazoo____930kg__ASM__IN)
 
     class Pylon10:
         Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__ = (10, Weapons.Kh_29T__AS_14_Kedge____670kg__ASM__TV_Guided__)
-        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (10, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
-        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (10, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
-        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (10, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
-        Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__ = (10, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr__)
-        Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__ = (10, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser__)
-        Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided = (10, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__RC_Guided)
-        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
-        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
+        Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__ = (
+        10, Weapons.Kh_29L__AS_14_Kedge____657kg__ASM__Semi_Act_Laser__)
+        Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__ = (
+        10, Weapons.Kh_31A__AS_17_Krypton____610kg__AShM__IN__Act_Rdr__)
+        Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__ = (
+        10, Weapons.Kh_31P__AS_17_Krypton____600kg__ARM__IN__Pas_Rdr__)
+        B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP = (
+        10, Weapons.B_8M1_pod___20_x_S_8KOM__80mm_UnGd_Rkts__HEAT_AP)
+        B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag = (
+        10, Weapons.B_13L_pod___5_x_S_13_OF__122mm_UnGd_Rkts__Blast_Frag)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (10, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
-        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
+        RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (
+        10, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (10, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
         RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag = (10, Weapons.RBK_500U___126_x_OAB_2_5RT__500kg_CBU_HE_Frag)
-        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
-        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
+        RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP = (
+        10, Weapons.RBK_500_255___30_x_PTAB_10_5__500kg_CBU_Heavy_HEAT_AP)
+        RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (
+        10, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_250___250kg_GP_Bomb_LD = (10, Weapons.FAB_250___250kg_GP_Bomb_LD)
         FAB_500_M_62___500kg_GP_Bomb_LD = (10, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         KAB_500LG___500kg_Laser_Guided_Bomb = (10, Weapons.KAB_500LG___500kg_Laser_Guided_Bomb)
@@ -30858,11 +32161,13 @@ class Su_34(PlaneType):
         FAB_100___100kg_GP_Bomb_LD = (10, Weapons.FAB_100___100kg_GP_Bomb_LD)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (10, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag = (10, Weapons.KMGU_2___96_x_AO_2_5RT_Dispenser__CBU__HE_Frag)
-        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
+        KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP = (
+        10, Weapons.KMGU_2___96_x_PTAB_2_5KO_Dispenser__CBU__HEAT_AP)
         R_73__AA_11_Archer____Infra_Red = (10, Weapons.R_73__AA_11_Archer____Infra_Red)
         R_77__AA_12_Adder____Active_Rdr = (10, Weapons.R_77__AA_12_Adder____Active_Rdr)
         R_27R__AA_10_Alamo_A____Semi_Act_Rdr = (10, Weapons.R_27R__AA_10_Alamo_A____Semi_Act_Rdr)
-        R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (10, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
+        R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range = (
+        10, Weapons.R_27ER__AA_10_Alamo_C____Semi_Act_Extended_Range)
         R_27T__AA_10_Alamo_B____Infra_Red = (10, Weapons.R_27T__AA_10_Alamo_B____Infra_Red)
         R_27ET__AA_10_Alamo_D____IR_Extended_Range = (10, Weapons.R_27ET__AA_10_Alamo_D____IR_Extended_Range)
         MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD = (10, Weapons.MBD3_U6_68_with_5_x_FAB_250___250kg_GP_Bombs_LD)
@@ -30878,7 +32183,8 @@ class Su_34(PlaneType):
 
     pylons = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
-    tasks = [task.AFAC, task.SEAD, task.AntishipStrike, task.CAS, task.PinpointStrike, task.GroundAttack, task.RunwayAttack]
+    tasks = [task.AFAC, task.SEAD, task.AntishipStrike, task.CAS, task.PinpointStrike, task.GroundAttack,
+             task.RunwayAttack]
     task_default = task.GroundAttack
 
 
@@ -30914,7 +32220,6 @@ class Yak_52(PlaneType):
     }
 
     class Properties:
-
         class SoloFlight:
             id = "SoloFlight"
 
@@ -30935,9 +32240,9 @@ class Yak_52(PlaneType):
                 Equally_Responsible = -2
 
     class Liveries:
-
         class USSR(Enum):
             Bare_Metall = "Bare_Metall"
+            DOSAAF_USSR = "DOSAAF_USSR"
 
         class Georgia(Enum):
             Bare_Metall = "Bare_Metall"
@@ -31103,8 +32408,8 @@ class Yak_52(PlaneType):
 
         class Russia(Enum):
             Bare_Metall = "Bare_Metall"
-            DOSAAF_RF = "DOSAAF_RF"
             DOSAAF_USSR = "DOSAAF_USSR"
+            DOSAAF_RF = "DOSAAF_RF"
             The_First_Flight = "The First Flight"
             The_Yakovlevs = "The Yakovlevs"
 
@@ -31236,7 +32541,8 @@ class Ju_88A4(PlaneType):
 
     property_defaults = {
     }
-#ERRR {LTF_5B}
+
+    # ERRR {LTF_5B}
 
     class Pylon1:
         SC_250_Type_1_L2___250kg_GP_Bomb_LD = (1, Weapons.SC_250_Type_1_L2___250kg_GP_Bomb_LD)
@@ -31245,10 +32551,14 @@ class Ju_88A4(PlaneType):
         SC_500_L2___500kg_GP_Bomb_LD = (1, Weapons.SC_500_L2___500kg_GP_Bomb_LD)
         SD_250_Stg___250kg_GP_Bomb_LD = (1, Weapons.SD_250_Stg___250kg_GP_Bomb_LD)
         SD_500_A___500kg_GP_Bomb_LD = (1, Weapons.SD_500_A___500kg_GP_Bomb_LD)
-        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (1, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
-        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (1, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
-        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (1, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
-#ERRR {LTF_5B}
+        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (
+        1, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
+        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (
+        1, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
+        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (
+        1, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
+
+    # ERRR {LTF_5B}
 
     class Pylon3:
         SC_250_Type_1_L2___250kg_GP_Bomb_LD = (3, Weapons.SC_250_Type_1_L2___250kg_GP_Bomb_LD)
@@ -31257,9 +32567,12 @@ class Ju_88A4(PlaneType):
         SC_500_L2___500kg_GP_Bomb_LD = (3, Weapons.SC_500_L2___500kg_GP_Bomb_LD)
         SD_250_Stg___250kg_GP_Bomb_LD = (3, Weapons.SD_250_Stg___250kg_GP_Bomb_LD)
         SD_500_A___500kg_GP_Bomb_LD = (3, Weapons.SD_500_A___500kg_GP_Bomb_LD)
-        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (3, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
-        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (3, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
-        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (3, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
+        AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions = (
+        3, Weapons.AB_250_2___144_x_SD_2__250kg_CBU_with_HE_submunitions)
+        AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions = (
+        3, Weapons.AB_250_2___17_x_SD_10A__250kg_CBU_with_10kg_Frag_HE_submunitions)
+        AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions = (
+        3, Weapons.AB_500_1___34_x_SD_10A__500kg_CBU_with_10kg_Frag_HE_submunitions)
 
     pylons = {1, 3}
 
@@ -31289,7 +32602,6 @@ class TF_51D(PlaneType):
     }
 
     class Liveries:
-
         class USSR(Enum):
             Bare_Metal = "Bare Metal"
 

--- a/dcs/ships.py
+++ b/dcs/ships.py
@@ -184,6 +184,24 @@ class Bulker_Handy_Wind(unittype.ShipType):
     air_weapon_dist = 0
 
 
+class Tanker_Seawise_Giant(unittype.ShipType):
+    id = "Seawise_Giant"
+    name = "Tanker Seawise Giant"
+    helicopter_num = 1
+    parking = 1
+    detection_range = 0
+    threat_range = 0
+    air_weapon_dist = 0
+
+
+class FAC_La_Combattante_IIa(unittype.ShipType):
+    id = "La_Combattante_II"
+    name = "FAC La Combattante IIa"
+    detection_range = 19000
+    threat_range = 4000
+    air_weapon_dist = 4000
+
+
 class CVN_74_John_C__Stennis(unittype.ShipType):
     id = "Stennis"
     name = "CVN-74 John C. Stennis"
@@ -350,6 +368,7 @@ class Boat_Schnellboot_type_S130(unittype.ShipType):
     threat_range = 4000
     air_weapon_dist = 4000
 
+
 ship_map = {
     "speedboat": Boat_Armed_Hi_speed,
     "VINSON": CVN_70_Carl_Vinson,
@@ -371,6 +390,8 @@ ship_map = {
     "SOM": SSK_641B_Tango,
     "CV_1143_5": CV_1143_5_Admiral_Kuznetsov_2017,
     "HandyWind": Bulker_Handy_Wind,
+    "Seawise_Giant": Tanker_Seawise_Giant,
+    "La_Combattante_II": FAC_La_Combattante_IIa,
     "Stennis": CVN_74_John_C__Stennis,
     "CVN_71": CVN_71_Theodore_Roosevelt,
     "CVN_72": CVN_72_Abraham_Lincoln,

--- a/dcs/statics.py
+++ b/dcs/statics.py
@@ -4,7 +4,6 @@ import dcs.unittype as unittype
 
 
 class Fortification:
-
     class Command_Center(unittype.StaticType):
         id = ".Command Center"
         name = "Command Center"
@@ -624,6 +623,7 @@ class Fortification:
         shape_name = "Freya_Shelter_Concrete"
         rate = 20
 
+
 fortification_map = {
     ".Command Center": Fortification.Command_Center,
     "Hangar A": Fortification.Hangar_A,
@@ -732,7 +732,6 @@ fortification_map = {
 
 
 class GroundObject:
-
     class Building(unittype.StaticType):
         id = "Building"
         name = "Building"
@@ -753,6 +752,7 @@ class GroundObject:
         name = "Train"
         category = ""
 
+
 groundobject_map = {
     "Building": GroundObject.Building,
     "Bridge": GroundObject.Bridge,
@@ -762,7 +762,6 @@ groundobject_map = {
 
 
 class Warehouse:
-
     class Warehouse(unittype.StaticType):
         id = "Warehouse"
         name = "Warehouse"
@@ -798,6 +797,7 @@ class Warehouse:
         category = "Warehouses"
         rate = 100
 
+
 warehouse_map = {
     "Warehouse": Warehouse.Warehouse,
     "Tank": Warehouse.Tank_1,
@@ -808,7 +808,6 @@ warehouse_map = {
 
 
 class Cargo:
-
     class UH_1H_cargo(unittype.StaticType):
         id = "uh1h_cargo"
         name = "UH-1H cargo"
@@ -928,6 +927,7 @@ class Cargo:
         category = "Cargos"
         rate = 100
         can_cargo = True
+
 
 cargo_map = {
     "uh1h_cargo": Cargo.UH_1H_cargo,

--- a/dcs/vehicles.py
+++ b/dcs/vehicles.py
@@ -33,9 +33,9 @@ class Artillery:
         threat_range = 17000
         air_weapon_dist = 17000
 
-    class SPH_2S9_Nona_120mm_M(unittype.VehicleType):
+    class SPM_2S9_Nona_120mm_M(unittype.VehicleType):
         id = "SAU 2-C9"
-        name = "SPH 2S9 Nona 120mm M"
+        name = "SPM 2S9 Nona 120mm M"
         detection_range = 0
         threat_range = 7000
         air_weapon_dist = 7000
@@ -62,9 +62,9 @@ class Artillery:
         threat_range = 1000
         air_weapon_dist = 1000
 
-    class HUMVEE_JTAC(unittype.VehicleType):
+    class MRLS_FDDM__FC(unittype.VehicleType):
         id = "MLRS FDDM"
-        name = "HUMVEE JTAC"
+        name = "MRLS FDDM (FC)"
         detection_range = 0
         threat_range = 1200
         air_weapon_dist = 1200
@@ -77,9 +77,9 @@ class Artillery:
         threat_range = 19000
         air_weapon_dist = 19000
 
-    class MLRS_BM_27_Uragan_220mm(unittype.VehicleType):
+    class MLRS_9K57_Uragan_BM_27_220mm(unittype.VehicleType):
         id = "Uragan_BM-27"
-        name = "MLRS BM-27 Uragan 220mm"
+        name = "MLRS 9K57 Uragan BM-27 220mm"
         detection_range = 0
         threat_range = 35800
         air_weapon_dist = 35800
@@ -106,6 +106,13 @@ class Artillery:
         air_weapon_dist = 32000
         eplrs = True
 
+    class SPH_T155_Firtina_155mm(unittype.VehicleType):
+        id = "T155_Firtina"
+        name = "SPH T155 Firtina 155mm"
+        detection_range = 0
+        threat_range = 41000
+        air_weapon_dist = 41000
+
     class PLZ_05(unittype.VehicleType):
         id = "PLZ05"
         name = "PLZ-05"
@@ -113,13 +120,6 @@ class Artillery:
         threat_range = 23500
         air_weapon_dist = 23500
         eplrs = True
-
-    class SPG_Sturmpanzer_IV_Brummbar(unittype.VehicleType):
-        id = "SturmPzIV"
-        name = "SPG Sturmpanzer IV Brummbar"
-        detection_range = 0
-        threat_range = 4500
-        air_weapon_dist = 2500
 
     class SPG_M12_GMC_155mm(unittype.VehicleType):
         id = "M12_GMC"
@@ -324,9 +324,9 @@ class AirDefence:
         threat_range = 4000
         air_weapon_dist = 4000
 
-    class SAM_Hawk_Generator__PCP(unittype.VehicleType):
+    class SAM_Hawk_Platoon_Command_Post__PCP(unittype.VehicleType):
         id = "Hawk pcp"
-        name = "SAM Hawk Generator (PCP)"
+        name = "SAM Hawk Platoon Command Post (PCP)"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -454,9 +454,9 @@ class AirDefence:
         threat_range = 2500
         air_weapon_dist = 2500
 
-    class AAA_ZU_23_Closed_Emplacement_Insurgent(unittype.VehicleType):
+    class AAA_ZU_23_Insurgent_Closed_Emplacement(unittype.VehicleType):
         id = "ZU-23 Closed Insurgent"
-        name = "AAA ZU-23 Closed Emplacement Insurgent"
+        name = "AAA ZU-23 Insurgent Closed Emplacement"
         detection_range = 5000
         threat_range = 2500
         air_weapon_dist = 2500
@@ -468,9 +468,9 @@ class AirDefence:
         threat_range = 2500
         air_weapon_dist = 2500
 
-    class AAA_ZU_23_Insurgent(unittype.VehicleType):
+    class AAA_ZU_23_Insurgent_Emplacement(unittype.VehicleType):
         id = "ZU-23 Insurgent"
-        name = "AAA ZU-23 Insurgent"
+        name = "AAA ZU-23 Insurgent Emplacement"
         detection_range = 5000
         threat_range = 2500
         air_weapon_dist = 2500
@@ -517,9 +517,9 @@ class AirDefence:
         threat_range = 0
         air_weapon_dist = 0
 
-    class SAM_SA_6_Kub_Long_Track_STR(unittype.VehicleType):
+    class SAM_SA_6_Kub_Straight_Flush_STR(unittype.VehicleType):
         id = "Kub 1S91 str"
-        name = "SAM SA-6 Kub \"Long Track\" STR"
+        name = "SAM SA-6 Kub \"Straight Flush\" STR"
         detection_range = 70000
         threat_range = 0
         air_weapon_dist = 0
@@ -645,12 +645,19 @@ class AirDefence:
         threat_range = 7000
         air_weapon_dist = 7000
 
-    class AAA_40mm_Bofors(unittype.VehicleType):
-        id = "bofors40"
-        name = "AAA 40mm Bofors"
+    class Disel_Power_Station_5I57A(unittype.VehicleType):
+        id = "generator_5i57"
+        name = "Disel Power Station 5I57A"
         detection_range = 0
-        threat_range = 7160
-        air_weapon_dist = 7160
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class AAA_Bofors_40mm(unittype.VehicleType):
+        id = "bofors40"
+        name = "AAA Bofors 40mm"
+        detection_range = 0
+        threat_range = 4000
+        air_weapon_dist = 4000
 
     class SAM_Rapier_LN(unittype.VehicleType):
         id = "rapier_fsa_launcher"
@@ -861,9 +868,9 @@ class Fortification:
 
 class Unarmed:
 
-    class GPU_APA_5D(unittype.VehicleType):
+    class GPU_APA_5D_on_Ural_4320(unittype.VehicleType):
         id = "Ural-4320 APA-5D"
-        name = "GPU APA-5D"
+        name = "GPU APA-5D on Ural 4320"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -910,9 +917,9 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
-    class Truck_HEMMT_TFFT_Fire(unittype.VehicleType):
+    class Firefighter_HEMMT_TFFT(unittype.VehicleType):
         id = "HEMTT TFFT"
-        name = "Truck HEMMT TFFT Fire"
+        name = "Firefighter HEMMT TFFT"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -945,9 +952,9 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
-    class APC_HMMWV_Jeep(unittype.VehicleType):
+    class LUV_HMMWV_Jeep(unittype.VehicleType):
         id = "Hummer"
-        name = "APC HMMWV Jeep"
+        name = "LUV HMMWV Jeep"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -988,9 +995,9 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
-    class APC_Tigr(unittype.VehicleType):
+    class LUV_Tigr(unittype.VehicleType):
         id = "Tigr_233036"
-        name = "APC Tigr"
+        name = "LUV Tigr"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1009,9 +1016,9 @@ class Unarmed:
         threat_range = 0
         air_weapon_dist = 0
 
-    class Truck_Ural_ATsP_6_Firefighter(unittype.VehicleType):
+    class Firefighter_Ural_ATsP_6(unittype.VehicleType):
         id = "Ural ATsP-6"
-        name = "Truck Ural ATsP-6 Firefighter"
+        name = "Firefighter Ural ATsP-6"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1082,6 +1089,20 @@ class Unarmed:
     class Truck_KrAZ_6322_6x6(unittype.VehicleType):
         id = "KrAZ6322"
         name = "Truck KrAZ-6322 6x6"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class Refueler_ATZ_5(unittype.VehicleType):
+        id = "ATZ-5"
+        name = "Refueler ATZ-5"
+        detection_range = 0
+        threat_range = 0
+        air_weapon_dist = 0
+
+    class Fire_Fight_Vehicle_AA_7_2_60(unittype.VehicleType):
+        id = "AA8"
+        name = "Fire Fight Vehicle AA-7.2/60"
         detection_range = 0
         threat_range = 0
         air_weapon_dist = 0
@@ -1208,9 +1229,9 @@ class Armor:
         threat_range = 4000
         air_weapon_dist = 2000
 
-    class IFV_BRDM_2(unittype.VehicleType):
+    class Scout_BRDM_2(unittype.VehicleType):
         id = "BRDM-2"
-        name = "IFV BRDM-2"
+        name = "Scout BRDM-2"
         detection_range = 0
         threat_range = 1600
         air_weapon_dist = 1600
@@ -1229,9 +1250,9 @@ class Armor:
         threat_range = 3000
         air_weapon_dist = 1000
 
-    class APC_Cobra__Scout(unittype.VehicleType):
+    class Scout_Cobra(unittype.VehicleType):
         id = "Cobra"
-        name = "APC Cobra (Scout)"
+        name = "Scout Cobra"
         detection_range = 0
         threat_range = 1200
         air_weapon_dist = 1200
@@ -1243,9 +1264,9 @@ class Armor:
         threat_range = 2500
         air_weapon_dist = 2500
 
-    class APC_HMMWV__Scout(unittype.VehicleType):
+    class Scout_HMMWV(unittype.VehicleType):
         id = "M1043 HMMWV Armament"
-        name = "APC HMMWV (Scout)"
+        name = "Scout HMMWV"
         detection_range = 0
         threat_range = 1200
         air_weapon_dist = 1200
@@ -1333,13 +1354,6 @@ class Armor:
         threat_range = 3500
         air_weapon_dist = 1500
 
-    class MBT_Leopard_2(unittype.VehicleType):
-        id = "Leopard-2"
-        name = "MBT Leopard 2"
-        detection_range = 0
-        threat_range = 3500
-        air_weapon_dist = 1500
-
     class MBT_M60A3_Patton(unittype.VehicleType):
         id = "M-60"
         name = "MBT M60A3 Patton"
@@ -1405,9 +1419,9 @@ class Armor:
         threat_range = 3500
         air_weapon_dist = 1200
 
-    class MT_M4_Sherman(unittype.VehicleType):
+    class Tk_M4_Sherman(unittype.VehicleType):
         id = "M4_Sherman"
-        name = "MT M4 Sherman"
+        name = "Tk M4 Sherman"
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
@@ -1426,16 +1440,30 @@ class Armor:
         threat_range = 4000
         air_weapon_dist = 3500
 
-    class APC_BTR_82A(unittype.VehicleType):
+    class IFV_BTR_82A(unittype.VehicleType):
         id = "BTR-82A"
-        name = "APC BTR-82A"
+        name = "IFV BTR-82A"
         detection_range = 0
         threat_range = 2000
         air_weapon_dist = 2000
 
-    class MT_PzIV_H(unittype.VehicleType):
+    class LT_PT_76(unittype.VehicleType):
+        id = "PT_76"
+        name = "LT PT-76"
+        detection_range = 0
+        threat_range = 2000
+        air_weapon_dist = 1000
+
+    class MBT_Chieftain_Mk_3(unittype.VehicleType):
+        id = "Chieftain_mk3"
+        name = "MBT Chieftain Mk.3"
+        detection_range = 0
+        threat_range = 3500
+        air_weapon_dist = 1500
+
+    class Tk_PzIV_H(unittype.VehicleType):
         id = "Pz_IV_H"
-        name = "MT PzIV H"
+        name = "Tk PzIV H"
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
@@ -1446,6 +1474,42 @@ class Armor:
         detection_range = 0
         threat_range = 1100
         air_weapon_dist = 0
+
+    class MBT_Leopard_2A5(unittype.VehicleType):
+        id = "Leopard-2A5"
+        name = "MBT Leopard-2A5"
+        detection_range = 0
+        threat_range = 3500
+        air_weapon_dist = 1500
+
+    class MBT_Leopard_2A6M(unittype.VehicleType):
+        id = "Leopard-2"
+        name = "MBT Leopard-2A6M"
+        detection_range = 0
+        threat_range = 3500
+        air_weapon_dist = 1500
+
+    class MBT_Leopard_2A4(unittype.VehicleType):
+        id = "leopard-2A4"
+        name = "MBT Leopard-2A4"
+        detection_range = 0
+        threat_range = 3500
+        air_weapon_dist = 1500
+
+    class MBT_Leopard_2A4_Trs(unittype.VehicleType):
+        id = "leopard-2A4_trs"
+        name = "MBT Leopard-2A4 Trs"
+        detection_range = 0
+        threat_range = 3500
+        air_weapon_dist = 1500
+
+    class ATGM_VAB_Mephisto(unittype.VehicleType):
+        id = "VAB_Mephisto"
+        name = "ATGM VAB Mephisto"
+        detection_range = 0
+        threat_range = 3800
+        air_weapon_dist = 3800
+        eplrs = True
 
     class ZTZ_96B(unittype.VehicleType):
         id = "ZTZ96B"
@@ -1504,6 +1568,13 @@ class Armor:
         detection_range = 0
         threat_range = 3000
         air_weapon_dist = 0
+
+    class SPG_Sturmpanzer_IV_Brummbar(unittype.VehicleType):
+        id = "SturmPzIV"
+        name = "SPG Sturmpanzer IV Brummbar"
+        detection_range = 0
+        threat_range = 4500
+        air_weapon_dist = 2500
 
     class IFV_Sd_Kfz_234_2_Puma(unittype.VehicleType):
         id = "Sd_Kfz_234_2_Puma"
@@ -1736,7 +1807,7 @@ vehicle_map = {
     "SAU Gvozdika": Artillery.SPH_2S1_Gvozdika_122mm,
     "SAU Msta": Artillery.SPH_2S19_Msta_152mm,
     "SAU Akatsia": Artillery.SPH_2S3_Akatsia_152mm,
-    "SAU 2-C9": Artillery.SPH_2S9_Nona_120mm_M,
+    "SAU 2-C9": Artillery.SPM_2S9_Nona_120mm_M,
     "M-109": Artillery.SPH_M109_Paladin_155mm,
     "SpGH_Dana": Artillery.SPH_Dana_vz77_152mm,
     "AAV7": Armor.APC_AAV_7_Amphibious,
@@ -1744,12 +1815,12 @@ vehicle_map = {
     "BMP-1": Armor.IFV_BMP_1,
     "BMP-2": Armor.IFV_BMP_2,
     "BMP-3": Armor.IFV_BMP_3,
-    "BRDM-2": Armor.IFV_BRDM_2,
+    "BRDM-2": Armor.Scout_BRDM_2,
     "BTR-80": Armor.APC_BTR_80,
     "BTR_D": Armor.APC_BTR_RD,
-    "Cobra": Armor.APC_Cobra__Scout,
+    "Cobra": Armor.Scout_Cobra,
     "LAV-25": Armor.IFV_LAV_25,
-    "M1043 HMMWV Armament": Armor.APC_HMMWV__Scout,
+    "M1043 HMMWV Armament": Armor.Scout_HMMWV,
     "M1045 HMMWV TOW": Armor.ATGM_HMMWV,
     "M1126 Stryker ICV": Armor.IFV_M1126_Stryker_ICV,
     "M-113": Armor.APC_M113,
@@ -1771,9 +1842,9 @@ vehicle_map = {
     "Soldier M4": Infantry.Infantry_M4,
     "Soldier M4 GRG": Infantry.Infantry_M4_Georgia,
     "Soldier RPG": Infantry.Infantry_RPG,
-    "MLRS FDDM": Artillery.HUMVEE_JTAC,
+    "MLRS FDDM": Artillery.MRLS_FDDM__FC,
     "Grad-URAL": Artillery.MLRS_BM_21_Grad_122mm,
-    "Uragan_BM-27": Artillery.MLRS_BM_27_Uragan_220mm,
+    "Uragan_BM-27": Artillery.MLRS_9K57_Uragan_BM_27_220mm,
     "Smerch": Artillery.MLRS_9A52_Smerch_CM_300mm,
     "Smerch_HE": Artillery.MLRS_9A52_Smerch_HE_300mm,
     "MLRS": Artillery.MLRS_M270_227mm,
@@ -1792,7 +1863,7 @@ vehicle_map = {
     "Patriot AMG": AirDefence.SAM_Patriot_CR__AMG_AN_MRC_137,
     "Patriot ECS": AirDefence.SAM_Patriot_ECS,
     "Gepard": AirDefence.SPAAA_Gepard,
-    "Hawk pcp": AirDefence.SAM_Hawk_Generator__PCP,
+    "Hawk pcp": AirDefence.SAM_Hawk_Platoon_Command_Post__PCP,
     "Vulcan": AirDefence.SPAAA_Vulcan_M163,
     "Hawk ln": AirDefence.SAM_Hawk_LN_M192,
     "M48 Chaparral": AirDefence.SAM_Chaparral_M48,
@@ -1810,16 +1881,16 @@ vehicle_map = {
     "ZU-23 Emplacement Closed": AirDefence.AAA_ZU_23_Closed_Emplacement,
     "ZU-23 Emplacement": AirDefence.AAA_ZU_23_Emplacement,
     "Ural-375 ZU-23": AirDefence.SPAAA_ZU_23_2_Mounted_Ural_375,
-    "ZU-23 Closed Insurgent": AirDefence.AAA_ZU_23_Closed_Emplacement_Insurgent,
+    "ZU-23 Closed Insurgent": AirDefence.AAA_ZU_23_Insurgent_Closed_Emplacement,
     "Ural-375 ZU-23 Insurgent": AirDefence.SPAAA_ZU_23_2_Insurgent_Mounted_Ural_375,
-    "ZU-23 Insurgent": AirDefence.AAA_ZU_23_Insurgent,
+    "ZU-23 Insurgent": AirDefence.AAA_ZU_23_Insurgent_Emplacement,
     "SA-18 Igla manpad": AirDefence.MANPADS_SA_18_Igla_Grouse,
     "SA-18 Igla comm": AirDefence.MANPADS_SA_18_Igla_Grouse_C2,
     "SA-18 Igla-S manpad": AirDefence.MANPADS_SA_18_Igla_S_Grouse,
     "SA-18 Igla-S comm": AirDefence.MANPADS_SA_18_Igla_S_Grouse_C2,
     "Igla manpad INS": AirDefence.MANPADS_SA_18_Igla_Grouse_Ins,
     "1L13 EWR": AirDefence.EWR_1L13,
-    "Kub 1S91 str": AirDefence.SAM_SA_6_Kub_Long_Track_STR,
+    "Kub 1S91 str": AirDefence.SAM_SA_6_Kub_Straight_Flush_STR,
     "S-300PS 40B6M tr": AirDefence.SAM_SA_10_S_300_Grumble_Flap_Lid_TR,
     "S-300PS 40B6MD sr": AirDefence.SAM_SA_10_S_300_Grumble_Clam_Shell_SR,
     "55G6 EWR": AirDefence.EWR_55G6,
@@ -1841,7 +1912,6 @@ vehicle_map = {
     "TACAN_beacon": Fortification.Beacon_TACAN_Portable_TTS_3030,
     "Challenger2": Armor.MBT_Challenger_II,
     "Leclerc": Armor.MBT_Leclerc,
-    "Leopard-2": Armor.MBT_Leopard_2,
     "M-60": Armor.MBT_M60A3_Patton,
     "M1128 Stryker MGS": Armor.SPG_Stryker_MGS,
     "M-1 Abrams": Armor.MBT_M1A2_Abrams,
@@ -1851,28 +1921,28 @@ vehicle_map = {
     "T-90": Armor.MBT_T_90,
     "Leopard1A3": Armor.MBT_Leopard_1A3,
     "Merkava_Mk4": Armor.MBT_Merkava_IV,
-    "Ural-4320 APA-5D": Unarmed.GPU_APA_5D,
+    "Ural-4320 APA-5D": Unarmed.GPU_APA_5D_on_Ural_4320,
     "ATMZ-5": Unarmed.Refueler_ATMZ_5,
     "ATZ-10": Unarmed.Refueler_ATZ_10,
     "GAZ-3307": Unarmed.Truck_GAZ_3307,
     "GAZ-3308": Unarmed.Truck_GAZ_3308,
     "GAZ-66": Unarmed.Truck_GAZ_66,
     "M978 HEMTT Tanker": Unarmed.Refueler_M978_HEMTT,
-    "HEMTT TFFT": Unarmed.Truck_HEMMT_TFFT_Fire,
+    "HEMTT TFFT": Unarmed.Firefighter_HEMMT_TFFT,
     "IKARUS Bus": Unarmed.Bus_IKARUS_280,
     "KAMAZ Truck": Unarmed.Truck_KAMAZ_43101,
     "LAZ Bus": Unarmed.Bus_LAZ_695,
     "LiAZ Bus": Unarmed.Bus_LiAZ_677,
-    "Hummer": Unarmed.APC_HMMWV_Jeep,
+    "Hummer": Unarmed.LUV_HMMWV_Jeep,
     "M 818": Unarmed.Truck_M818_6x6,
     "MAZ-6303": Unarmed.Truck_MAZ_6303,
     "Predator GCS": Unarmed.MCC_Predator_UAV_CP__GCS,
     "Predator TrojanSpirit": Unarmed.MCC_COMM_Predator_UAV_CL,
     "Suidae": Unarmed.Suidae,
-    "Tigr_233036": Unarmed.APC_Tigr,
+    "Tigr_233036": Unarmed.LUV_Tigr,
     "Trolley bus": Unarmed.Bus_ZIU_9_Trolley,
     "UAZ-469": Unarmed.LUV_UAZ_469_Jeep,
-    "Ural ATsP-6": Unarmed.Truck_Ural_ATsP_6_Firefighter,
+    "Ural ATsP-6": Unarmed.Firefighter_Ural_ATsP_6,
     "Ural-4320-31": Unarmed.Truck_Ural_4320_31_Arm_d,
     "Ural-4320T": Unarmed.Truck_Ural_4320T,
     "Ural-375 PBU": Unarmed.Truck_Ural_375_Mobile_C2,
@@ -1892,31 +1962,42 @@ vehicle_map = {
     "Coach a passenger": Carriage.Passenger_Car,
     "Coach a platform": Carriage.Coach_Platform,
     "Scud_B": MissilesSS.SSM_SS_1C_Scud_B,
-    "M4_Sherman": Armor.MT_M4_Sherman,
+    "M4_Sherman": Armor.Tk_M4_Sherman,
     "M2A1_halftrack": Armor.APC_M2A1_Halftrack,
     "S_75M_Volhov": AirDefence.SAM_SA_2_S_75_Guideline_LN,
     "SNR_75V": AirDefence.SAM_SA_2_S_75_Fan_Song_TR,
     "ZSU_57_2": AirDefence.SPAAA_ZSU_57_2,
     "T-72B3": Armor.MBT_T_72B3,
-    "BTR-82A": Armor.APC_BTR_82A,
+    "BTR-82A": Armor.IFV_BTR_82A,
     "S-60_Type59_Artillery": AirDefence.AAA_S_60_57mm,
+    "generator_5i57": AirDefence.Disel_Power_Station_5I57A,
+    "ATZ-5": Unarmed.Refueler_ATZ_5,
+    "AA8": Unarmed.Fire_Fight_Vehicle_AA_7_2_60,
+    "PT_76": Armor.LT_PT_76,
     "Bedford_MWD": Unarmed.Truck_Bedford,
-    "bofors40": AirDefence.AAA_40mm_Bofors,
+    "bofors40": AirDefence.AAA_Bofors_40mm,
     "rapier_fsa_launcher": AirDefence.SAM_Rapier_LN,
     "rapier_fsa_optical_tracker_unit": AirDefence.SAM_Rapier_Tracker,
     "rapier_fsa_blindfire_radar": AirDefence.SAM_Rapier_Blindfire_TR,
     "Land_Rover_101_FC": Unarmed.Truck_Land_Rover_101_FC,
     "Land_Rover_109_S3": Unarmed.LUV_Land_Rover_109,
+    "Chieftain_mk3": Armor.MBT_Chieftain_Mk_3,
     "hy_launcher": MissilesSS.AShM_SS_N_2_Silkworm,
     "Silkworm_SR": MissilesSS.AShM_Silkworm_SR,
     "ES44AH": Locomotive.Loco_ES44AH,
     "Boxcartrinity": Carriage.Flatcar,
     "Tankcartrinity": Carriage.Tank_Cartrinity,
     "Wellcarnsc": Carriage.Well_Car,
-    "Pz_IV_H": Armor.MT_PzIV_H,
+    "Pz_IV_H": Armor.Tk_PzIV_H,
     "Sd_Kfz_251": Armor.APC_Sd_Kfz_251_Halftrack,
     "flak18": AirDefence.AAA_8_8cm_Flak_18,
     "Blitz_36-6700A": Unarmed.Truck_Opel_Blitz,
+    "Leopard-2A5": Armor.MBT_Leopard_2A5,
+    "Leopard-2": Armor.MBT_Leopard_2A6M,
+    "leopard-2A4": Armor.MBT_Leopard_2A4,
+    "leopard-2A4_trs": Armor.MBT_Leopard_2A4_Trs,
+    "T155_Firtina": Artillery.SPH_T155_Firtina_155mm,
+    "VAB_Mephisto": Armor.ATGM_VAB_Mephisto,
     "ZTZ96B": Armor.ZTZ_96B,
     "ZBD04A": Armor.ZBD_04A,
     "HQ-7_LN_SP": AirDefence.HQ_7_Self_Propelled_LN,
@@ -1932,7 +2013,7 @@ vehicle_map = {
     "Jagdpanther_G1": Armor.SPG_Jagdpanther_G1,
     "JagdPz_IV": Armor.SPG_Jagdpanzer_IV,
     "Stug_IV": Armor.SPG_StuG_IV,
-    "SturmPzIV": Artillery.SPG_Sturmpanzer_IV_Brummbar,
+    "SturmPzIV": Armor.SPG_Sturmpanzer_IV_Brummbar,
     "Sd_Kfz_234_2_Puma": Armor.IFV_Sd_Kfz_234_2_Puma,
     "flak30": AirDefence.AAA_Flak_38_20mm,
     "flak36": AirDefence.AAA_8_8cm_Flak_36,

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -172,8 +172,8 @@ class Weapons:
     BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH = {"clsid": "{BRU55_2*AGM-154C}", "name": "BRU-55 with 2 x AGM-154C - JSOW Unitary BROACH", "weight": 1055.5}
     BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = {"clsid": "{BRU55_2*GBU-38}", "name": "BRU-55 with 2 x GBU-38 - JDAM, 500lb GPS Guided Bomb", "weight": 573}
     BRU_57_with_2_x_AGM_154A___JSOW_CEB__CBU_type_ = {"clsid": "{BRU57_2*AGM-154A}", "name": "BRU-57 with 2 x AGM-154A - JSOW CEB (CBU-type)", "weight": 1082}
-    BRU_57_with_2_x_CBU_103 = {"clsid": "{BRU57_2*CBU-103}", "name": "BRU-57 with 2 x CBU-103", "weight": 951}
-    BRU_57_with_2_x_CBU_105 = {"clsid": "{BRU57_2*CBU-105}", "name": "BRU-57 with 2 x CBU-105", "weight": 925}
+    BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD = {"clsid": "{BRU57_2*CBU-103}", "name": "BRU-57 with 2 x CBU-103 - 202 x CEM, CBU with WCMD", "weight": 951}
+    BRU_57_with_2_x_CBU_105___10_x_SFW__CBU_with_WCMD = {"clsid": "{BRU57_2*CBU-105}", "name": "BRU-57 with 2 x CBU-105 - 10 x SFW, CBU with WCMD", "weight": 925}
     BRU_57_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb = {"clsid": "{BRU57_2*GBU-38}", "name": "BRU-57 with 2 x GBU-38 - JDAM, 500lb GPS Guided Bomb", "weight": 573}
     BR_250 = {"clsid": "BR_250", "name": "BR-250", "weight": 250}
     BR_500 = {"clsid": "BR_500", "name": "BR-500", "weight": 500}
@@ -198,12 +198,12 @@ class Weapons:
     CATM_9M = {"clsid": "CATM-9M", "name": "Captive AIM-9M for ACM", "weight": 85.73}
     CBLS_200 = {"clsid": "CBLS-200", "name": "4*BDU-33", "weight": 98}
     CBU87_10 = {"clsid": "CBU87*10", "name": "10 x CBU-87 - 202 x CEM Cluster Bombs", "weight": 4300}
-    CBU97_10 = {"clsid": "CBU97*10", "name": "10 x CBU-97 - 10 x CEM Cluster Bombs", "weight": 4170}
+    CBU97_10 = {"clsid": "CBU97*10", "name": "10 x CBU-97 - 10 x SFW Cluster Bombs", "weight": 4170}
     CBU_103___202_x_CEM__CBU_with_WCMD = {"clsid": "{CBU_103}", "name": "CBU-103 - 202 x CEM, CBU with WCMD", "weight": 430}
-    CBU_105___10_x_CEM__CBU_with_WCMD = {"clsid": "{CBU_105}", "name": "CBU-105 - 10 x CEM, CBU with WCMD", "weight": 417}
+    CBU_105___10_x_SFW__CBU_with_WCMD = {"clsid": "{CBU_105}", "name": "CBU-105 - 10 x SFW, CBU with WCMD", "weight": 417}
     CBU_52B___220_x_HE_Frag_bomblets = {"clsid": "{CBU-52B}", "name": "CBU-52B - 220 x HE/Frag bomblets", "weight": 356}
     CBU_87___202_x_CEM_Cluster_Bomb = {"clsid": "{CBU-87}", "name": "CBU-87 - 202 x CEM Cluster Bomb", "weight": 430}
-    CBU_97___10_x_CEM_Cluster_Bomb = {"clsid": "{5335D97A-35A5-4643-9D9B-026C75961E52}", "name": "CBU-97 - 10 x CEM Cluster Bomb", "weight": 417}
+    CBU_97___10_x_SFW_Cluster_Bomb = {"clsid": "{5335D97A-35A5-4643-9D9B-026C75961E52}", "name": "CBU-97 - 10 x SFW Cluster Bomb", "weight": 417}
     CBU_99___490lbs__247_x_HEAT_Bomblets = {"clsid": "{CBU_99}", "name": "CBU-99 - 490lbs, 247 x HEAT Bomblets", "weight": 222}
     DEFA_553 = {"clsid": "{C-101-DEFA553}", "name": "DEFA-553", "weight": 218}
     DIS_AKD_10 = {"clsid": "DIS_AKD-10", "name": "AKD-10", "weight": 58}
@@ -221,6 +221,7 @@ class Weapons:
     DIS_GBU_12_DUAL_GDJ_II19_L = {"clsid": "DIS_GBU_12_DUAL_GDJ_II19_L", "name": "GDJ-II19 - 2 x GBU-12", "weight": 629}
     DIS_GBU_12_DUAL_GDJ_II19_R = {"clsid": "DIS_GBU_12_DUAL_GDJ_II19_R", "name": "GDJ-II19 - 2 x GBU-12", "weight": 629}
     DIS_GBU_16 = {"clsid": "DIS_GBU_16", "name": "GBU-16", "weight": 564}
+    DIS_GDJ_YJ83K = {"clsid": "DIS_GDJ_YJ83K", "name": "YJ-83K", "weight": 765}
     DIS_LAU68_MK5_DUAL_GDJ_II19_L = {"clsid": "DIS_LAU68_MK5_DUAL_GDJ_II19_L", "name": "GDJ-II19 - 2 x LAU68 MK5", "weight": 261.06}
     DIS_LAU68_MK5_DUAL_GDJ_II19_R = {"clsid": "DIS_LAU68_MK5_DUAL_GDJ_II19_R", "name": "GDJ-II19 - 2 x LAU68 MK5", "weight": 261.06}
     DIS_LD_10 = {"clsid": "DIS_LD-10", "name": "LD-10", "weight": 289}
@@ -236,7 +237,6 @@ class Weapons:
     DIS_MK_82_DUAL_GDJ_II19_R = {"clsid": "DIS_MK_82_DUAL_GDJ_II19_R", "name": "GDJ-II19 - 2 x Mk-82", "weight": 561}
     DIS_PL_12 = {"clsid": "DIS_PL-12", "name": "PL-12", "weight": 199}
     DIS_PL_5EII = {"clsid": "DIS_PL-5EII", "name": "PL-5EII", "weight": 153}
-    DIS_PL_5EII_TIP = {"clsid": "DIS_PL-5EII_TIP", "name": "PL-5EII", "weight": 83}
     DIS_PL_8A = {"clsid": "DIS_PL-8A", "name": "PL-8A", "weight": 115}
     DIS_PL_8B = {"clsid": "DIS_PL-8B", "name": "PL-8B", "weight": 115}
     DIS_RKT_90_UG = {"clsid": "DIS_RKT_90_UG", "name": "UG_90MM", "weight": 382.5}
@@ -249,13 +249,14 @@ class Weapons:
     DIS_SMOKE_GENERATOR_R = {"clsid": "DIS_SMOKE_GENERATOR_R", "name": "Smoke Generator - red", "weight": 0}
     DIS_SMOKE_GENERATOR_W = {"clsid": "DIS_SMOKE_GENERATOR_W", "name": "Smoke Generator - white", "weight": 0}
     DIS_SMOKE_GENERATOR_Y = {"clsid": "DIS_SMOKE_GENERATOR_Y", "name": "Smoke Generator - yellow", "weight": 0}
-    DIS_SPJ_POD = {"clsid": "DIS_SPJ_POD", "name": "SPJ POD", "weight": 270}
+    DIS_SPJ_POD = {"clsid": "DIS_SPJ_POD", "name": "KG-600", "weight": 270}
     DIS_TANK1100 = {"clsid": "DIS_TANK1100", "name": "1100L Tank", "weight": 1064}
     DIS_TANK800 = {"clsid": "DIS_TANK800", "name": "800L Tank", "weight": 730}
     DIS_TYPE200 = {"clsid": "DIS_TYPE200", "name": "TYPE-200A", "weight": 200}
     DIS_TYPE200_DUAL_L = {"clsid": "DIS_TYPE200_DUAL_L", "name": "TYPE-200A Dual", "weight": 400}
     DIS_TYPE200_DUAL_R = {"clsid": "DIS_TYPE200_DUAL_R", "name": "TYPE-200A Dual", "weight": 400}
     DIS_WMD7 = {"clsid": "DIS_WMD7", "name": "WMD7 POD", "weight": 295}
+    DIS_YJ83K = {"clsid": "DIS_YJ83K", "name": "YJ-83K", "weight": 715}
     DWS39_MJ1 = {"clsid": "{DWS39_MJ1}", "name": "DWS39 MJ1", "weight": 605}
     DWS39_MJ1_MJ2 = {"clsid": "{DWS39_MJ1_MJ2}", "name": "DWS39 MJ1-MJ2", "weight": 605}
     DWS39_MJ2 = {"clsid": "{DWS39_MJ2}", "name": "DWS39 MJ2", "weight": 605}
@@ -318,8 +319,8 @@ class Weapons:
     GBU_16 = {"clsid": "{BRU-32 GBU-16}", "name": "GBU-16", "weight": 621.38}
     GBU_16___1000lb_Laser_Guided_Bomb = {"clsid": "{0D33DDAE-524F-4A4E-B5B8-621754FE3ADE}", "name": "GBU-16 - 1000lb Laser Guided Bomb", "weight": 513}
     GBU_24 = {"clsid": "{BRU-32 GBU-24}", "name": "GBU-24", "weight": 1107.38}
-    GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", "name": "GBU-24 Paveway III - 2000lb Laser Guided Bomb", "weight": 900}
-    GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = {"clsid": "{GBU-24}", "name": "GBU-24 Paveway III - 2000lb Laser Guided Bomb", "weight": 934}
+    GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb = {"clsid": "{34759BBC-AF1E-4AEE-A581-498FF7A6EBCE}", "name": "GBU-24 Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
+    GBU_24_Paveway_III___2000lb_Laser_Guided_Bomb_ = {"clsid": "{GBU-24}", "name": "GBU-24 Paveway III - 2000lb Laser Guided Bomb", "weight": 1087}
     GBU_27___2000lb_Laser_Guided_Penetrator_Bomb = {"clsid": "{EF0A9419-01D6-473B-99A3-BEBDB923B14D}", "name": "GBU-27 - 2000lb Laser Guided Penetrator Bomb", "weight": 1200}
     GBU_28___5000lb_Laser_Guided_Penetrator_Bomb = {"clsid": "{F06B775B-FC70-44B5-8A9F-5B5E2EB839C7}", "name": "GBU-28 - 5000lb Laser Guided Penetrator Bomb", "weight": 2130}
     GBU_31V3B_8 = {"clsid": "GBU-31V3B*8", "name": "8 x GBU-31(V)3/B - JDAM, 2000lb GPS Guided Penetrator Bombs", "weight": 7848}
@@ -784,10 +785,10 @@ class Weapons:
     S_25L___320Kg__340mm_Laser_Guided_Rkt = {"clsid": "{0180F983-C14A-11d8-9897-000476191836}", "name": "S-25L - 320Kg, 340mm Laser Guided Rkt", "weight": 500}
     S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator = {"clsid": "{A0648264-4BC0-4EE8-A543-D119F6BA4257}", "name": "S-25-OFM - 340mm UnGd Rkt, 480kg Penetrator", "weight": 495}
     Tangazh_ELINT_pod = {"clsid": "{0519A262-0AB6-11d6-9193-00A0249B6F00}", "name": "Tangazh ELINT pod", "weight": 200}
-    TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = {"clsid": "{TER_9A_2L*CBU-87}", "name": "TER-9A with 2 x CBU-87 - 202 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 913}
-    TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = {"clsid": "{TER_9A_2R*CBU-87}", "name": "TER-9A with 2 x CBU-87 - 202 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 913}
-    TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = {"clsid": "{TER_9A_2L*CBU-97}", "name": "TER-9A with 2 x CBU-97 - 10 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 887}
-    TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_ = {"clsid": "{TER_9A_2R*CBU-97}", "name": "TER-9A with 2 x CBU-97 - 10 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 887}
+    TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb = {"clsid": "{TER_9A_2L*CBU-87}", "name": "TER-9A with 2 x CBU-87 - 202 x CEM Cluster Bomb", "weight": 913}
+    TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_ = {"clsid": "{TER_9A_2R*CBU-87}", "name": "TER-9A with 2 x CBU-87 - 202 x CEM Cluster Bomb", "weight": 913}
+    TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb = {"clsid": "{TER_9A_2L*CBU-97}", "name": "TER-9A with 2 x CBU-97 - 10 x SFW Cluster Bomb", "weight": 887}
+    TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = {"clsid": "{TER_9A_2R*CBU-97}", "name": "TER-9A with 2 x CBU-97 - 10 x SFW Cluster Bomb", "weight": 887}
     TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{TER_9A_2L*GBU-12}", "name": "TER-9A with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 607}
     TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = {"clsid": "{TER_9A_2R*GBU-12}", "name": "TER-9A with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 607}
     TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{TER_9A_2L*MK-82AIR}", "name": "TER-9A with 2 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 537}
@@ -797,8 +798,8 @@ class Weapons:
     TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD = {"clsid": "{TER_9A_2L*MK-82}", "name": "TER-9A with 2 x Mk-82 - 500lb GP Bomb LD", "weight": 509}
     TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = {"clsid": "{TER_9A_2R*MK-82}", "name": "TER-9A with 2 x Mk-82 - 500lb GP Bomb LD", "weight": 509}
     TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD = {"clsid": "{TER_9A_3*BDU-33}", "name": "TER-9A with 3 x BDU-33 - 25lb Practice Bomb LD", "weight": 86.9}
-    TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = {"clsid": "{TER_9A_3*CBU-87}", "name": "TER-9A with 3 x CBU-87 - 202 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 1343}
-    TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb = {"clsid": "{TER_9A_3*CBU-97}", "name": "TER-9A with 3 x CBU-97 - 10 x Anti-Armor Skeet SFW Cluster Bomb", "weight": 1304}
+    TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb = {"clsid": "{TER_9A_3*CBU-87}", "name": "TER-9A with 3 x CBU-87 - 202 x CEM Cluster Bomb", "weight": 1343}
+    TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb = {"clsid": "{TER_9A_3*CBU-97}", "name": "TER-9A with 3 x CBU-97 - 10 x SFW Cluster Bomb", "weight": 1304}
     TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{TER_9A_3*MK-82AIR}", "name": "TER-9A with 3 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 779}
     TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = {"clsid": "{TER_9A_3*MK-82_Snakeye}", "name": "TER-9A with 3 x Mk-82 Snakeye - 500lb GP Bomb HD", "weight": 801.5}
     TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD = {"clsid": "{TER_9A_3*MK-82}", "name": "TER-9A with 3 x Mk-82 - 500lb GP Bomb LD", "weight": 737}
@@ -1176,8 +1177,8 @@ weapon_ids = {
     "{BRU55_2*AGM-154C}": Weapons.BRU_55_with_2_x_AGM_154C___JSOW_Unitary_BROACH,
     "{BRU55_2*GBU-38}": Weapons.BRU_55_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb,
     "{BRU57_2*AGM-154A}": Weapons.BRU_57_with_2_x_AGM_154A___JSOW_CEB__CBU_type_,
-    "{BRU57_2*CBU-103}": Weapons.BRU_57_with_2_x_CBU_103,
-    "{BRU57_2*CBU-105}": Weapons.BRU_57_with_2_x_CBU_105,
+    "{BRU57_2*CBU-103}": Weapons.BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD,
+    "{BRU57_2*CBU-105}": Weapons.BRU_57_with_2_x_CBU_105___10_x_SFW__CBU_with_WCMD,
     "{BRU57_2*GBU-38}": Weapons.BRU_57_with_2_x_GBU_38___JDAM__500lb_GPS_Guided_Bomb,
     "BR_250": Weapons.BR_250,
     "BR_500": Weapons.BR_500,
@@ -1204,10 +1205,10 @@ weapon_ids = {
     "CBU87*10": Weapons.CBU87_10,
     "CBU97*10": Weapons.CBU97_10,
     "{CBU_103}": Weapons.CBU_103___202_x_CEM__CBU_with_WCMD,
-    "{CBU_105}": Weapons.CBU_105___10_x_CEM__CBU_with_WCMD,
+    "{CBU_105}": Weapons.CBU_105___10_x_SFW__CBU_with_WCMD,
     "{CBU-52B}": Weapons.CBU_52B___220_x_HE_Frag_bomblets,
     "{CBU-87}": Weapons.CBU_87___202_x_CEM_Cluster_Bomb,
-    "{5335D97A-35A5-4643-9D9B-026C75961E52}": Weapons.CBU_97___10_x_CEM_Cluster_Bomb,
+    "{5335D97A-35A5-4643-9D9B-026C75961E52}": Weapons.CBU_97___10_x_SFW_Cluster_Bomb,
     "{CBU_99}": Weapons.CBU_99___490lbs__247_x_HEAT_Bomblets,
     "{C-101-DEFA553}": Weapons.DEFA_553,
     "DIS_AKD-10": Weapons.DIS_AKD_10,
@@ -1225,6 +1226,7 @@ weapon_ids = {
     "DIS_GBU_12_DUAL_GDJ_II19_L": Weapons.DIS_GBU_12_DUAL_GDJ_II19_L,
     "DIS_GBU_12_DUAL_GDJ_II19_R": Weapons.DIS_GBU_12_DUAL_GDJ_II19_R,
     "DIS_GBU_16": Weapons.DIS_GBU_16,
+    "DIS_GDJ_YJ83K": Weapons.DIS_GDJ_YJ83K,
     "DIS_LAU68_MK5_DUAL_GDJ_II19_L": Weapons.DIS_LAU68_MK5_DUAL_GDJ_II19_L,
     "DIS_LAU68_MK5_DUAL_GDJ_II19_R": Weapons.DIS_LAU68_MK5_DUAL_GDJ_II19_R,
     "DIS_LD-10": Weapons.DIS_LD_10,
@@ -1240,7 +1242,6 @@ weapon_ids = {
     "DIS_MK_82_DUAL_GDJ_II19_R": Weapons.DIS_MK_82_DUAL_GDJ_II19_R,
     "DIS_PL-12": Weapons.DIS_PL_12,
     "DIS_PL-5EII": Weapons.DIS_PL_5EII,
-    "DIS_PL-5EII_TIP": Weapons.DIS_PL_5EII_TIP,
     "DIS_PL-8A": Weapons.DIS_PL_8A,
     "DIS_PL-8B": Weapons.DIS_PL_8B,
     "DIS_RKT_90_UG": Weapons.DIS_RKT_90_UG,
@@ -1260,6 +1261,7 @@ weapon_ids = {
     "DIS_TYPE200_DUAL_L": Weapons.DIS_TYPE200_DUAL_L,
     "DIS_TYPE200_DUAL_R": Weapons.DIS_TYPE200_DUAL_R,
     "DIS_WMD7": Weapons.DIS_WMD7,
+    "DIS_YJ83K": Weapons.DIS_YJ83K,
     "{DWS39_MJ1}": Weapons.DWS39_MJ1,
     "{DWS39_MJ1_MJ2}": Weapons.DWS39_MJ1_MJ2,
     "{DWS39_MJ2}": Weapons.DWS39_MJ2,
@@ -1788,10 +1790,10 @@ weapon_ids = {
     "{0180F983-C14A-11d8-9897-000476191836}": Weapons.S_25L___320Kg__340mm_Laser_Guided_Rkt,
     "{A0648264-4BC0-4EE8-A543-D119F6BA4257}": Weapons.S_25_OFM___340mm_UnGd_Rkt__480kg_Penetrator,
     "{0519A262-0AB6-11d6-9193-00A0249B6F00}": Weapons.Tangazh_ELINT_pod,
-    "{TER_9A_2L*CBU-87}": Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb,
-    "{TER_9A_2R*CBU-87}": Weapons.TER_9A_with_2_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_,
-    "{TER_9A_2L*CBU-97}": Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb,
-    "{TER_9A_2R*CBU-97}": Weapons.TER_9A_with_2_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb_,
+    "{TER_9A_2L*CBU-87}": Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb,
+    "{TER_9A_2R*CBU-87}": Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_,
+    "{TER_9A_2L*CBU-97}": Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb,
+    "{TER_9A_2R*CBU-97}": Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_,
     "{TER_9A_2L*GBU-12}": Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
     "{TER_9A_2R*GBU-12}": Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_,
     "{TER_9A_2L*MK-82AIR}": Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
@@ -1801,8 +1803,8 @@ weapon_ids = {
     "{TER_9A_2L*MK-82}": Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD,
     "{TER_9A_2R*MK-82}": Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_,
     "{TER_9A_3*BDU-33}": Weapons.TER_9A_with_3_x_BDU_33___25lb_Practice_Bomb_LD,
-    "{TER_9A_3*CBU-87}": Weapons.TER_9A_with_3_x_CBU_87___202_x_Anti_Armor_Skeet_SFW_Cluster_Bomb,
-    "{TER_9A_3*CBU-97}": Weapons.TER_9A_with_3_x_CBU_97___10_x_Anti_Armor_Skeet_SFW_Cluster_Bomb,
+    "{TER_9A_3*CBU-87}": Weapons.TER_9A_with_3_x_CBU_87___202_x_CEM_Cluster_Bomb,
+    "{TER_9A_3*CBU-97}": Weapons.TER_9A_with_3_x_CBU_97___10_x_SFW_Cluster_Bomb,
     "{TER_9A_3*MK-82AIR}": Weapons.TER_9A_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
     "{TER_9A_3*MK-82_Snakeye}": Weapons.TER_9A_with_3_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,
     "{TER_9A_3*MK-82}": Weapons.TER_9A_with_3_x_Mk_82___500lb_GP_Bomb_LD,


### PR DESCRIPTION
Hello, 

I ran the data-export for today new openbeta version, in order to support the newly added units :
- PT-76
- АА-7,2-60 FireFighter - Ural 4332
- ATZ-5 - Ural 4320
- Diesel power station 5i57A
- VAB Mephisto
- Chieftain Mk.3
- La Combattante II (ship)
- Leopard 2A5
- Leopard 2A6M (replaced Leopard-2)
- Leopard 2A4
- Leopard 2A4TR (Turkey)
- Seawise Giant (ship)
- SPH T-155 Fırtına

Khopa