### PR TITLE
Add multirole fighters target option.

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -207,6 +207,9 @@ class Targets(metaclass=TargetType):
                 class Fighters(TargetType, metaclass=TargetType):
                     id = "Fighters"
 
+                class MultiroleFighters(TargetType, metaclass=TargetType):
+                    id = "Multirole fighters"
+
                 class Bombers(TargetType, metaclass=TargetType):
                     id = "Bombers"
 
@@ -559,6 +562,7 @@ class EngageTargets(Task):
             targets = [Targets.All]
         self.params = {
             "targetTypes": {i: targets[i - 1] for i in range(1, len(targets) + 1)},
+            "value": ";".join([t.id for t in targets]),
             "maxDistEnabled": True if max_distance else False,
             "maxDist": max_distance,
             "priority": 0
@@ -575,6 +579,7 @@ class EngageTargetsInZone(Task):
             targets = [Targets.All]
         self.params = {
             "targetTypes": {i: targets[i - 1] for i in range(1, len(targets) + 1)},
+            "value": ";".join([t.id for t in targets]),
             "priority": 0,
             "x": position.x,
             "y": position.y,


### PR DESCRIPTION
Not sure when this got added to DCS, but multirole fighters are a
separte target type now.

The task also emits a `value` field in addition to `targetTypes` that is
the same thing but a semicolon delimited list.

The ME also produces a `noTargetTypes` which is like `targetTypes`,
but for all the things that *weren't* selected. I've omitted that since
it doesn't seem to matter.