### PR TITLE
Add invisible FARP

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -604,7 +604,7 @@ class Mission:
              heading=0,
              hidden=False,
              dead=False,
-             farp_type=unit.FARP):
+             farp_type : Union[str, Type[unit.FARP], Type[unit.SingleHeliPad], Type[unit.InvisibleFARP]] = unit.FARP):
         """Add a static group with 1 static object.
 
         Args:
@@ -617,12 +617,18 @@ class Mission:
             heading: of the object
             hidden: should the object be hidden on the map
             dead: should the object be rendered as dead
-            farp_type: the desired farp type
+            farp_type: the desired farp type or its name
 
         Returns:
             StaticGroup: the new farp group
         """
         sg = unitgroup.StaticGroup(self.next_group_id(), name)
+
+        from dcs.unit import farp_mapping
+        if isinstance(farp_type, str):
+            farp_type = farp_mapping.get(farp_type)
+        if farp_type not in farp_mapping.values():
+            raise TypeError(f"'{type(farp_type)}' is not a valid FARP type.")
 
         s = farp_type(self.next_unit_id(), name, frequency, modulation, callsign_id)
         s.position = copy.copy(position)

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -603,7 +603,8 @@ class Mission:
              callsign_id=1,
              heading=0,
              hidden=False,
-             dead=False):
+             dead=False,
+             farp_type=unit.FARP):
         """Add a static group with 1 static object.
 
         Args:
@@ -616,13 +617,14 @@ class Mission:
             heading: of the object
             hidden: should the object be hidden on the map
             dead: should the object be rendered as dead
+            farp_type: the desired farp type
 
         Returns:
             StaticGroup: the new farp group
         """
         sg = unitgroup.StaticGroup(self.next_group_id(), name)
 
-        s = unit.FARP(self.next_unit_id(), name, frequency, modulation, callsign_id)
+        s = farp_type(self.next_unit_id(), name, frequency, modulation, callsign_id)
         s.position = copy.copy(position)
         s.heading = heading
         sg.add_unit(s)

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -604,7 +604,7 @@ class Mission:
              heading=0,
              hidden=False,
              dead=False,
-             farp_type : Union[str, Type[unit.FARP], Type[unit.SingleHeliPad], Type[unit.InvisibleFARP]] = unit.FARP):
+             farp_type: Union[str, Type[unit.FARP], Type[unit.SingleHeliPad], Type[unit.InvisibleFARP]] = unit.FARP):
         """Add a static group with 1 static object.
 
         Args:

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -216,6 +216,7 @@ class SingleHeliPad(Static):
 
         return d
 
+
 class InvisibleFARP(Static):
     def __init__(self, unit_id=None, name=None, frequency=127.5, modulation=0, callsign_id=1):
         super(InvisibleFARP, self).__init__(unit_id, name, "Invisible FARP")
@@ -239,3 +240,10 @@ class InvisibleFARP(Static):
         d["heliport_callsign_id"] = self.heliport_callsign_id
 
         return d
+
+
+farp_map = {
+    "FARP": FARP,
+    "SingleHeliPad": SingleHeliPad,
+    "InvisibleFARP": InvisibleFARP,
+}

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -242,7 +242,7 @@ class InvisibleFARP(Static):
         return d
 
 
-farp_map = {
+farp_mapping = {
     "FARP": FARP,
     "SingleHeliPad": SingleHeliPad,
     "InvisibleFARP": InvisibleFARP,

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -215,3 +215,27 @@ class SingleHeliPad(Static):
         d["heliport_callsign_id"] = self.heliport_callsign_id
 
         return d
+
+class InvisibleFARP(Static):
+    def __init__(self, unit_id=None, name=None, frequency=127.5, modulation=0, callsign_id=1):
+        super(InvisibleFARP, self).__init__(unit_id, name, "Invisible FARP")
+        self.category = "Heliports"
+        self.shape_name = "invisiblefarp"
+        self.heliport_frequency: float = frequency
+        self.heliport_modulation = modulation
+        self.heliport_callsign_id: int = callsign_id
+        self.can_cargo = False
+
+    def load_from_dict(self, d):
+        super(InvisibleFARP, self).load_from_dict(d)
+        self.heliport_frequency = float(d.get("heliport_frequency", 127.5))
+        self.heliport_modulation = d.get("heliport_modulation", 0)
+        self.heliport_callsign_id = d.get("heliport_callsign_id", 0)
+
+    def dict(self):
+        d = super(InvisibleFARP, self).dict()
+        d["heliport_frequency"] = self.heliport_frequency
+        d["heliport_modulation"] = self.heliport_modulation
+        d["heliport_callsign_id"] = self.heliport_callsign_id
+
+        return d


### PR DESCRIPTION
Hi, I started to write a new mission tool using `pydcs` and couldn't find the new invisible FARP. So I added it. I also added a new `farp_type` parameter to `Mission.farp`. This lets you change the farp type by passing a class reference. I moved it to the end so that it hopefully doesn't cause any conflicts with the existing code.

Here is a small sample script that generates a mission with one instance of each farp type:

~~~ python
import dcs

mission = dcs.Mission(dcs.terrain.Syria())

hatay = mission.terrain.hatay()

usa = mission.country("USA")
mission.farp(country=usa,
             name="FARP 1",
             position=dcs.Point(hatay.position.x + 1000, hatay.position.y + 1000),
             )

mission.farp(country=usa,
             name="FARP 2",
             position=dcs.Point(hatay.position.x + 2000, hatay.position.y + 1000),
             farp_type=dcs.unit.SingleHeliPad
             )

mission.farp(country=usa,
             name="FARP 3",
             position=dcs.Point(hatay.position.x + 3000, hatay.position.y + 1000),
             farp_type=dcs.unit.InvisibleFARP
             )


mission.save("farp_sample.miz")
~~~

Let me know what you think.