### PR TITLE
Fix incorrect type annotations, add py.typed.

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, List, Dict, Sequence, Union, Optional, Type
 
 from dcs.coalition import Coalition
-from dcs.terrain.terrain import Warehouses
+from dcs.terrain.terrain import Terrain, Warehouses
 from dcs.triggers import Triggers
 import dcs.countries as countries
 import dcs.helicopters as helicopters
@@ -96,15 +96,7 @@ class Mission:
 
     _CURRENT_MIZ_VERSION: int = 19  # on save this version number will be written
 
-    def __init__(self, terrain: Union[
-            terrain_.Caucasus,
-            terrain_.Nevada,
-            terrain_.Normandy,
-            terrain_.PersianGulf,
-            terrain_.TheChannel,
-            terrain_.Syria,
-            terrain_.MarianaIslands] = None
-    ):
+    def __init__(self, terrain: Optional[Terrain] = None) -> None:
         if terrain is None:
             terrain = terrain_.Caucasus()
 

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -1073,10 +1073,10 @@ class Mission:
                                   name,
                                   aircraft_type: Type[unittype.FlyingType],
                                   airport: terrain_.Airport,
-                                  maintask: Type[task.MainTask] = None,
+                                  maintask: Optional[Type[task.MainTask]] = None,
                                   start_type: StartType = StartType.Cold,
                                   group_size=1,
-                                  parking_slots: List[terrain_.ParkingSlot] = None) -> unitgroup.FlyingGroup:
+                                  parking_slots: Optional[List[terrain_.ParkingSlot]] = None) -> unitgroup.FlyingGroup:
         """Add a new Plane/Helicopter group at the given airport.
 
         Runway, warm/cold start depends on the given start_type.
@@ -1120,7 +1120,7 @@ class Mission:
                                name,
                                aircraft_type: Type[unittype.FlyingType],
                                pad_group: Union[unitgroup.ShipGroup, unitgroup.StaticGroup],
-                               maintask: Type[task.MainTask] = None,
+                               maintask: Optional[Type[task.MainTask]] = None,
                                start_type: StartType = StartType.Cold,
                                group_size=1) -> unitgroup.FlyingGroup:
         """Add a new Plane/Helicopter group at the given FARP or carrier unit.

--- a/dcs/point.py
+++ b/dcs/point.py
@@ -32,7 +32,7 @@ class StaticPoint:
         self.type = ""
         self.name: str = ""
         self.position = mapping.Point(0, 0)
-        self.speed = 0
+        self.speed = 0.0
         self.formation_template = ""
         self.action = PointAction.None_  # type: PointAction
         self.landing_refuel_rearm_time: Optional[int] = None

--- a/dcs/point.py
+++ b/dcs/point.py
@@ -35,7 +35,7 @@ class StaticPoint:
         self.speed = 0
         self.formation_template = ""
         self.action = PointAction.None_  # type: PointAction
-        self.landing_refuel_rearm_time: Optional[str] = None
+        self.landing_refuel_rearm_time: Optional[int] = None
 
     def load_from_dict(self, d: Dict[str, Any], translation) -> None:
         self.alt = d["alt"]
@@ -50,7 +50,10 @@ class StaticPoint:
                 self.name = str(translation.get_string(d["name"]))
             else:
                 self.name = d["name"]
-        self.landing_refuel_rearm_time = d.get("timeReFuAr")
+        try:
+            self.landing_refuel_rearm_time = int(d["timeReFuAr"])
+        except KeyError:
+            self.landing_refuel_rearm_time = None
 
     def dict(self) -> Dict[str, Any]:
         if not isinstance(self.name, str):
@@ -66,7 +69,7 @@ class StaticPoint:
             "action": self.action.value
         }
 
-        if self.landing_refuel_rearm_time:
+        if self.landing_refuel_rearm_time is not None:
             d["timeReFuAr"] = self.landing_refuel_rearm_time
 
         return d

--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -15,6 +15,9 @@ class UnitType:
 
 class VehicleType(UnitType):
     eplrs = False
+    detection_range = 0
+    threat_range = 0
+    air_weapon_dist = 0
 
 
 class ShipType(UnitType):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     keywords='dcs digital combat simulator eagle dynamics mission framework',
     packages=['dcs', 'dcs/terrain', 'dcs/lua', 'dcs/scripts'],
     package_data={
-        'dcs/terrain': ['caucasus.p', 'nevada.p']
+        'dcs': ['py.typed'],
+        'dcs/terrain': ['caucasus.p', 'nevada.p'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
These commits together are the errors I found while updating Liberation to type check our uses of pydcs. In one case there was an actual bug (loading a mission with a refuel/rearm landing waypoint and then resaving it would corrupt the mission by writing a string back where an integer was needed).

This also adds the py.typed file, without which mypy ignore type annotations in this package when checking dependents: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages