### PR TITLE
Use floats for qnh and temperature

### DIFF
--- a/dcs/weather.py
+++ b/dcs/weather.py
@@ -79,9 +79,9 @@ class Weather:
         self.wind_at_8000 = Wind()
         self.enable_fog = False
         self.turbulence_at_ground = 0
-        self.season_temperature = 20
+        self.season_temperature = 20.0
         self.type_weather = 0
-        self.qnh = 760
+        self.qnh = 760.0
         self.cyclones = []
         self.name = "Summer, clean sky"
         self.fog_thickness = 0


### PR DESCRIPTION
From testing through Liberation, DCS appears to accept float values just fine.
If mmHg is an integer, there is poor resolution. For example the inches Hg value of 29.94 would not be possible to have. Next up from 29.92 would be 29.96.