### PR TITLE
Dont fail so soon when p graph files are not found

### DIFF
--- a/dcs/terrain/caucasus.py
+++ b/dcs/terrain/caucasus.py
@@ -3024,7 +3024,7 @@ class Caucasus(Terrain):
     center = {"lat": 43.69666, "long": 32.96}
     bounds = mapping.Rectangle(380 * 1000, -560 * 1000, -600 * 1000, 1130 * 1000)
     map_view_default = MapView(mapping.Point(-255714.28571428, 680571.42857143), 1000000)
-    city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'caucasus.p'))  # type: Graph
+    city_graph = None
     temperature = [
         (-4, 14),
         (-8, 14),
@@ -3047,6 +3047,11 @@ class Caucasus(Terrain):
         # 36TWQ9949898109
         self.bullseye_blue = {"x": -291014, "y": 617414}
         self.bullseye_red = {"x": 11557, "y": 371700}
+
+        try:
+            self.city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'caucasus.p'))  # type: Graph
+        except:
+            pass
 
         self.airports['Anapa-Vityazevo'] = Anapa_Vityazevo()
         self.airports['Krasnodar-Center'] = Krasnodar_Center()

--- a/dcs/terrain/caucasus.py
+++ b/dcs/terrain/caucasus.py
@@ -3050,7 +3050,7 @@ class Caucasus(Terrain):
 
         try:
             self.city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'caucasus.p'))  # type: Graph
-        except:
+        except FileNotFoundError:
             pass
 
         self.airports['Anapa-Vityazevo'] = Anapa_Vityazevo()

--- a/dcs/terrain/nevada.py
+++ b/dcs/terrain/nevada.py
@@ -2194,7 +2194,7 @@ class Nevada(Terrain):
 
         try:
             self.city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'nevada.p'))  # type: Graph
-        except:
+        except FileNotFoundError:
             pass
 
         self.airports['Creech AFB'] = Creech_AFB()

--- a/dcs/terrain/nevada.py
+++ b/dcs/terrain/nevada.py
@@ -2168,7 +2168,7 @@ class Nevada(Terrain):
     center = {"lat": 39.81806, "long": -114.73333}
     bounds = mapping.Rectangle(-166934.953125, -329334.875000, -497177.656250, 209836.890625)
     map_view_default = MapView(mapping.Point(-340928.57142857, -55928.571428568), 1000000)
-    city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'nevada.p'))
+    city_graph = None
     temperature = [
         (0, 10),
         (2, 16),
@@ -2191,6 +2191,11 @@ class Nevada(Terrain):
         # 11SPE9400410022
         self.bullseye_blue = {"x": -409931.344, "y": -14024.097}
         self.bullseye_red = {"x": -288293.969, "y": -88022.641}
+
+        try:
+            self.city_graph = Graph.from_pickle(os.path.join(os.path.dirname(__file__), 'nevada.p'))  # type: Graph
+        except:
+            pass
 
         self.airports['Creech AFB'] = Creech_AFB()
         self.airports['Groom Lake AFB'] = Groom_Lake_AFB()


### PR DESCRIPTION
The failure on p file loading was causing issues when building a python project with pydcs into an exe file. This PR solves it.

Considering that the city_graph objects are not widely used in pydcs, I think it would be preferrable to fail only when the p files are actually needed. That way you can use pydcs as a library without the p files, as long as you don't use the destroy_oil_transport.py code.