### PR TITLE
Don't validate cloud base - only warn

### DIFF
--- a/dcs/weather.py
+++ b/dcs/weather.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 import random
 import math
 from enum import Enum
@@ -50,7 +51,7 @@ class CloudPreset:
 
     def validate_base(self, base: int) -> None:
         if not self.min_base <= base <= self.max_base:
-            raise ValueError(
+            logging.warn(
                 f"Cloud base {base}m is out of range for {self.name}. Must be between "
                 f"{self.min_base}m and {self.max_base}m.")
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -6,18 +6,6 @@ from dcs.cloud_presets import Clouds
 
 
 class CloudPresetTests(unittest.TestCase):
-    def test_validate_base(self) -> None:
-        preset = CloudPreset("test preset", "", "", 2, 3)
-
-        with self.assertRaises(ValueError):
-            preset.validate_base(1)
-
-        preset.validate_base(2)
-        preset.validate_base(3)
-
-        with self.assertRaises(ValueError):
-            preset.validate_base(4)
-
     def test_by_name(self) -> None:
         with self.assertRaises(KeyError):
             CloudPreset.by_name("does not exist")
@@ -51,10 +39,6 @@ class WeatherTests(unittest.TestCase):
         self.assertEqual(clouds["thickness"], 200)
         self.assertEqual(clouds["density"], 0)
         self.assertEqual(clouds["iprecptns"], 0)
-
-        weather.clouds_base = 0
-        with self.assertRaises(ValueError):
-            weather.dict()
 
         weather_dict["clouds"]["preset"] = "Preset2"
         weather.load_from_dict(weather_dict)


### PR DESCRIPTION
When editing (opening, modifying and saving) an existing mission using pydcs, it doesn't really make sense to validate the mission. Doing so will cause problems with editing existing missions that for some reason deviate from pydcs's idea of what is valid.

For example, a mission produced directly with the Mission Editor had a cloud base of 800. Because of this it was not possible to re-save the mission with pydcs. The Mission Editor appears to be more liberal than pydcs.

If we want to raise validation errors, that should probably be done when _setting_ the property during the editing phase - not in the `save` phase.
![unknown](https://user-images.githubusercontent.com/548345/129921286-97f4bca4-bb7b-40c0-b0cf-a123088c4bf9.png)
