### PR TITLE
Preserve index array for integer based key dictionaries

### DIFF
--- a/dcs/lua/serialize.py
+++ b/dcs/lua/serialize.py
@@ -5,7 +5,9 @@ def dumps(value, varname=None, indent=None):
 
     if isinstance(value, dict):
         e = []
-        for key in sorted(value.keys(), key=str):
+        areAllKeysInts = all(isinstance(k, int) for k in value.keys())
+        dictionaryKeys = value.keys() if areAllKeysInts else sorted(value.keys(), key=str)
+        for key in dictionaryKeys:
             child = value[key]
             KNL = "\n" if indent and isinstance(child, (dict, list)) else ""
             selem = '\t' * indentcount

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,25 @@
+import unittest
+from dcs.lua.serialize import dumps
+
+class TestLuaSerialize(unittest.TestCase):
+
+    def test_all_keys_are_ints_should_arrange_in_numeric_sequence(self):
+        original = {9: 9, 10: 10 }
+        
+        dumped = dumps(original, 'v')
+
+        self.assertEqual('v={[9]=9,[10]=10}', dumped)
+
+    def test_all_keys_are_string_should_arrange_in_alphabetical_order(self):
+        original = {"z": 1, "a": 2, "b": 3, "y": 4}
+
+        dumped = dumps(original, 'v')
+
+        self.assertEqual('v={["a"]=2,["b"]=3,["y"]=4,["z"]=1}', dumped)
+
+    def test_some_key_is_string_should_arrange_in_alphabetical_order(self):
+        original = {3: 2, 10:3, "x": 4, 1: 1}
+
+        dumped = dumps(original, 'v')
+
+        self.assertEqual('v={[1]=1,[10]=3,[3]=2,["x"]=4}', dumped)


### PR DESCRIPTION
Initial scenario: use PyDCS to open a Mission file, perform small manipulation and then re-save the file.

If the contents of the `mission` file is placed under source code control (unzip and placed under git), various elements would be rearranged and generate noise on diffs.

# Demonstrated Problem A
Consider the following original order:
```
{
    [1] = a,
    [2] = b,
    ...
    [9] = c,
    [10] = d
}
```
When `pydcs` performs the `mission.save()` method call, the order in the `mission` file would be:
```
{
    [1] = a,
    [10] = d,  # <---- notice this
    [2] = b,
    ...
    [9] = c
}
```
The problem becomes harder if there is something added at index before `10` would generate a bunch of noise. In the reshuffle (consider `c`).
```
{
    [1] = a,
    [10] = c, # I'm "new green" even though just changed position
    [11] = d,
    [2] = b,
    ...
    [9] = I_WAS_JUST_INSERTED,
}
```

# Demonstrated Problem B
Most tables in the serialize/deserialize cycle of PyDCS keeps a consistent ordering based on name or absolute index order during the `loads` function and/or `load_from_dict`

But there are some API's which do not apply this consistently. An example is `mission.trigger.actions` where the action is type of `SoundToCoalition`. 

If there are more than 30 sounds in the mission, it will reshuffle the entire array upon every cycle of `mission.load_file` and `mission.save` method.

The workaround for the above was to implement the following calls. Not ideal.
```python
    for trigger in mission.triggerrules.triggers:
        trigger.actions.sort(key=lambda action: action.file if isinstance(action, SoundToCoalition) else "")
```

# Motivation for Suggested Implementation
Getting our `mission` and other supporting files (e.g. `warehouse`, `mapResources`) under source code control would help a lot on reducing unnecessary noise and other logical errors which `pydcs` may introduce by accident with rich missions.

The updated implementation preserves the original intention of sorting string based keys whilst embracing the numeric ordering of some of the dictionary lookups to be predictable.

In the problem A, the solution proposed would effectively mean that the diff would be.
```
    {
        [1] = a,
        [2] = b,
        ...
        [9] = {
+           I_WAS_JUST_INSERTED
        },
+        [10] = { ## THANK YOU for BRACING onto NEW LINES
            c
        },
+        [11] = {
            d
        }
    }
```