### PR TITLE
Use manual heading for ground spawned aircraft

### DIFF
--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -181,6 +181,9 @@ class Group(Generic[UnitT, PointT]):
         for u in self.units:
             u.skill = skill
 
+    def is_ground_spawned(self) -> bool:
+        return False
+
     def dict(self):
         if not isinstance(self.name, str):
             raise TypeError("Point name expected to be `str`")
@@ -203,7 +206,7 @@ class Group(Generic[UnitT, PointT]):
                 d["units"][i] = unit.dict()
                 dunit = d["units"][i]
                 if len(self.points) > 1:
-                    use_manual_heading = getattr(self, "manualHeading", False)
+                    use_manual_heading = getattr(self, "manualHeading", False) or self.is_ground_spawned()
                     if not use_manual_heading:
                         hdg = self.points[0].position.heading_between_point(self.points[1].position)
                     else:
@@ -348,6 +351,12 @@ class FlyingGroup(Generic[FlyingUnitT], MovingGroup[FlyingUnitT]):
         if t is None:
             raise KeyError(f"Could not find PlaneType or HelicopterType matching {type_id}")
         return t
+
+    def is_ground_spawned(self) -> bool:
+        if len(self.points) > 0:
+            if self.points[0].type in ["TakeOffGround", "TakeOffGroundHot"]:
+                return True
+        return False
 
     def load_from_dict(self, d):
         super(FlyingGroup, self).load_from_dict(d)


### PR DESCRIPTION
Ground-spawned aircraft can have their heading set, and if pydcs doesn't respect that it will rewrite the heading to point towards the first waypoint, when editing a mission file.

I'm not sure if this is the most elegant way to do this. I don't fully understand the code. These spawn types are not defined in any constants in the code.

Before open/save:

![heading_before](https://user-images.githubusercontent.com/548345/133927893-e9b0fd01-1ec3-4ed2-8088-076810003b33.png)

After saving with pydcs (first aircraft has been manually corrected):

![heading](https://user-images.githubusercontent.com/548345/133927902-991e1f80-1a23-4fed-bf20-bdd625b35bd7.png)
