### PR TITLE
Add support for oblong drawing

### DIFF
--- a/dcs/drawing/layer.py
+++ b/dcs/drawing/layer.py
@@ -437,3 +437,44 @@ class Layer:
         )
         self.add_drawing(drawing)
         return drawing
+
+    def add_oblong(
+        self,
+        p1: Point,
+        p2: Point,
+        radius: float,
+        color=Rgba(255, 0, 0, 255),
+        fill=Rgba(255, 0, 0, 60),
+        line_thickness=4,
+        line_style=LineStyle.Solid,
+        resolution=20,
+    ) -> FreeFormPolygon:
+        hdg_p1_p2 = p1.heading_between_point(p2)
+        points: List[Point] = []
+
+        for i in range(0, resolution + 1):
+            hdg = hdg_p1_p2 - 90 + i * (180 / resolution)
+            points.append(p2.point_from_heading(hdg, radius))
+
+        for i in range(0, resolution + 1):
+            hdg = hdg_p1_p2 + 90 + i * (180 / resolution)
+            points.append(p1.point_from_heading(hdg, radius))
+
+        # Copy first point and insert last to close the polygon
+        points.append(points[0] * 1)
+
+        # Transform points to local coordinates
+        startPoint = points[0] * 1  # Copy
+        for point in points:
+            point.x -= startPoint.x
+            point.y -= startPoint.y
+
+        polygon = self.add_freeform_polygon(
+            startPoint,
+            points,
+            color=color,
+            fill=fill,
+            line_thickness=line_thickness,
+            line_style=line_style,
+        )
+        return polygon

--- a/tests/test_drawings.py
+++ b/tests/test_drawings.py
@@ -116,3 +116,14 @@ class DrawingTests(unittest.TestCase):
         red_layer = m.drawings.get_layer(StandardLayer.Red)
         
         self.assertEqual(StandardIcon.MechanizedArtillery.value, red_layer.objects[0].file)
+
+    def test_add_oblong(self) -> None:
+        m: Mission = dcs.mission.Mission()
+
+        layer = m.drawings.get_layer(StandardLayer.Common)
+        self.assertEqual(0, len(layer.objects))
+        oblong = layer.add_oblong(Point(1000, 1000), Point(4000, 1000), 1000, resolution=20)
+        self.assertEqual(1, len(layer.objects))
+        # Resolution 20 should give 43 points
+        # (21 in each end and one extra to close polygon)
+        self.assertEqual(43, len(oblong.points))


### PR DESCRIPTION
Used to draw things like these:
![racetracks](https://user-images.githubusercontent.com/548345/140719629-b0560310-3bd2-45b9-8acf-91216c4819e7.png)

This is technically a helper function. But it's a common primitive in air tasking maps. And I suspect DCS will add it to the standard primitives sometime in the future, upon which we can change this code to use that instead. So I believe it belongs in the layer class.