### PR TITLE
Data export for DCS 2.7.9.17830.

### DIFF
--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -224,6 +224,7 @@ class Russia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -291,6 +292,7 @@ class Russia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -664,6 +666,7 @@ class Ukraine(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -723,6 +726,7 @@ class Ukraine(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -991,6 +995,7 @@ class USA(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -1057,6 +1062,7 @@ class USA(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -1360,6 +1366,7 @@ class Turkey(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -1407,6 +1414,7 @@ class Turkey(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -1696,6 +1704,7 @@ class UK(Country):
         Yak_52 = planes.Yak_52
         B_17G = planes.B_17G
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -1741,6 +1750,7 @@ class UK(Country):
         Plane.Yak_52,
         Plane.B_17G,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -2021,6 +2031,7 @@ class France(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -2066,6 +2077,7 @@ class France(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -2420,6 +2432,7 @@ class Germany(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -2468,6 +2481,7 @@ class Germany(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -2957,6 +2971,7 @@ class USAFAggressors(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         A_50 = planes.A_50
         An_26B = planes.An_26B
         An_30M = planes.An_30M
@@ -3057,6 +3072,7 @@ class USAFAggressors(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.A_50,
         Plane.An_26B,
         Plane.An_30M,
@@ -3450,6 +3466,7 @@ class Canada(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -3492,6 +3509,7 @@ class Canada(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -3765,6 +3783,7 @@ class Spain(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -3809,6 +3828,7 @@ class Spain(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -4109,6 +4129,7 @@ class TheNetherlands(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -4154,6 +4175,7 @@ class TheNetherlands(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -4433,6 +4455,7 @@ class Belgium(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -4476,6 +4499,7 @@ class Belgium(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -4738,6 +4762,7 @@ class Norway(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -4781,6 +4806,7 @@ class Norway(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -5038,6 +5064,7 @@ class Denmark(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -5081,6 +5108,7 @@ class Denmark(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -5358,6 +5386,7 @@ class Israel(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -5405,6 +5434,7 @@ class Israel(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -5726,6 +5756,7 @@ class Georgia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         TF_51D = planes.TF_51D
 
     planes = [
@@ -5769,6 +5800,7 @@ class Georgia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.TF_51D,
     ]
 
@@ -6049,6 +6081,7 @@ class Insurgents(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.P_51D,
@@ -6085,6 +6118,7 @@ class Insurgents(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -6293,6 +6327,7 @@ class Abkhazia(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.Su_25,
@@ -6334,6 +6369,7 @@ class Abkhazia(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -6533,6 +6569,7 @@ class SouthOssetia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.FW_190A8,
@@ -6568,6 +6605,7 @@ class SouthOssetia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -6743,6 +6781,7 @@ class Italy(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -6790,6 +6829,7 @@ class Italy(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -7062,6 +7102,7 @@ class Australia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -7106,6 +7147,7 @@ class Australia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -7358,6 +7400,7 @@ class Switzerland(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -7397,6 +7440,7 @@ class Switzerland(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -7625,6 +7669,7 @@ class Austria(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -7661,6 +7706,7 @@ class Austria(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -7991,6 +8037,7 @@ class Belarus(Country):
         MiG_19P = planes.MiG_19P
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -8038,6 +8085,7 @@ class Belarus(Country):
         Plane.MiG_19P,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -8277,6 +8325,7 @@ class Bulgaria(Country):
         L_39C = planes.L_39C
         M_2000C = planes.M_2000C
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -8321,6 +8370,7 @@ class Bulgaria(Country):
         Plane.L_39C,
         Plane.M_2000C,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -8603,6 +8653,7 @@ class CzechRepublic(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -8644,6 +8695,7 @@ class CzechRepublic(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -8918,6 +8970,7 @@ class China(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -8966,6 +9019,7 @@ class China(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -9126,6 +9180,7 @@ class Croatia(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -9162,6 +9217,7 @@ class Croatia(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -9463,6 +9519,7 @@ class Egypt(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -9503,6 +9560,7 @@ class Egypt(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -9814,6 +9872,7 @@ class Finland(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -9850,6 +9909,7 @@ class Finland(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -10133,6 +10193,7 @@ class Greece(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -10176,6 +10237,7 @@ class Greece(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -10492,6 +10554,7 @@ class Hungary(Country):
         M_2000C = planes.M_2000C
         MiG_19P = planes.MiG_19P
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -10532,6 +10595,7 @@ class Hungary(Country):
         Plane.M_2000C,
         Plane.MiG_19P,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -10807,6 +10871,7 @@ class India(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -10851,6 +10916,7 @@ class India(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -11157,6 +11223,7 @@ class Iran(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -11203,6 +11270,7 @@ class Iran(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -11503,6 +11571,7 @@ class Iraq(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -11546,6 +11615,7 @@ class Iraq(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -11829,6 +11899,7 @@ class Japan(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -11867,6 +11938,7 @@ class Japan(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -12212,6 +12284,7 @@ class Kazakhstan(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -12260,6 +12333,7 @@ class Kazakhstan(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -12520,6 +12594,7 @@ class NorthKorea(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -12558,6 +12633,7 @@ class NorthKorea(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -12815,6 +12891,7 @@ class Pakistan(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -12858,6 +12935,7 @@ class Pakistan(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -13160,6 +13238,7 @@ class Poland(Country):
         M_2000C = planes.M_2000C
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -13207,6 +13286,7 @@ class Poland(Country):
         Plane.M_2000C,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -13512,6 +13592,7 @@ class Romania(Country):
         M_2000C = planes.M_2000C
         MiG_21Bis = planes.MiG_21Bis
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -13553,6 +13634,7 @@ class Romania(Country):
         Plane.M_2000C,
         Plane.MiG_21Bis,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -13822,6 +13904,7 @@ class SaudiArabia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -13864,6 +13947,7 @@ class SaudiArabia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -14157,6 +14241,7 @@ class Serbia(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -14197,6 +14282,7 @@ class Serbia(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -14464,6 +14550,7 @@ class Slovakia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -14504,6 +14591,7 @@ class Slovakia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -14762,6 +14850,7 @@ class SouthKorea(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -14805,6 +14894,7 @@ class SouthKorea(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -15047,6 +15137,7 @@ class Sweden(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -15087,6 +15178,7 @@ class Sweden(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -15365,6 +15457,7 @@ class Syria(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -15406,6 +15499,7 @@ class Syria(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -15666,6 +15760,7 @@ class Yemen(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -15705,6 +15800,7 @@ class Yemen(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -15981,6 +16077,7 @@ class Vietnam(Country):
         MiG_15bis = planes.MiG_15bis
         MiG_19P = planes.MiG_19P
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -16022,6 +16119,7 @@ class Vietnam(Country):
         Plane.MiG_15bis,
         Plane.MiG_19P,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -16284,6 +16382,7 @@ class Venezuela(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -16322,6 +16421,7 @@ class Venezuela(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -16552,6 +16652,7 @@ class Tunisia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -16588,6 +16689,7 @@ class Tunisia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -16825,6 +16927,7 @@ class Thailand(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -16864,6 +16967,7 @@ class Thailand(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -17118,6 +17222,7 @@ class Sudan(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -17158,6 +17263,7 @@ class Sudan(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -17390,6 +17496,7 @@ class Philippines(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -17429,6 +17536,7 @@ class Philippines(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -17685,6 +17793,7 @@ class Morocco(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -17723,6 +17832,7 @@ class Morocco(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -17956,6 +18066,7 @@ class Mexico(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -17993,6 +18104,7 @@ class Mexico(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -18232,6 +18344,7 @@ class Malaysia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -18269,6 +18382,7 @@ class Malaysia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -18535,6 +18649,7 @@ class Libya(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -18573,6 +18688,7 @@ class Libya(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -18821,6 +18937,7 @@ class Jordan(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -18859,6 +18976,7 @@ class Jordan(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -19138,6 +19256,7 @@ class Indonesia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -19182,6 +19301,7 @@ class Indonesia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -19413,6 +19533,7 @@ class Honduras(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -19449,6 +19570,7 @@ class Honduras(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -19703,6 +19825,7 @@ class Ethiopia(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -19742,6 +19865,7 @@ class Ethiopia(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -19994,6 +20118,7 @@ class Chile(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -20036,6 +20161,7 @@ class Chile(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -20291,6 +20417,7 @@ class Brazil(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -20328,6 +20455,7 @@ class Brazil(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -20578,6 +20706,7 @@ class Bahrain(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -20613,6 +20742,7 @@ class Bahrain(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -20877,6 +21007,7 @@ class ThirdReich(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -20913,6 +21044,7 @@ class ThirdReich(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -21180,6 +21312,7 @@ class Yugoslavia(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -21218,6 +21351,7 @@ class Yugoslavia(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -21507,6 +21641,7 @@ class USSR(Country):
         Hawk = planes.Hawk
         M_2000C = planes.M_2000C
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -21568,6 +21703,7 @@ class USSR(Country):
         Plane.Hawk,
         Plane.M_2000C,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -21767,6 +21903,7 @@ class ItalianSocialRepublic(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -21802,6 +21939,7 @@ class ItalianSocialRepublic(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -22130,6 +22268,7 @@ class Algeria(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -22182,6 +22321,7 @@ class Algeria(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -22455,6 +22595,7 @@ class Kuwait(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -22493,6 +22634,7 @@ class Kuwait(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -22736,6 +22878,7 @@ class Qatar(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -22773,6 +22916,7 @@ class Qatar(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -23034,6 +23178,7 @@ class Oman(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -23072,6 +23217,7 @@ class Oman(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -23336,6 +23482,7 @@ class UnitedArabEmirates(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -23376,6 +23523,7 @@ class UnitedArabEmirates(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -23614,6 +23762,7 @@ class SouthAfrica(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -23653,6 +23802,7 @@ class SouthAfrica(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -23944,6 +24094,7 @@ class Cuba(Country):
         M_2000C = planes.M_2000C
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -23991,6 +24142,7 @@ class Cuba(Country):
         Plane.M_2000C,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -24243,6 +24395,7 @@ class Portugal(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -24284,6 +24437,7 @@ class Portugal(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -24570,6 +24724,7 @@ class GDR(Country):
         MiG_19P = planes.MiG_19P
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -24609,6 +24764,7 @@ class GDR(Country):
         Plane.MiG_19P,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -24864,6 +25020,7 @@ class Lebanon(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -24901,6 +25058,7 @@ class Lebanon(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -25383,6 +25541,7 @@ class CombinedJointTaskForcesBlue(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         A_50 = planes.A_50
         An_26B = planes.An_26B
         An_30M = planes.An_30M
@@ -25483,6 +25642,7 @@ class CombinedJointTaskForcesBlue(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.A_50,
         Plane.An_26B,
         Plane.An_30M,
@@ -26092,6 +26252,7 @@ class CombinedJointTaskForcesRed(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         A_50 = planes.A_50
         An_26B = planes.An_26B
         An_30M = planes.An_30M
@@ -26192,6 +26353,7 @@ class CombinedJointTaskForcesRed(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.A_50,
         Plane.An_26B,
         Plane.An_30M,
@@ -26801,6 +26963,7 @@ class UnitedNationsPeacekeepers(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
         A_50 = planes.A_50
         An_26B = planes.An_26B
         An_30M = planes.An_30M
@@ -26901,6 +27064,7 @@ class UnitedNationsPeacekeepers(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
         Plane.A_50,
         Plane.An_26B,
         Plane.An_30M,
@@ -27264,6 +27428,7 @@ class Argentina(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -27301,6 +27466,7 @@ class Argentina(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -27558,6 +27724,7 @@ class Cyprus(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -27594,6 +27761,7 @@ class Cyprus(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -27840,6 +28008,7 @@ class Slovenia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -27877,6 +28046,7 @@ class Slovenia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -28126,6 +28296,7 @@ class Bolivia(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -28168,6 +28339,7 @@ class Bolivia(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -28396,6 +28568,7 @@ class Ghana(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -28432,6 +28605,7 @@ class Ghana(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -28674,6 +28848,7 @@ class Nigeria(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -28711,6 +28886,7 @@ class Nigeria(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:
@@ -28963,6 +29139,7 @@ class Peru(Country):
         MiG_21Bis = planes.MiG_21Bis
         Yak_52 = planes.Yak_52
         Ju_88A4 = planes.Ju_88A4
+        C_47 = planes.C_47
 
     planes = [
         Plane.A_10C,
@@ -29005,6 +29182,7 @@ class Peru(Country):
         Plane.MiG_21Bis,
         Plane.Yak_52,
         Plane.Ju_88A4,
+        Plane.C_47,
     ]
 
     class Helicopter:

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -681,6 +681,23 @@ class F_A_18C(PlaneType):
         },
     }
 
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Hornet",
+            "Squid",
+            "Ragin",
+            "Roman",
+            "Sting",
+            "Jury",
+            "Joker",
+            "Ram",
+            "Hawk",
+            "Devil",
+            "Check",
+            "Snake",
+        ]
+    }
+
     class Liveries:
 
         class Australia(Enum):
@@ -1186,6 +1203,14 @@ class B_52H(PlaneType):
     chaff_charge_size = 1
     flare_charge_size = 1
     eplrs = True
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Buff",
+            "Dump",
+            "Kenworth",
+        ]
+    }
 
     class Liveries:
 
@@ -4873,6 +4898,14 @@ class B_1B(PlaneType):
     flare_charge_size = 2
     eplrs = True
 
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Bone",
+            "Dark",
+            "Vader",
+        ]
+    }
+
     class Liveries:
 
         class Combined_Joint_Task_Forces_Blue(Enum):
@@ -5524,6 +5557,22 @@ class F_15E(PlaneType):
     flare_charge_size = 2
     eplrs = True
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Dude",
+            "Thud",
+            "Gunny",
+            "Mad",
+            "Trek",
+            "Sniper",
+            "Sled",
+            "Best",
+            "Jazz",
+            "Rage",
+            "Tahoe",
+        ]
+    }
 
     class Liveries:
 
@@ -8193,6 +8242,23 @@ class F_16C_bl_50(PlaneType):
     eplrs = True
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Viper",
+            "Venom",
+            "Lobo",
+            "Cowboy",
+            "Python",
+            "Rattler",
+            "Panther",
+            "Wolf",
+            "Weasel",
+            "Wild",
+            "Ninja",
+            "Jedi",
+        ]
+    }
+
     class Liveries:
 
         class Combined_Joint_Task_Forces_Blue(Enum):
@@ -8414,6 +8480,23 @@ class F_16C_bl_52d(PlaneType):
     flare_charge_size = 2
     eplrs = True
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Viper",
+            "Venom",
+            "Lobo",
+            "Cowboy",
+            "Python",
+            "Rattler",
+            "Panther",
+            "Wolf",
+            "Weasel",
+            "Wild",
+            "Ninja",
+            "Jedi",
+        ]
+    }
 
     class Liveries:
 
@@ -12122,330 +12205,412 @@ class MosquitoFBMkVI(PlaneType):
 
         class USSR(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Georgia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Venezuela(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Australia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Israel(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Combined_Joint_Task_Forces_Blue(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Sudan(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Norway(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Romania(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Iran(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Ukraine(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Libya(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Belgium(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Slovakia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Greece(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class UK(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Third_Reich(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Hungary(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Abkhazia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Morocco(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class United_Nations_Peacekeepers(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Switzerland(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class SouthOssetia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Vietnam(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class China(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Yemen(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Kuwait(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Serbia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Oman(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class India(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Egypt(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class TheNetherlands(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Poland(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Syria(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Finland(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Kazakhstan(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Denmark(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Sweden(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Croatia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class CzechRepublic(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class GDR(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Yugoslavia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Bulgaria(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class SouthKorea(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Tunisia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Combined_Joint_Task_Forces_Red(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Lebanon(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Portugal(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Cuba(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Insurgents(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class SaudiArabia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class France(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class USA(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Honduras(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Qatar(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Russia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class United_Arab_Emirates(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Italian_Social_Republi(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Austria(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Bahrain(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Italy(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Chile(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Turkey(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Philippines(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Algeria(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Pakistan(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Malaysia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Indonesia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Iraq(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Germany(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class South_Africa(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Jordan(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Mexico(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class USAFAggressors(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Brazil(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Spain(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Belarus(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Canada(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class NorthKorea(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Ethiopia(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Japan(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
         class Thailand(Enum):
             L_3_PZ474_1945 = "L-3 PZ474 1945"
+            No__235_Squadron_RAF_1944 = "No. 235 Squadron RAF 1944"
             RAF = "RAF"
 
     class Pylon1:
@@ -12494,7 +12659,23 @@ class MosquitoFBMkVI(PlaneType):
         _500_lb_MC_Short_tail_ = (4, Weapons._500_lb_MC_Short_tail_)
         _250_lb_S_A_P__ = (4, Weapons._250_lb_S_A_P__)
 
-    pylons: Set[int] = {1, 2, 3, 4}
+    class Pylon5:
+        _4_x_RP_3_60lb_F_No1_Mk_I = (5, Weapons._4_x_RP_3_60lb_F_No1_Mk_I)
+        _2_x_RP_3_60lb_F_No1_Mk_I = (5, Weapons._2_x_RP_3_60lb_F_No1_Mk_I)
+        _4_x_RP_3_60lb_SAP_No2_Mk_I = (5, Weapons._4_x_RP_3_60lb_SAP_No2_Mk_I)
+        _2_x_RP_3_60lb_SAP_No2_Mk_I = (5, Weapons._2_x_RP_3_60lb_SAP_No2_Mk_I)
+        _4_x_RP_3_25lb_AP_Mk_I = (5, Weapons._4_x_RP_3_25lb_AP_Mk_I)
+        _2_x_RP_3_25lb_AP_Mk_I = (5, Weapons._2_x_RP_3_25lb_AP_Mk_I)
+
+    class Pylon6:
+        _4_x_RP_3_60lb_F_No1_Mk_I_ = (6, Weapons._4_x_RP_3_60lb_F_No1_Mk_I_)
+        _2_x_RP_3_60lb_F_No1_Mk_I_ = (6, Weapons._2_x_RP_3_60lb_F_No1_Mk_I_)
+        _4_x_RP_3_60lb_SAP_No2_Mk_I_ = (6, Weapons._4_x_RP_3_60lb_SAP_No2_Mk_I_)
+        _2_x_RP_3_60lb_SAP_No2_Mk_I_ = (6, Weapons._2_x_RP_3_60lb_SAP_No2_Mk_I_)
+        _4_x_RP_3_25lb_AP_Mk_I_ = (6, Weapons._4_x_RP_3_25lb_AP_Mk_I_)
+        _2_x_RP_3_25lb_AP_Mk_I_ = (6, Weapons._2_x_RP_3_25lb_AP_Mk_I_)
+
+    pylons: Set[int] = {1, 2, 3, 4, 5, 6}
 
     tasks = [task.CAP, task.Escort, task.Intercept, task.FighterSweep, task.GroundAttack, task.CAS, task.AFAC, task.RunwayAttack, task.AntishipStrike]
     task_default = task.CAP
@@ -14438,13 +14619,53 @@ class AJS37(PlaneType):
     panel_radio = {
         1: {
             "channels": {
-                6: 141,
+                27: 270,
                 2: 264,
+                38: 251,
                 3: 265,
+                4: 256,
+                5: 254,
+                6: 250,
+                7: 270,
+                8: 257,
+                10: 262,
+                12: 268,
+                14: 260,
+                16: 261,
+                20: 266,
+                24: 256,
+                28: 257,
+                32: 268,
+                40: 266,
+                33: 269,
+                41: 305,
+                17: 267,
+                21: 305,
+                25: 254,
+                29: 255,
+                34: 260,
+                42: 264,
+                9: 255,
+                11: 259,
+                13: 269,
+                15: 263,
+                18: 251,
+                22: 264,
+                26: 250,
+                30: 262,
+                36: 261,
+                44: 125,
+                47: 121.5,
+                46: 141,
+                39: 253,
+                43: 265,
+                37: 267,
+                45: 121,
+                35: 263,
                 1: 305,
-                4: 125,
-                5: 121,
-                7: 121.5
+                19: 253,
+                23: 265,
+                31: 259
             },
         },
     }
@@ -14499,6 +14720,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Georgia(Enum):
@@ -14506,6 +14728,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Venezuela(Enum):
@@ -14513,6 +14736,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Australia(Enum):
@@ -14520,6 +14744,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Israel(Enum):
@@ -14527,6 +14752,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Combined_Joint_Task_Forces_Blue(Enum):
@@ -14534,6 +14760,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Sudan(Enum):
@@ -14541,6 +14768,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Norway(Enum):
@@ -14548,6 +14776,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Romania(Enum):
@@ -14555,6 +14784,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Iran(Enum):
@@ -14562,6 +14792,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Ukraine(Enum):
@@ -14569,6 +14800,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Libya(Enum):
@@ -14576,6 +14808,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Belgium(Enum):
@@ -14583,6 +14816,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Slovakia(Enum):
@@ -14590,6 +14824,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Greece(Enum):
@@ -14597,6 +14832,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class UK(Enum):
@@ -14604,6 +14840,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Third_Reich(Enum):
@@ -14611,6 +14848,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Hungary(Enum):
@@ -14618,6 +14856,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Abkhazia(Enum):
@@ -14625,6 +14864,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Morocco(Enum):
@@ -14632,6 +14872,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class United_Nations_Peacekeepers(Enum):
@@ -14639,6 +14880,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Switzerland(Enum):
@@ -14646,6 +14888,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class SouthOssetia(Enum):
@@ -14653,6 +14896,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Vietnam(Enum):
@@ -14660,6 +14904,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class China(Enum):
@@ -14667,6 +14912,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Yemen(Enum):
@@ -14674,6 +14920,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Kuwait(Enum):
@@ -14681,6 +14928,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Serbia(Enum):
@@ -14688,6 +14936,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Oman(Enum):
@@ -14695,6 +14944,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class India(Enum):
@@ -14702,6 +14952,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Egypt(Enum):
@@ -14709,6 +14960,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class TheNetherlands(Enum):
@@ -14716,6 +14968,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Poland(Enum):
@@ -14723,6 +14976,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Syria(Enum):
@@ -14730,6 +14984,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Finland(Enum):
@@ -14737,6 +14992,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Kazakhstan(Enum):
@@ -14744,6 +15000,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Denmark(Enum):
@@ -14751,6 +15008,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Sweden(Enum):
@@ -14758,6 +15016,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Croatia(Enum):
@@ -14765,6 +15024,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class CzechRepublic(Enum):
@@ -14772,6 +15032,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class GDR(Enum):
@@ -14779,6 +15040,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Yugoslavia(Enum):
@@ -14786,6 +15048,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Bulgaria(Enum):
@@ -14793,6 +15056,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class SouthKorea(Enum):
@@ -14800,6 +15064,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Tunisia(Enum):
@@ -14807,6 +15072,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Combined_Joint_Task_Forces_Red(Enum):
@@ -14814,6 +15080,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Lebanon(Enum):
@@ -14821,6 +15088,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Portugal(Enum):
@@ -14828,6 +15096,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Cuba(Enum):
@@ -14835,6 +15104,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Insurgents(Enum):
@@ -14842,6 +15112,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class SaudiArabia(Enum):
@@ -14849,6 +15120,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class France(Enum):
@@ -14856,6 +15128,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class USA(Enum):
@@ -14863,6 +15136,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Honduras(Enum):
@@ -14870,6 +15144,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Qatar(Enum):
@@ -14877,6 +15152,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Russia(Enum):
@@ -14884,6 +15160,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class United_Arab_Emirates(Enum):
@@ -14891,6 +15168,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Italian_Social_Republi(Enum):
@@ -14898,6 +15176,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Austria(Enum):
@@ -14905,6 +15184,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Bahrain(Enum):
@@ -14912,6 +15192,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Italy(Enum):
@@ -14919,6 +15200,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Chile(Enum):
@@ -14926,6 +15208,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Turkey(Enum):
@@ -14933,6 +15216,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Philippines(Enum):
@@ -14940,6 +15224,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Algeria(Enum):
@@ -14947,6 +15232,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Pakistan(Enum):
@@ -14954,6 +15240,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Malaysia(Enum):
@@ -14961,6 +15248,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Indonesia(Enum):
@@ -14968,6 +15256,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Iraq(Enum):
@@ -14975,6 +15264,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Germany(Enum):
@@ -14982,6 +15272,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class South_Africa(Enum):
@@ -14989,6 +15280,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Jordan(Enum):
@@ -14996,6 +15288,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Mexico(Enum):
@@ -15003,6 +15296,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class USAFAggressors(Enum):
@@ -15010,6 +15304,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Brazil(Enum):
@@ -15017,6 +15312,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Spain(Enum):
@@ -15024,6 +15320,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Belarus(Enum):
@@ -15031,6 +15328,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Canada(Enum):
@@ -15038,6 +15336,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class NorthKorea(Enum):
@@ -15045,6 +15344,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Ethiopia(Enum):
@@ -15052,6 +15352,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Japan(Enum):
@@ -15059,6 +15360,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
         class Thailand(Enum):
@@ -15066,6 +15368,7 @@ class AJS37(PlaneType):
             BareMetal = "BareMetal"
             _37402 = "37402"
             F7_Skaraborg = "F7 Skaraborg"
+            SE_DXN_v3 = "SE-DXN_v3"
             SF_37_Akktu_Stakki___F21 = "SF-37 Akktu Stakki - F21"
 
     class Pylon1:
@@ -18917,6 +19220,8 @@ class JF_17(PlaneType):
         DIS_GB6_HE = (3, Weapons.DIS_GB6_HE)
         DIS_TANK800 = (3, Weapons.DIS_TANK800)
         DIS_TANK1100 = (3, Weapons.DIS_TANK1100)
+        DIS_TANK800_EMPTY = (3, Weapons.DIS_TANK800_EMPTY)
+        DIS_TANK1100_EMPTY = (3, Weapons.DIS_TANK1100_EMPTY)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_83___1000lb_GP_Bomb_LD = (3, Weapons.Mk_83___1000lb_GP_Bomb_LD)
@@ -18929,6 +19234,7 @@ class JF_17(PlaneType):
 
     class Pylon4:
         DIS_TANK800 = (4, Weapons.DIS_TANK800)
+        DIS_TANK800_EMPTY = (4, Weapons.DIS_TANK800_EMPTY)
         Mk_83___1000lb_GP_Bomb_LD = (4, Weapons.Mk_83___1000lb_GP_Bomb_LD)
         Mk_84___2000lb_GP_Bomb_LD = (4, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         DIS_GBU_10 = (4, Weapons.DIS_GBU_10)
@@ -18952,6 +19258,8 @@ class JF_17(PlaneType):
         DIS_GB6_HE = (5, Weapons.DIS_GB6_HE)
         DIS_TANK800 = (5, Weapons.DIS_TANK800)
         DIS_TANK1100 = (5, Weapons.DIS_TANK1100)
+        DIS_TANK800_EMPTY = (5, Weapons.DIS_TANK800_EMPTY)
+        DIS_TANK1100_EMPTY = (5, Weapons.DIS_TANK1100_EMPTY)
         Mk_82_Snakeye___500lb_GP_Bomb_HD = (5, Weapons.Mk_82_Snakeye___500lb_GP_Bomb_HD)
         Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
         Mk_83___1000lb_GP_Bomb_LD = (5, Weapons.Mk_83___1000lb_GP_Bomb_LD)
@@ -21703,6 +22011,23 @@ class F_16C_50(PlaneType):
         },
     }
 
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Viper",
+            "Venom",
+            "Lobo",
+            "Cowboy",
+            "Python",
+            "Rattler",
+            "Panther",
+            "Wolf",
+            "Weasel",
+            "Wild",
+            "Ninja",
+            "Jedi",
+        ]
+    }
+
     property_defaults: Dict[str, Any] = {
         "LAU3ROF": 0,
         "LaserCode100": 6,
@@ -22208,6 +22533,7 @@ class F_16C_50(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD)
         MXU_648_TP = (3, Weapons.MXU_648_TP)
+        ALQ_184 = (3, Weapons.ALQ_184)
 #ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD)
         TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = (3, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD)
@@ -22251,6 +22577,7 @@ class F_16C_50(PlaneType):
     class Pylon5:
         Fuel_tank_300_gal = (5, Weapons.Fuel_tank_300_gal)
         MXU_648_TP = (5, Weapons.MXU_648_TP)
+        ALQ_184 = (5, Weapons.ALQ_184)
 #ERRR <CLEAN>
 
     class Pylon6:
@@ -22328,6 +22655,7 @@ class F_16C_50(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.BRU_57_with_2_x_CBU_103___202_x_CEM__CBU_with_WCMD)
         MXU_648_TP = (7, Weapons.MXU_648_TP)
+        ALQ_184 = (7, Weapons.ALQ_184)
 #ERRR <CLEAN>
         TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (7, Weapons.TER_9A_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
         TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_ = (7, Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD_)
@@ -26532,6 +26860,10 @@ class F_14A_135_GR(PlaneType):
         class USSR(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26546,6 +26878,10 @@ class F_14A_135_GR(PlaneType):
         class Georgia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26560,6 +26896,10 @@ class F_14A_135_GR(PlaneType):
         class Venezuela(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26574,6 +26914,10 @@ class F_14A_135_GR(PlaneType):
         class Australia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26588,6 +26932,10 @@ class F_14A_135_GR(PlaneType):
         class Israel(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26602,6 +26950,10 @@ class F_14A_135_GR(PlaneType):
         class Combined_Joint_Task_Forces_Blue(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26617,6 +26969,10 @@ class F_14A_135_GR(PlaneType):
         class Sudan(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26631,6 +26987,10 @@ class F_14A_135_GR(PlaneType):
         class Norway(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26645,6 +27005,10 @@ class F_14A_135_GR(PlaneType):
         class Romania(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26659,6 +27023,10 @@ class F_14A_135_GR(PlaneType):
         class Iran(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26673,6 +27041,10 @@ class F_14A_135_GR(PlaneType):
         class Ukraine(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26687,6 +27059,10 @@ class F_14A_135_GR(PlaneType):
         class Libya(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26701,6 +27077,10 @@ class F_14A_135_GR(PlaneType):
         class Belgium(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26715,6 +27095,10 @@ class F_14A_135_GR(PlaneType):
         class Slovakia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26729,6 +27113,10 @@ class F_14A_135_GR(PlaneType):
         class Greece(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26743,6 +27131,10 @@ class F_14A_135_GR(PlaneType):
         class UK(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26757,6 +27149,10 @@ class F_14A_135_GR(PlaneType):
         class Third_Reich(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26771,6 +27167,10 @@ class F_14A_135_GR(PlaneType):
         class Hungary(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26785,6 +27185,10 @@ class F_14A_135_GR(PlaneType):
         class Abkhazia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26799,6 +27203,10 @@ class F_14A_135_GR(PlaneType):
         class Morocco(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26813,6 +27221,10 @@ class F_14A_135_GR(PlaneType):
         class United_Nations_Peacekeepers(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26827,6 +27239,10 @@ class F_14A_135_GR(PlaneType):
         class Switzerland(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26841,6 +27257,10 @@ class F_14A_135_GR(PlaneType):
         class SouthOssetia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26855,6 +27275,10 @@ class F_14A_135_GR(PlaneType):
         class Vietnam(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26869,6 +27293,10 @@ class F_14A_135_GR(PlaneType):
         class China(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26883,6 +27311,10 @@ class F_14A_135_GR(PlaneType):
         class Yemen(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26897,6 +27329,10 @@ class F_14A_135_GR(PlaneType):
         class Kuwait(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26911,6 +27347,10 @@ class F_14A_135_GR(PlaneType):
         class Serbia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26925,6 +27365,10 @@ class F_14A_135_GR(PlaneType):
         class Oman(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26939,6 +27383,10 @@ class F_14A_135_GR(PlaneType):
         class India(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26953,6 +27401,10 @@ class F_14A_135_GR(PlaneType):
         class Egypt(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26967,6 +27419,10 @@ class F_14A_135_GR(PlaneType):
         class TheNetherlands(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26981,6 +27437,10 @@ class F_14A_135_GR(PlaneType):
         class Poland(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -26995,6 +27455,10 @@ class F_14A_135_GR(PlaneType):
         class Syria(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27009,6 +27473,10 @@ class F_14A_135_GR(PlaneType):
         class Finland(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27023,6 +27491,10 @@ class F_14A_135_GR(PlaneType):
         class Kazakhstan(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27037,6 +27509,10 @@ class F_14A_135_GR(PlaneType):
         class Denmark(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27051,6 +27527,10 @@ class F_14A_135_GR(PlaneType):
         class Sweden(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27065,6 +27545,10 @@ class F_14A_135_GR(PlaneType):
         class Croatia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27079,6 +27563,10 @@ class F_14A_135_GR(PlaneType):
         class CzechRepublic(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27093,6 +27581,10 @@ class F_14A_135_GR(PlaneType):
         class GDR(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27107,6 +27599,10 @@ class F_14A_135_GR(PlaneType):
         class Yugoslavia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27121,6 +27617,10 @@ class F_14A_135_GR(PlaneType):
         class Bulgaria(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27135,6 +27635,10 @@ class F_14A_135_GR(PlaneType):
         class SouthKorea(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27149,6 +27653,10 @@ class F_14A_135_GR(PlaneType):
         class Tunisia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27163,6 +27671,10 @@ class F_14A_135_GR(PlaneType):
         class Combined_Joint_Task_Forces_Red(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27178,6 +27690,10 @@ class F_14A_135_GR(PlaneType):
         class Lebanon(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27192,6 +27708,10 @@ class F_14A_135_GR(PlaneType):
         class Portugal(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27206,6 +27726,10 @@ class F_14A_135_GR(PlaneType):
         class Cuba(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27220,6 +27744,10 @@ class F_14A_135_GR(PlaneType):
         class Insurgents(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27234,6 +27762,10 @@ class F_14A_135_GR(PlaneType):
         class SaudiArabia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27248,6 +27780,10 @@ class F_14A_135_GR(PlaneType):
         class France(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27262,6 +27798,10 @@ class F_14A_135_GR(PlaneType):
         class USA(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27277,6 +27817,10 @@ class F_14A_135_GR(PlaneType):
         class Honduras(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27291,6 +27835,10 @@ class F_14A_135_GR(PlaneType):
         class Qatar(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27305,6 +27853,10 @@ class F_14A_135_GR(PlaneType):
         class Russia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27319,6 +27871,10 @@ class F_14A_135_GR(PlaneType):
         class United_Arab_Emirates(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27333,6 +27889,10 @@ class F_14A_135_GR(PlaneType):
         class Italian_Social_Republi(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27347,6 +27907,10 @@ class F_14A_135_GR(PlaneType):
         class Austria(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27361,6 +27925,10 @@ class F_14A_135_GR(PlaneType):
         class Bahrain(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27375,6 +27943,10 @@ class F_14A_135_GR(PlaneType):
         class Italy(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27389,6 +27961,10 @@ class F_14A_135_GR(PlaneType):
         class Chile(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27403,6 +27979,10 @@ class F_14A_135_GR(PlaneType):
         class Turkey(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27417,6 +27997,10 @@ class F_14A_135_GR(PlaneType):
         class Philippines(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27431,6 +28015,10 @@ class F_14A_135_GR(PlaneType):
         class Algeria(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27445,6 +28033,10 @@ class F_14A_135_GR(PlaneType):
         class Pakistan(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27459,6 +28051,10 @@ class F_14A_135_GR(PlaneType):
         class Malaysia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27473,6 +28069,10 @@ class F_14A_135_GR(PlaneType):
         class Indonesia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27487,6 +28087,10 @@ class F_14A_135_GR(PlaneType):
         class Iraq(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27501,6 +28105,10 @@ class F_14A_135_GR(PlaneType):
         class Germany(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27515,6 +28123,10 @@ class F_14A_135_GR(PlaneType):
         class South_Africa(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27529,6 +28141,10 @@ class F_14A_135_GR(PlaneType):
         class Jordan(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27543,6 +28159,10 @@ class F_14A_135_GR(PlaneType):
         class Mexico(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27557,6 +28177,10 @@ class F_14A_135_GR(PlaneType):
         class USAFAggressors(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27571,6 +28195,10 @@ class F_14A_135_GR(PlaneType):
         class Brazil(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27585,6 +28213,10 @@ class F_14A_135_GR(PlaneType):
         class Spain(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27599,6 +28231,10 @@ class F_14A_135_GR(PlaneType):
         class Belarus(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27613,6 +28249,10 @@ class F_14A_135_GR(PlaneType):
         class Canada(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27627,6 +28267,10 @@ class F_14A_135_GR(PlaneType):
         class NorthKorea(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27641,6 +28285,10 @@ class F_14A_135_GR(PlaneType):
         class Ethiopia(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27655,6 +28303,10 @@ class F_14A_135_GR(PlaneType):
         class Japan(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27669,6 +28321,10 @@ class F_14A_135_GR(PlaneType):
         class Thailand(Enum):
             VF_154_Black_Knights_101 = "VF-154 Black Knights 101"
             VF_32_Swordsmen_AB200__1976 = "VF-32 Swordsmen AB200 (1976)"
+            VF_1_Wolfpack_NK100__1974 = "VF-1 Wolfpack NK100 (1974)"
+            VF_1_Wolfpack_NK101__1974 = "VF-1 Wolfpack NK101 (1974)"
+            VF_1_Wolfpack_NK102__1974 = "VF-1 Wolfpack NK102 (1974)"
+            VF_1_Wolfpack_NK103__1974 = "VF-1 Wolfpack NK103 (1974)"
             VF_11_AE101_1988 = "VF-11 AE101 1988"
             VF_11_AE103_1988 = "VF-11 AE103 1988"
             VF_11_AE106_1988 = "VF-11 AE106 1988"
@@ -27953,6 +28609,23 @@ class FA_18C_hornet(PlaneType):
                 15: 263
             },
         },
+    }
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Hornet",
+            "Squid",
+            "Ragin",
+            "Roman",
+            "Sting",
+            "Jury",
+            "Joker",
+            "Ram",
+            "Hawk",
+            "Devil",
+            "Check",
+            "Snake",
+        ]
     }
 
     property_defaults: Dict[str, Any] = {
@@ -31164,6 +31837,7 @@ class M_2000C(PlaneType):
         "LoadNVGCase": False,
         "InitHotDrift": 0,
         "EnableTAF": True,
+        "DisableVTBExport": False,
     }
 
     class Properties:
@@ -31213,6 +31887,9 @@ class M_2000C(PlaneType):
 
         class EnableTAF:
             id = "EnableTAF"
+
+        class DisableVTBExport:
+            id = "DisableVTBExport"
 
     class Liveries:
 
@@ -39645,6 +40322,28 @@ class Ju_88A4(PlaneType):
     task_default = task.GroundAttack
 
 
+class C_47(PlaneType):
+    id = "C-47"
+    height = 5.16
+    width = 29.11
+    length = 19.43
+    fuel_max = 1470
+    max_speed = 369
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+        ]
+    }
+
+    property_defaults: Dict[str, Any] = {
+    }
+
+    pylons: Set[int] = set()
+
+    tasks = [task.Transport, task.Escort, task.AFAC]
+    task_default = task.Transport
+
+
 class TF_51D(PlaneType):
     id = "TF-51D"
     flyable = True
@@ -40042,5 +40741,6 @@ plane_map = {
     "Yak-52": Yak_52,
     "B-17G": B_17G,
     "Ju-88A4": Ju_88A4,
+    "C-47": C_47,
     "TF-51D": TF_51D,
 }

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -284,7 +284,9 @@ class Weapons:
     DIS_SMOKE_GENERATOR_Y = {"clsid": "DIS_SMOKE_GENERATOR_Y", "name": "Smoke Generator - yellow", "weight": 0}
     DIS_SPJ_POD = {"clsid": "DIS_SPJ_POD", "name": "KG-600", "weight": 270}
     DIS_TANK1100 = {"clsid": "DIS_TANK1100", "name": "1100L Tank", "weight": 1064}
+    DIS_TANK1100_EMPTY = {"clsid": "DIS_TANK1100_EMPTY", "name": "1100L Tank Empty", "weight": 75}
     DIS_TANK800 = {"clsid": "DIS_TANK800", "name": "800L Tank", "weight": 730}
+    DIS_TANK800_EMPTY = {"clsid": "DIS_TANK800_EMPTY", "name": "800L Tank Empty", "weight": 45}
     DIS_TYPE200 = {"clsid": "DIS_TYPE200", "name": "TYPE-200A", "weight": 200}
     DIS_TYPE200_DUAL_L = {"clsid": "DIS_TYPE200_DUAL_L", "name": "TYPE-200A Dual", "weight": 400}
     DIS_TYPE200_DUAL_R = {"clsid": "DIS_TYPE200_DUAL_R", "name": "TYPE-200A Dual", "weight": 400}
@@ -619,7 +621,7 @@ class Weapons:
     MAK79_Mk_83 = {"clsid": "{MAK79_MK83 1R}", "name": "MAK79 Mk-83", "weight": 457}
     MAK79_Mk_83_ = {"clsid": "{MAK79_MK83 1L}", "name": "MAK79 Mk-83", "weight": 457}
     Matra_Magic_II = {"clsid": "{MMagicII}", "name": "Matra Magic II", "weight": 85}
-    Matra_Super_530D = {"clsid": "{Matra_S530D}", "name": "Matra Super 530D", "weight": 275}
+    Matra_Super_530D = {"clsid": "{Matra_S530D}", "name": "Matra Super 530D", "weight": 350}
     Matra_Type_155_Rocket_Pod = {"clsid": "{Matra155RocketPod}", "name": "Matra Type 155 Rocket Pod", "weight": 190}
     MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = {"clsid": "{5A1AC2B4-CA4B-4D09-A1AF-AC52FBC4B60B}", "name": "MBD2-67U with 4 x FAB-100 - 100kg GP Bombs LD", "weight": 465}
     MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD_ = {"clsid": "{29A828E2-C6BB-11d8-9897-000476191836}", "name": "MBD2-67U with 4 x FAB-100 - 100kg GP Bombs LD", "weight": 465}
@@ -719,9 +721,9 @@ class Weapons:
     Rb_04E_Anti_ship_Missile = {"clsid": "{Rb04}", "name": "Rb-04E Anti-ship Missile", "weight": 661}
     Rb_05A_MCLOS_ASM_AShM_AAM = {"clsid": "{Robot05}", "name": "Rb-05A MCLOS ASM/AShM/AAM", "weight": 341}
     Rb_15F_Programmable_Anti_ship_Missile = {"clsid": "{Rb15}", "name": "Rb-15F Programmable Anti-ship Missile", "weight": 610}
-    Rb_24J__AIM_9P__Sidewinder_IR_AAM = {"clsid": "{Robot24J}", "name": "Rb-24J (AIM-9P) Sidewinder IR AAM", "weight": 90}
-    Rb_24__AIM_9B__Sidewinder_IR_AAM = {"clsid": "{Robot24}", "name": "Rb-24 (AIM-9B) Sidewinder IR AAM", "weight": 90}
-    Rb_74__AIM_9L__Sidewinder_IR_AAM = {"clsid": "{Robot74}", "name": "Rb-74 (AIM-9L) Sidewinder IR AAM", "weight": 90}
+    Rb_24J__AIM_9P__Sidewinder_IR_AAM = {"clsid": "{Robot24J}", "name": "Rb-24J (AIM-9P) Sidewinder IR AAM", "weight": 140}
+    Rb_24__AIM_9B__Sidewinder_IR_AAM = {"clsid": "{Robot24}", "name": "Rb-24 (AIM-9B) Sidewinder IR AAM", "weight": 132}
+    Rb_74__AIM_9L__Sidewinder_IR_AAM = {"clsid": "{Robot74}", "name": "Rb-74 (AIM-9L) Sidewinder IR AAM", "weight": 144}
     Rb_75A__AGM_65A_Maverick___TV_ASM_ = {"clsid": "{RB75}", "name": "Rb-75A (AGM-65A Maverick) (TV ASM)", "weight": 269.5}
     Rb_75B__AGM_65B_Maverick___TV_ASM_ = {"clsid": "{RB75B}", "name": "Rb-75B (AGM-65B Maverick) (TV ASM)", "weight": 269.5}
     Rb_75T__AGM_65A_Maverick___TV_ASM_Lg_HE_Whd_ = {"clsid": "{RB75T}", "name": "Rb-75T (AGM-65A Maverick) (TV ASM Lg HE Whd)", "weight": 354}
@@ -737,6 +739,9 @@ class Weapons:
     RPL_541_2000_liters_Fuel_Tank__ = {"clsid": "{M2KC_08_RPL541}", "name": "RPL 541 2000 liters Fuel Tank ", "weight": 1837}
     RPL_541_2000_liters_Fuel_Tank__Empty_ = {"clsid": "{M2KC_02_RPL541_EMPTY}", "name": "RPL 541 2000 liters Fuel Tank (Empty)", "weight": 257}
     RPL_541_2000_liters_Fuel_Tank__Empty__ = {"clsid": "{M2KC_08_RPL541_EMPTY}", "name": "RPL 541 2000 liters Fuel Tank (Empty)", "weight": 257}
+    RP_3_25lb_AP_Mk_I = {"clsid": "{British_AP_25LBNo1_3INCHNo1}", "name": "RP-3 25lb AP Mk.I", "weight": 22}
+    RP_3_60lb_F_No1_Mk_I = {"clsid": "{British_HE_60LBFNo1_3INCHNo1}", "name": "RP-3 60lb F No1 Mk.I", "weight": 31.6}
+    RP_3_60lb_SAP_No2_Mk_I = {"clsid": "{British_HE_60LBSAPNo2_3INCHNo1}", "name": "RP-3 60lb SAP No2 Mk.I", "weight": 38.1}
     RS2US___AAM__beam_rider = {"clsid": "{RS-2US}", "name": "RS2US - AAM, beam-rider", "weight": 105.2}
     R_13M1___AAM__IR_guided = {"clsid": "{R-13M1}", "name": "R-13M1 - AAM, IR guided", "weight": 122.4}
     R_13M___AAM__IR_guided = {"clsid": "{R-13M}", "name": "R-13M - AAM, IR guided", "weight": 119.7}
@@ -995,6 +1000,12 @@ class Weapons:
     _2_x_RBK_250_PTAB_2_5M_ = {"clsid": "{RBK_250_PTAB25M_DUAL_R}", "name": "2 x RBK-250 PTAB-2.5M", "weight": 578}
     _2_x_RBK_500_255_PTAB_10_5 = {"clsid": "{RBK_500_PTAB105_DUAL_L}", "name": "2 x RBK-500-255 PTAB-10-5", "weight": 538}
     _2_x_RBK_500_255_PTAB_10_5_ = {"clsid": "{RBK_500_PTAB105_DUAL_R}", "name": "2 x RBK-500-255 PTAB-10-5", "weight": 538}
+    _2_x_RP_3_25lb_AP_Mk_I = {"clsid": "{MOSSIE_2_British_AP_25LBNo1_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "2 x RP-3 25lb AP Mk.I", "weight": 174}
+    _2_x_RP_3_25lb_AP_Mk_I_ = {"clsid": "{MOSSIE_2_British_AP_25LBNo1_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "2 x RP-3 25lb AP Mk.I", "weight": 174}
+    _2_x_RP_3_60lb_F_No1_Mk_I = {"clsid": "{MOSSIE_2_British_HE_60LBFNo1_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "2 x RP-3 60lb F No1 Mk.I", "weight": 193.2}
+    _2_x_RP_3_60lb_F_No1_Mk_I_ = {"clsid": "{MOSSIE_2_British_HE_60LBFNo1_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "2 x RP-3 60lb F No1 Mk.I", "weight": 193.2}
+    _2_x_RP_3_60lb_SAP_No2_Mk_I = {"clsid": "{MOSSIE_2_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "2 x RP-3 60lb SAP No2 Mk.I", "weight": 206.2}
+    _2_x_RP_3_60lb_SAP_No2_Mk_I_ = {"clsid": "{MOSSIE_2_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "2 x RP-3 60lb SAP No2 Mk.I", "weight": 206.2}
     _2_x_S_25 = {"clsid": "{S25_DUAL_L}", "name": "2 x S-25", "weight": 902}
     _2_x_S_25_ = {"clsid": "{S25_DUAL_R}", "name": "2 x S-25", "weight": 902}
     _2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator = {"clsid": "{TWIN_S25}", "name": "2 x S-25-OFM - 340mm UnGdrocket, 480kg Penetrator", "weight": 902}
@@ -1027,6 +1038,12 @@ class Weapons:
     _4_x_AN_M64___500lb_GP_Bomb_LD = {"clsid": "{4xAN-M64_on_InvCountedAttachmentPoints}", "name": "4 x AN-M64 - 500lb GP Bomb LD", "weight": 908}
     _4_x_BGM_71D_TOW_ATGM = {"clsid": "{3EA17AB0-A805-4D9E-8732-4CE00CB00F17}", "name": "4 x BGM-71D TOW ATGM", "weight": 250}
     _4_x_GBU_27___2000lb_Laser_Guided_Penetrator_Bombs = {"clsid": "{B8C99F40-E486-4040-B547-6639172A5D57}", "name": "4 x GBU-27 - 2000lb Laser Guided Penetrator Bombs", "weight": 3936}
+    _4_x_RP_3_25lb_AP_Mk_I = {"clsid": "{MOSSIE_4_British_AP_25LBNo1_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "4 x RP-3 25lb AP Mk.I", "weight": 218}
+    _4_x_RP_3_25lb_AP_Mk_I_ = {"clsid": "{MOSSIE_4_British_AP_25LBNo1_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "4 x RP-3 25lb AP Mk.I", "weight": 218}
+    _4_x_RP_3_60lb_F_No1_Mk_I = {"clsid": "{MOSSIE_4_British_HE_60LBFNo1_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "4 x RP-3 60lb F No1 Mk.I", "weight": 256.4}
+    _4_x_RP_3_60lb_F_No1_Mk_I_ = {"clsid": "{MOSSIE_4_British_HE_60LBFNo1_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "4 x RP-3 60lb F No1 Mk.I", "weight": 256.4}
+    _4_x_RP_3_60lb_SAP_No2_Mk_I = {"clsid": "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}", "name": "4 x RP-3 60lb SAP No2 Mk.I", "weight": 282.4}
+    _4_x_RP_3_60lb_SAP_No2_Mk_I_ = {"clsid": "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}", "name": "4 x RP-3 60lb SAP No2 Mk.I", "weight": 282.4}
     _500_lb_GP_Mk_I = {"clsid": "{British_GP_500LB_Bomb_Mk1}", "name": "500 lb GP Mk.I", "weight": 213.188}
     _500_lb_GP_Mk_IV = {"clsid": "{British_GP_500LB_Bomb_Mk4}", "name": "500 lb GP Mk.IV", "weight": 213.188}
     _500_lb_GP_Mk_V = {"clsid": "{British_GP_500LB_Bomb_Mk5}", "name": "500 lb GP Mk.V", "weight": 213.188}
@@ -1356,7 +1373,9 @@ weapon_ids = {
     "DIS_SMOKE_GENERATOR_Y": Weapons.DIS_SMOKE_GENERATOR_Y,
     "DIS_SPJ_POD": Weapons.DIS_SPJ_POD,
     "DIS_TANK1100": Weapons.DIS_TANK1100,
+    "DIS_TANK1100_EMPTY": Weapons.DIS_TANK1100_EMPTY,
     "DIS_TANK800": Weapons.DIS_TANK800,
+    "DIS_TANK800_EMPTY": Weapons.DIS_TANK800_EMPTY,
     "DIS_TYPE200": Weapons.DIS_TYPE200,
     "DIS_TYPE200_DUAL_L": Weapons.DIS_TYPE200_DUAL_L,
     "DIS_TYPE200_DUAL_R": Weapons.DIS_TYPE200_DUAL_R,
@@ -1809,6 +1828,9 @@ weapon_ids = {
     "{M2KC_08_RPL541}": Weapons.RPL_541_2000_liters_Fuel_Tank__,
     "{M2KC_02_RPL541_EMPTY}": Weapons.RPL_541_2000_liters_Fuel_Tank__Empty_,
     "{M2KC_08_RPL541_EMPTY}": Weapons.RPL_541_2000_liters_Fuel_Tank__Empty__,
+    "{British_AP_25LBNo1_3INCHNo1}": Weapons.RP_3_25lb_AP_Mk_I,
+    "{British_HE_60LBFNo1_3INCHNo1}": Weapons.RP_3_60lb_F_No1_Mk_I,
+    "{British_HE_60LBSAPNo2_3INCHNo1}": Weapons.RP_3_60lb_SAP_No2_Mk_I,
     "{RS-2US}": Weapons.RS2US___AAM__beam_rider,
     "{R-13M1}": Weapons.R_13M1___AAM__IR_guided,
     "{R-13M}": Weapons.R_13M___AAM__IR_guided,
@@ -2067,6 +2089,12 @@ weapon_ids = {
     "{RBK_250_PTAB25M_DUAL_R}": Weapons._2_x_RBK_250_PTAB_2_5M_,
     "{RBK_500_PTAB105_DUAL_L}": Weapons._2_x_RBK_500_255_PTAB_10_5,
     "{RBK_500_PTAB105_DUAL_R}": Weapons._2_x_RBK_500_255_PTAB_10_5_,
+    "{MOSSIE_2_British_AP_25LBNo1_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._2_x_RP_3_25lb_AP_Mk_I,
+    "{MOSSIE_2_British_AP_25LBNo1_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._2_x_RP_3_25lb_AP_Mk_I_,
+    "{MOSSIE_2_British_HE_60LBFNo1_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._2_x_RP_3_60lb_F_No1_Mk_I,
+    "{MOSSIE_2_British_HE_60LBFNo1_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._2_x_RP_3_60lb_F_No1_Mk_I_,
+    "{MOSSIE_2_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._2_x_RP_3_60lb_SAP_No2_Mk_I,
+    "{MOSSIE_2_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._2_x_RP_3_60lb_SAP_No2_Mk_I_,
     "{S25_DUAL_L}": Weapons._2_x_S_25,
     "{S25_DUAL_R}": Weapons._2_x_S_25_,
     "{TWIN_S25}": Weapons._2_x_S_25_OFM___340mm_UnGdrocket__480kg_Penetrator,
@@ -2099,6 +2127,12 @@ weapon_ids = {
     "{4xAN-M64_on_InvCountedAttachmentPoints}": Weapons._4_x_AN_M64___500lb_GP_Bomb_LD,
     "{3EA17AB0-A805-4D9E-8732-4CE00CB00F17}": Weapons._4_x_BGM_71D_TOW_ATGM,
     "{B8C99F40-E486-4040-B547-6639172A5D57}": Weapons._4_x_GBU_27___2000lb_Laser_Guided_Penetrator_Bombs,
+    "{MOSSIE_4_British_AP_25LBNo1_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._4_x_RP_3_25lb_AP_Mk_I,
+    "{MOSSIE_4_British_AP_25LBNo1_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._4_x_RP_3_25lb_AP_Mk_I_,
+    "{MOSSIE_4_British_HE_60LBFNo1_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._4_x_RP_3_60lb_F_No1_Mk_I,
+    "{MOSSIE_4_British_HE_60LBFNo1_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._4_x_RP_3_60lb_F_No1_Mk_I_,
+    "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_LEFT_WING_RAILS}": Weapons._4_x_RP_3_60lb_SAP_No2_Mk_I,
+    "{MOSSIE_4_British_HE_60LBSAPNo2_3INCHNo1_ON_RIGHT_WING_RAILS}": Weapons._4_x_RP_3_60lb_SAP_No2_Mk_I_,
     "{British_GP_500LB_Bomb_Mk1}": Weapons._500_lb_GP_Mk_I,
     "{British_GP_500LB_Bomb_Mk4}": Weapons._500_lb_GP_Mk_IV,
     "{British_GP_500LB_Bomb_Mk5}": Weapons._500_lb_GP_Mk_V,

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -534,17 +534,15 @@ from dcs.unittype import FlyingType
 
         -- tasks
         writeln(file, "")
-        s = ''
-        j = 1
-        while j <= #plane.Tasks do
-            local objname = string.gsub(plane.Tasks[j].Name, "[-()/., *']", "")
-            s = s..'task.'..objname..''
-            j = j + 1
-            if j <= #plane.Tasks then
-                s = s..', '
+        tasks = {}
+        for j in pairs(plane.Tasks) do
+            -- For some reason some entries in this list are null. Skip those.
+            if plane.Tasks[j] ~= nil then
+                local objname = string.gsub(plane.Tasks[j].Name, "[-()/., *']", "")
+                table.insert(tasks, 'task.'..objname..'')
             end
         end
-        writeln(file, '    tasks = ['..s..']')
+        writeln(file, '    tasks = ['..table.concat(tasks, ', ')..']')
         local objname = string.gsub(plane.DefaultTask.Name, "[-()/., *']", "")
         writeln(file, '    task_default = task.'..objname..'')
         -- writeln(file, safename..'.load_payloads()')


### PR DESCRIPTION
Includes Viper ECM, radio config change for the Viggen, and a bunch of new callsigns for a few US jets.

The first commit fixes the export script to work for the latest DCS. The second is the data.