### PR TITLE
Adding OptFormation Data

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1660,7 +1660,8 @@ class OptFormation(Option):
         WW2_FighterVic = 14
 
     class VariantIndex(IntEnum):
-        """The distance that the formation is spread apart is dependent on the formation index.  Ignore text for rotaries, its always small-medium-large."""
+        """The distance that the formation is spread apart is dependent on the formation index.
+        Ignore text for rotaries, its always small-medium-large."""
         Close = 1
         Open = 2
         GroupClose = 3
@@ -1670,7 +1671,14 @@ class OptFormation(Option):
         Right = 0
         Left = 1
 
-    def __init__(self, value: Values = Values.value, formationIndex: FormationIndex = FormationIndex.value, variantIndex: VariantIndex = VariantIndex.value, zInverse: ZInverse = ZInverse.value):
+    def __init__(
+        self,
+        value: Values = Values.value,
+        formationIndex: FormationIndex = FormationIndex.value,
+        variantIndex: VariantIndex = VariantIndex.value,
+        zInverse: ZInverse = ZInverse.value
+    ):
+
         super(OptFormation, self).__init__(value.value)
         self.params["action"]["params"]["formationIndex"] = formationIndex
         if variantIndex:
@@ -1689,156 +1697,315 @@ class OptFormation(Option):
     # Rotary formation constructors:
     @staticmethod
     def rotary_wedge():
-        return OptFormation(value=OptFormation.Values.RotaryWedge, formationIndex=OptFormation.FormationIndex.RotaryWedge)
+        return OptFormation(
+            value=OptFormation.Values.RotaryWedge,
+            formationIndex=OptFormation.FormationIndex.RotaryWedge
+        )
 
     @staticmethod
     def rotary_eschelon_right_small():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonRightSmall, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonRightSmall,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Right,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_eschelon_right_medium():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonRightMedium, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonRightMedium,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Right,
+            variantIndex=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def rotary_eschelon_right_large():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonRightLarge, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonRightLarge,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Right,
+            variantIndex=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def rotary_eschelon_left_small():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftSmall, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonLeftSmall,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Left,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_eschelon_left_medium():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftMedium, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonLeftMedium,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Left,
+            variantIndex=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def rotary_eschelon_left_large():
-        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftLarge, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.RotaryEchelonLeftLarge,
+            formationIndex=OptFormation.FormationIndex.RotaryEchelon,
+            zInverse=OptFormation.ZInverse.Left,
+            variantIndex=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def rotary_front_right_small():
-        return OptFormation(value=OptFormation.Values.RotaryFrontRightSmall, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryFrontRightSmall,
+            formationIndex=OptFormation.FormationIndex.RotaryFront,
+            zInverse=OptFormation.ZInverse.Right,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_front_right_medium():
-        return OptFormation(value=OptFormation.Values.RotaryFrontRightMedium, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryFrontRightMedium,
+            formationIndex=OptFormation.FormationIndex.RotaryFront,
+            zInverse=OptFormation.ZInverse.Right,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_front_left_small():
-        return OptFormation(value=OptFormation.Values.RotaryFrontLeftSmall, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryFrontLeftSmall,
+            formationIndex=OptFormation.FormationIndex.RotaryFront,
+            zInverse=OptFormation.ZInverse.Left,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_front_left_medium():
-        return OptFormation(value=OptFormation.Values.RotaryFrontLeftMedium, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.RotaryFrontLeftMedium,
+            formationIndex=OptFormation.FormationIndex.RotaryFront,
+            zInverse=OptFormation.ZInverse.Left,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def rotary_column():
-        return OptFormation(value=OptFormation.Values.RotaryColumn, formationIndex=OptFormation.FormationIndex.RotaryColumn)
+        return OptFormation(
+            value=OptFormation.Values.RotaryColumn,
+            formationIndex=OptFormation.FormationIndex.RotaryColumn
+        )
 
     # Aircraft formation constructors:
     @staticmethod
     def line_abreast_close():
-        return OptFormation(value=OptFormation.Values.LineAbreastClose, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.LineAbreastClose,
+            formationIndex=OptFormation.FormationIndex.LineAbreast,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def line_abreast_open():
-        return OptFormation(value=OptFormation.Values.LineAbreastOpen, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.LineAbreastOpen,
+            formationIndex=OptFormation.FormationIndex.LineAbreast,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def line_abreast_group_close():
-        return OptFormation(value=OptFormation.Values.LineAbreastClose, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.LineAbreastClose,
+            formationIndex=OptFormation.FormationIndex.LineAbreast,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def trail_close():
-        return OptFormation(value=OptFormation.Values.TrailClose, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.TrailClose,
+            formationIndex=OptFormation.FormationIndex.Trail,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def trail_open():
-        return OptFormation(value=OptFormation.Values.TrailOpen, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.TrailOpen,
+            formationIndex=OptFormation.FormationIndex.Trail,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def trail_group_close():
-        return OptFormation(value=OptFormation.Values.TrailGroupClose, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.TrailGroupClose,
+            formationIndex=OptFormation.FormationIndex.Trail,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def wedge_close():
-        return OptFormation(value=OptFormation.Values.WedgeClose, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.WedgeClose,
+            formationIndex=OptFormation.FormationIndex.Wedge,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def wedge_open():
-        return OptFormation(value=OptFormation.Values.WedgeOpen, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.WedgeOpen,
+            formationIndex=OptFormation.FormationIndex.Wedge,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def wedge_group_close():
-        return OptFormation(value=OptFormation.Values.WedgeGroupClose, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.WedgeGroupClose,
+            formationIndex=OptFormation.FormationIndex.Wedge,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def echelon_right_close():
-        return OptFormation(value=OptFormation.Values.EchelonRightClose, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.EchelonRightClose,
+            formationIndex=OptFormation.FormationIndex.EchelonRight,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def echelon_right_open():
-        return OptFormation(value=OptFormation.Values.EchelonRightOpen, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.EchelonRightOpen,
+            formationIndex=OptFormation.FormationIndex.EchelonRight,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def echelon_right_group_close():
-        return OptFormation(value=OptFormation.Values.EchelonRightGroupClose, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.EchelonRightGroupClose,
+            formationIndex=OptFormation.FormationIndex.EchelonRight,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def echelon_left_close():
-        return OptFormation(value=OptFormation.Values.EchelonLeftClose, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.EchelonLeftClose,
+            formationIndex=OptFormation.FormationIndex.EchelonLeft,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def echelon_left_open():
-        return OptFormation(value=OptFormation.Values.EchelonLeftOpen, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.EchelonLeftOpen,
+            formationIndex=OptFormation.FormationIndex.EchelonLeft,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def echelon_left_group_close():
-        return OptFormation(value=OptFormation.Values.EchelonLeftGroupClose, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.EchelonLeftGroupClose,
+            formationIndex=OptFormation.FormationIndex.EchelonLeft,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def finger_four_close():
-        return OptFormation(value=OptFormation.Values.FingerFourClose, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.FingerFourClose,
+            formationIndex=OptFormation.FormationIndex.FingerFour,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def finger_four_open():
-        return OptFormation(value=OptFormation.Values.FingerFourOpen, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.FingerFourOpen,
+            formationIndex=OptFormation.FormationIndex.FingerFour,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def finger_four_group_close():
-        return OptFormation(value=OptFormation.Values.FingerFourGroupClose, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.FingerFourGroupClose,
+            formationIndex=OptFormation.FormationIndex.FingerFour,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def spread_four_close():
-        return OptFormation(value=OptFormation.Values.SpreadFourClose, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.SpreadFourClose,
+            formationIndex=OptFormation.FormationIndex.SpreadFour,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def spread_four_open():
-        return OptFormation(value=OptFormation.Values.SpreadFourOpen, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.SpreadFourOpen,
+            formationIndex=OptFormation.FormationIndex.SpreadFour,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def spread_four_group_close():
-        return OptFormation(value=OptFormation.Values.SpreadFourGroupClose, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(
+            value=OptFormation.Values.SpreadFourGroupClose,
+            formationIndex=OptFormation.FormationIndex.SpreadFour,
+            variant_index=OptFormation.VariantIndex.GroupClose
+        )
 
     @staticmethod
     def ww2_bomber_element_close():
-        return OptFormation(value=OptFormation.Values.WW2_BomberElementClose, formationIndex=OptFormation.FormationIndex.WW2_BomberElement, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.WW2_BomberElementClose,
+            formationIndex=OptFormation.FormationIndex.WW2_BomberElement,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def ww2_bomber_element_open():
-        return OptFormation(value=OptFormation.Values.WW2_BomberElementOpen, formationIndex=OptFormation.FormationIndex.WW2_BomberElement, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.WW2_BomberElementOpen,
+            formationIndex=OptFormation.FormationIndex.WW2_BomberElement,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
     @staticmethod
     def ww2_bomber_element_height_seperation():
-        return OptFormation(value=OptFormation.Values.WW2_BomberElementHeightSeperation, formationIndex=OptFormation.FormationIndex.WW2_BomberElementHeightSeperation)
+        return OptFormation(
+            value=OptFormation.Values.WW2_BomberElementHeightSeperation,
+            formationIndex=OptFormation.FormationIndex.WW2_BomberElementHeightSeperation
+        )
 
     @staticmethod
     def ww2_fighter_vic_close():
-        return OptFormation(value=OptFormation.Values.WW2_FighterVicClose, formationIndex=OptFormation.FormationIndex.WW2_FighterVic, variant_index=OptFormation.VariantIndex.Close)
+        return OptFormation(
+            value=OptFormation.Values.WW2_FighterVicClose,
+            formationIndex=OptFormation.FormationIndex.WW2_FighterVic,
+            variant_index=OptFormation.VariantIndex.Close
+        )
 
     @staticmethod
     def ww2_fighter_vic_open():
-        return OptFormation(value=OptFormation.Values.WW2_FighterVicOpen, formationIndex=OptFormation.FormationIndex.WW2_FighterVic, variant_index=OptFormation.VariantIndex.Open)
+        return OptFormation(
+            value=OptFormation.Values.WW2_FighterVicOpen,
+            formationIndex=OptFormation.FormationIndex.WW2_FighterVic,
+            variant_index=OptFormation.VariantIndex.Open
+        )
 
 
 class OptRTBOnBingoFuel(Option):

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1612,8 +1612,8 @@ class OptFormation(Option):
         RotaryFrontLeftMedium = 655618
         # RotaryColumn has no VariantIndex or zInverse field.
         RotaryColumn = 720896
-        
-        #Aircraft below
+
+        # Aircraft Values below
         LineAbreastClose = 65537
         LineAbreastOpen = 65538
         LineAbreastGroupClose = 65539
@@ -1686,159 +1686,159 @@ class OptFormation(Option):
     def variant_index(self) -> Union[str, int, bool]:
         return self.params["action"]["params"]["variantIndex"]
 
-    #Rotary formation constructors:
+    # Rotary formation constructors:
     @staticmethod
     def rotary_wedge():
-        return OptFormation(value = OptFormation.Values.RotaryWedge, formationIndex = OptFormation.FormationIndex.RotaryWedge)
+        return OptFormation(value=OptFormation.Values.RotaryWedge, formationIndex=OptFormation.FormationIndex.RotaryWedge)
 
     @staticmethod
     def rotary_eschelon_right_small():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonRightSmall, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.RotaryEchelonRightSmall, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def rotary_eschelon_right_medium():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonRightMedium, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.RotaryEchelonRightMedium, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def rotary_eschelon_right_large():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonRightLarge, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.RotaryEchelonRightLarge, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def rotary_eschelon_left_small():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftSmall, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftSmall, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def rotary_eschelon_left_medium():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftMedium, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftMedium, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def rotary_eschelon_left_large():
-        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftLarge, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.GroupClose)
-        
+        return OptFormation(value=OptFormation.Values.RotaryEchelonLeftLarge, formationIndex=OptFormation.FormationIndex.RotaryEchelon, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.GroupClose)
+
     @staticmethod
     def rotary_front_right_small():
-        return OptFormation(value = OptFormation.Values.RotaryFrontRightSmall, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
-    
+        return OptFormation(value=OptFormation.Values.RotaryFrontRightSmall, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+
     @staticmethod
     def rotary_front_right_medium():
-        return OptFormation(value = OptFormation.Values.RotaryFrontRightMedium, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
-    
+        return OptFormation(value=OptFormation.Values.RotaryFrontRightMedium, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+
     @staticmethod
     def rotary_front_left_small():
-        return OptFormation(value = OptFormation.Values.RotaryFrontLeftSmall, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
-    
+        return OptFormation(value=OptFormation.Values.RotaryFrontLeftSmall, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+
     @staticmethod
     def rotary_front_left_medium():
-        return OptFormation(value = OptFormation.Values.RotaryFrontLeftMedium, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
-    
+        return OptFormation(value=OptFormation.Values.RotaryFrontLeftMedium, formationIndex=OptFormation.FormationIndex.RotaryFront, zInverse=OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+
     @staticmethod
     def rotary_column():
-        return OptFormation(value = OptFormation.Values.RotaryColumn, formationIndex = OptFormation.FormationIndex.RotaryColumn)
+        return OptFormation(value=OptFormation.Values.RotaryColumn, formationIndex=OptFormation.FormationIndex.RotaryColumn)
 
-    #Aircraft formation constructors:
+    # Aircraft formation constructors:
     @staticmethod
     def line_abreast_close():
-        return OptFormation(value = OptFormation.Values.LineAbreastClose, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.LineAbreastClose, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def line_abreast_open():
-        return OptFormation(value = OptFormation.Values.LineAbreastOpen, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.LineAbreastOpen, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def line_abreast_group_close():
-        return OptFormation(value = OptFormation.Values.LineAbreastClose, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.LineAbreastClose, formationIndex=OptFormation.FormationIndex.LineAbreast, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def trail_close():
-        return OptFormation(value = OptFormation.Values.TrailClose, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.TrailClose, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def trail_open():
-        return OptFormation(value = OptFormation.Values.TrailOpen, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.TrailOpen, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def trail_group_close():
-        return OptFormation(value = OptFormation.Values.TrailGroupClose, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.TrailGroupClose, formationIndex=OptFormation.FormationIndex.Trail, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def wedge_close():
-        return OptFormation(value = OptFormation.Values.WedgeClose, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.WedgeClose, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def wedge_open():
-        return OptFormation(value = OptFormation.Values.WedgeOpen, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.WedgeOpen, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def wedge_group_close():
-        return OptFormation(value = OptFormation.Values.WedgeGroupClose, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.WedgeGroupClose, formationIndex=OptFormation.FormationIndex.Wedge, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def echelon_right_close():
-        return OptFormation(value = OptFormation.Values.EchelonRightClose, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.EchelonRightClose, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def echelon_right_open():
-        return OptFormation(value = OptFormation.Values.EchelonRightOpen, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.EchelonRightOpen, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def echelon_right_group_close():
-        return OptFormation(value = OptFormation.Values.EchelonRightGroupClose, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.EchelonRightGroupClose, formationIndex=OptFormation.FormationIndex.EchelonRight, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def echelon_left_close():
-        return OptFormation(value = OptFormation.Values.EchelonLeftClose, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.EchelonLeftClose, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def echelon_left_open():
-        return OptFormation(value = OptFormation.Values.EchelonLeftOpen, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.EchelonLeftOpen, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def echelon_left_group_close():
-        return OptFormation(value = OptFormation.Values.EchelonLeftGroupClose, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.EchelonLeftGroupClose, formationIndex=OptFormation.FormationIndex.EchelonLeft, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def finger_four_close():
-        return OptFormation(value = OptFormation.Values.FingerFourClose, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.FingerFourClose, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def finger_four_open():
-        return OptFormation(value = OptFormation.Values.FingerFourOpen, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.FingerFourOpen, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def finger_four_group_close():
-        return OptFormation(value = OptFormation.Values.FingerFourGroupClose, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.GroupClose)
+        return OptFormation(value=OptFormation.Values.FingerFourGroupClose, formationIndex=OptFormation.FormationIndex.FingerFour, variant_index=OptFormation.VariantIndex.GroupClose)
 
     @staticmethod
     def spread_four_close():
-        return OptFormation(value = OptFormation.Values.SpreadFourClose, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.SpreadFourClose, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def spread_four_open():
-        return OptFormation(value = OptFormation.Values.SpreadFourOpen, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.SpreadFourOpen, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def spread_four_group_close():
-        return OptFormation(value = OptFormation.Values.SpreadFourGroupClose, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.GroupClose)
-    
+        return OptFormation(value=OptFormation.Values.SpreadFourGroupClose, formationIndex=OptFormation.FormationIndex.SpreadFour, variant_index=OptFormation.VariantIndex.GroupClose)
+
     @staticmethod
     def ww2_bomber_element_close():
-        return OptFormation(value = OptFormation.Values.WW2_BomberElementClose, formationIndex = OptFormation.FormationIndex.WW2_BomberElement, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.WW2_BomberElementClose, formationIndex=OptFormation.FormationIndex.WW2_BomberElement, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def ww2_bomber_element_open():
-        return OptFormation(value = OptFormation.Values.WW2_BomberElementOpen, formationIndex = OptFormation.FormationIndex.WW2_BomberElement, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.WW2_BomberElementOpen, formationIndex=OptFormation.FormationIndex.WW2_BomberElement, variant_index=OptFormation.VariantIndex.Open)
 
     @staticmethod
     def ww2_bomber_element_height_seperation():
-        return OptFormation(value = OptFormation.Values.WW2_BomberElementHeightSeperation, formationIndex = OptFormation.FormationIndex.WW2_BomberElementHeightSeperation)
+        return OptFormation(value=OptFormation.Values.WW2_BomberElementHeightSeperation, formationIndex=OptFormation.FormationIndex.WW2_BomberElementHeightSeperation)
 
     @staticmethod
     def ww2_fighter_vic_close():
-        return OptFormation(value = OptFormation.Values.WW2_FighterVicClose, formationIndex = OptFormation.FormationIndex.WW2_FighterVic, variant_index = OptFormation.VariantIndex.Close)
+        return OptFormation(value=OptFormation.Values.WW2_FighterVicClose, formationIndex=OptFormation.FormationIndex.WW2_FighterVic, variant_index=OptFormation.VariantIndex.Close)
 
     @staticmethod
     def ww2_fighter_vic_open():
-        return OptFormation(value = OptFormation.Values.WW2_FighterVicOpen, formationIndex = OptFormation.FormationIndex.WW2_FighterVic, variant_index = OptFormation.VariantIndex.Open)
+        return OptFormation(value=OptFormation.Values.WW2_FighterVicOpen, formationIndex=OptFormation.FormationIndex.WW2_FighterVic, variant_index=OptFormation.VariantIndex.Open)
 
 
 class OptRTBOnBingoFuel(Option):

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1637,6 +1637,8 @@ class OptFormation(Option):
         WW2_BomberElementHeightSeperation = 851968
         WW2_FighterVicClose = 917505
         WW2_FighterVicOpen = 917506
+        ModernBomberFormationClose = 1114113
+        ModernBomberFormationOpen = 1114114
 
     class FormationIndex(IntEnum):
         """Formations are for Aircraft only (not helicopters) unless explicitly stated otherwise."""
@@ -1654,6 +1656,7 @@ class OptFormation(Option):
         WW2_BomberElement = 12
         WW2_BomberElementHeightSeperation = 13
         WW2_FighterVic = 14
+        ModernBomberFormation = 17
 
     class VariantIndex(IntEnum):
         """The distance that the formation is spread apart is dependent on the formation index.
@@ -2034,6 +2037,24 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WW2_FighterVicOpen,
             formationIndex=OptFormation.FormationIndex.WW2_FighterVic,
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
+        )
+
+    @staticmethod
+    def modern_bomber_formation_close():
+        return OptFormation(
+            value=OptFormation.Values.ModernBomberFormationClose,
+            formationIndex=OptFormation.FormationIndex.ModernBomberFormation,
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
+        )
+
+    @staticmethod
+    def modern_bomber_formation_open():
+        return OptFormation(
+            value=OptFormation.Values.ModernBomberFormationOpen,
+            formationIndex=OptFormation.FormationIndex.ModernBomberFormation,
             zInverse=None,
             variantIndex=OptFormation.VariantIndex.Open
         )

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1680,11 +1680,11 @@ class OptFormation(Option):
     ):
 
         super(OptFormation, self).__init__(value.value)
-        self.params["action"]["params"]["formationIndex"] = formationIndex
+        self.params["action"]["params"]["formationIndex"] = formationIndex.value
         if variantIndex:
-            self.params["action"]["params"]["variantIndex"] = variantIndex
+            self.params["action"]["params"]["variantIndex"] = variantIndex.value
         if zInverse:
-            self.params["action"]["params"]["zInverse"] = zInverse
+            self.params["action"]["params"]["zInverse"] = zInverse.value
 
     @property
     def formation_index(self) -> Union[str, int, bool]:

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1680,9 +1680,9 @@ class OptFormation(Option):
 
         super(OptFormation, self).__init__(value.value)
         self.params["action"]["params"]["formationIndex"] = formationIndex.value
-        if variantIndex:
+        if variantIndex is not None:
             self.params["action"]["params"]["variantIndex"] = variantIndex.value
-        if zInverse:
+        if zInverse is not None:
             self.params["action"]["params"]["zInverse"] = zInverse.value
 
     @property

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1592,10 +1592,6 @@ class OptFormation(Option):
 
     Key = 5
 
-    formationIndex: int
-    variantIndex: int
-    zInverse: int
-
     class Values(IntEnum):
         """Values are for Rotary or Fixed Wing only.  Rotary values are preceded by Rotary."""
         # RotaryWedge has no VariantIndex or zInverse field.
@@ -1661,7 +1657,7 @@ class OptFormation(Option):
 
     class VariantIndex(IntEnum):
         """The distance that the formation is spread apart is dependent on the formation index.
-        Ignore text for rotaries, its always small-medium-large."""
+        Ignore text for rotaries, its always small(1)-medium(2)-large(3)."""
         Close = 1
         Open = 2
         GroupClose = 3
@@ -1673,10 +1669,10 @@ class OptFormation(Option):
 
     def __init__(
         self,
-        value: Values,
-        formationIndex: FormationIndex,
-        variantIndex: Optional[VariantIndex],
-        zInverse: Optional[ZInverse]
+        value: Values = Values.EchelonRightOpen,
+        formationIndex: FormationIndex = FormationIndex.EchelonRight,
+        variantIndex: Optional[VariantIndex] = VariantIndex.Open,
+        zInverse: Optional[ZInverse] = None
     ):
 
         super(OptFormation, self).__init__(value.value)

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1673,10 +1673,10 @@ class OptFormation(Option):
 
     def __init__(
         self,
-        value: Values = Values.value,
-        formationIndex: FormationIndex = FormationIndex.value,
-        variantIndex: VariantIndex = VariantIndex.value,
-        zInverse: ZInverse = ZInverse.value
+        value: Values,
+        formationIndex: FormationIndex,
+        variantIndex: Optional[VariantIndex],
+        zInverse: Optional[ZInverse]
     ):
 
         super(OptFormation, self).__init__(value.value)

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1588,12 +1588,257 @@ class OptChaffFlareUsing(Option):
 
 
 class OptFormation(Option):
+    """Formations changed data structures during DCS development.  Use the static methods to build the desired formation."""
+
     Key = 5
 
-    # TODO missing option enums
+    formationIndex: int
+    variantIndex: int
+    zInverse: int
 
-    def __init__(self, value=None):
-        super(OptFormation, self).__init__(value)
+    class Values(IntEnum):
+        """Values are for Rotary or Fixed Wing only.  Rotary values are preceded by Rotary."""
+        # RotaryWedge has no VariantIndex or zInverse field.
+        RotaryWedge = 8
+        RotaryEchelonRightSmall = 589825
+        RotaryEchelonRightMedium = 583826
+        RotaryEchelonRightLarge = 589827
+        RotaryEchelonLeftSmall = 590081
+        RotaryEchelonLeftMedium = 590082
+        RotaryEchelonLeftLarge = 590083
+        RotaryFrontRightSmall = 655361
+        RotaryFrontRightMedium = 655362
+        RotaryFrontLeftSmall = 655617
+        RotaryFrontLeftMedium = 655618
+        # RotaryColumn has no VariantIndex or zInverse field.
+        RotaryColumn = 720896
+        
+        #Aircraft below
+        LineAbreastClose = 65537
+        LineAbreastOpen = 65538
+        LineAbreastGroupClose = 65539
+        TrailClose = 131073
+        TrailOpen = 131074
+        TrailGroupClose = 131075
+        WedgeClose = 196609
+        WedgeOpen = 196610
+        WedgeGroupClose = 196611
+        EchelonRightClose = 262145
+        EchelonRightOpen = 262146
+        EchelonRightGroupClose = 262147
+        EchelonLeftClose = 327681
+        EchelonLeftOpen = 327682
+        EchelonLeftGroupClose = 327683
+        FingerFourClose = 393217
+        FingerFourOpen = 393218
+        FingerFourGroupClose = 393219
+        SpreadFourClose = 458753
+        SpreadFourOpen = 458754
+        SpreadFourGroupClose = 458755
+        WW2_BomberElementClose = 786433
+        WW2_BomberElementOpen = 786434
+        # WW2: Bomber Height Seperation has no VariantIndex field.
+        WW2_BomberElementHeightSeperation = 851968
+        WW2_FighterVicClose = 917505
+        WW2_FighterVicOpen = 917506
+
+    class FormationIndex(IntEnum):
+        """Formations are for Aircraft only (not helicopters) unless explicitly stated otherwise."""
+        LineAbreast = 1
+        Trail = 2
+        Wedge = 3
+        EchelonRight = 4
+        EchelonLeft = 5
+        FingerFour = 6
+        SpreadFour = 7
+        RotaryWedge = 8
+        RotaryEchelon = 9
+        RotaryFront = 10
+        RotaryColumn = 11
+        WW2_BomberElement = 12
+        WW2_BomberElementHeightSeperation = 13
+        WW2_FighterVic = 14
+
+    class VariantIndex(IntEnum):
+        """The distance that the formation is spread apart is dependent on the formation index.  Ignore text for rotaries, its always small-medium-large."""
+        Close = 1
+        Open = 2
+        GroupClose = 3
+
+    class ZInverse(IntEnum):
+        """Only used by rotaries.  Combines with FormationIndex to vary left/right."""
+        Right = 0
+        Left = 1
+
+    def __init__(self, value: Values = Values.value, formationIndex: FormationIndex = FormationIndex.value, variantIndex: VariantIndex = VariantIndex.value, zInverse: ZInverse = ZInverse.value):
+        super(OptFormation, self).__init__(value.value)
+        self.params["action"]["params"]["formationIndex"] = formationIndex
+        if variantIndex:
+            self.params["action"]["params"]["variantIndex"] = variantIndex
+        if zInverse:
+            self.params["action"]["params"]["zInverse"] = zInverse
+
+    @property
+    def formation_index(self) -> Union[str, int, bool]:
+        return self.params["action"]["params"]["formationIndex"]
+
+    @property
+    def variant_index(self) -> Union[str, int, bool]:
+        return self.params["action"]["params"]["variantIndex"]
+
+    #Rotary formation constructors:
+    @staticmethod
+    def rotary_wedge():
+        return OptFormation(value = OptFormation.Values.RotaryWedge, formationIndex = OptFormation.FormationIndex.RotaryWedge)
+
+    @staticmethod
+    def rotary_eschelon_right_small():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonRightSmall, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def rotary_eschelon_right_medium():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonRightMedium, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def rotary_eschelon_right_large():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonRightLarge, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def rotary_eschelon_left_small():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftSmall, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def rotary_eschelon_left_medium():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftMedium, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def rotary_eschelon_left_large():
+        return OptFormation(value = OptFormation.Values.RotaryEchelonLeftLarge, formationIndex = OptFormation.FormationIndex.RotaryEchelon, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.GroupClose)
+        
+    @staticmethod
+    def rotary_front_right_small():
+        return OptFormation(value = OptFormation.Values.RotaryFrontRightSmall, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+    
+    @staticmethod
+    def rotary_front_right_medium():
+        return OptFormation(value = OptFormation.Values.RotaryFrontRightMedium, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Right, variantIndex=OptFormation.VariantIndex.Close)
+    
+    @staticmethod
+    def rotary_front_left_small():
+        return OptFormation(value = OptFormation.Values.RotaryFrontLeftSmall, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+    
+    @staticmethod
+    def rotary_front_left_medium():
+        return OptFormation(value = OptFormation.Values.RotaryFrontLeftMedium, formationIndex = OptFormation.FormationIndex.RotaryFront, zInverse= OptFormation.ZInverse.Left, variantIndex=OptFormation.VariantIndex.Close)
+    
+    @staticmethod
+    def rotary_column():
+        return OptFormation(value = OptFormation.Values.RotaryColumn, formationIndex = OptFormation.FormationIndex.RotaryColumn)
+
+    #Aircraft formation constructors:
+    @staticmethod
+    def line_abreast_close():
+        return OptFormation(value = OptFormation.Values.LineAbreastClose, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def line_abreast_open():
+        return OptFormation(value = OptFormation.Values.LineAbreastOpen, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def line_abreast_group_close():
+        return OptFormation(value = OptFormation.Values.LineAbreastClose, formationIndex = OptFormation.FormationIndex.LineAbreast, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def trail_close():
+        return OptFormation(value = OptFormation.Values.TrailClose, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def trail_open():
+        return OptFormation(value = OptFormation.Values.TrailOpen, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def trail_group_close():
+        return OptFormation(value = OptFormation.Values.TrailGroupClose, formationIndex = OptFormation.FormationIndex.Trail, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def wedge_close():
+        return OptFormation(value = OptFormation.Values.WedgeClose, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def wedge_open():
+        return OptFormation(value = OptFormation.Values.WedgeOpen, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def wedge_group_close():
+        return OptFormation(value = OptFormation.Values.WedgeGroupClose, formationIndex = OptFormation.FormationIndex.Wedge, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def echelon_right_close():
+        return OptFormation(value = OptFormation.Values.EchelonRightClose, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def echelon_right_open():
+        return OptFormation(value = OptFormation.Values.EchelonRightOpen, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def echelon_right_group_close():
+        return OptFormation(value = OptFormation.Values.EchelonRightGroupClose, formationIndex = OptFormation.FormationIndex.EchelonRight, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def echelon_left_close():
+        return OptFormation(value = OptFormation.Values.EchelonLeftClose, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def echelon_left_open():
+        return OptFormation(value = OptFormation.Values.EchelonLeftOpen, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def echelon_left_group_close():
+        return OptFormation(value = OptFormation.Values.EchelonLeftGroupClose, formationIndex = OptFormation.FormationIndex.EchelonLeft, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def finger_four_close():
+        return OptFormation(value = OptFormation.Values.FingerFourClose, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def finger_four_open():
+        return OptFormation(value = OptFormation.Values.FingerFourOpen, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def finger_four_group_close():
+        return OptFormation(value = OptFormation.Values.FingerFourGroupClose, formationIndex = OptFormation.FormationIndex.FingerFour, variant_index = OptFormation.VariantIndex.GroupClose)
+
+    @staticmethod
+    def spread_four_close():
+        return OptFormation(value = OptFormation.Values.SpreadFourClose, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def spread_four_open():
+        return OptFormation(value = OptFormation.Values.SpreadFourOpen, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def spread_four_group_close():
+        return OptFormation(value = OptFormation.Values.SpreadFourGroupClose, formationIndex = OptFormation.FormationIndex.SpreadFour, variant_index = OptFormation.VariantIndex.GroupClose)
+    
+    @staticmethod
+    def ww2_bomber_element_close():
+        return OptFormation(value = OptFormation.Values.WW2_BomberElementClose, formationIndex = OptFormation.FormationIndex.WW2_BomberElement, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def ww2_bomber_element_open():
+        return OptFormation(value = OptFormation.Values.WW2_BomberElementOpen, formationIndex = OptFormation.FormationIndex.WW2_BomberElement, variant_index = OptFormation.VariantIndex.Open)
+
+    @staticmethod
+    def ww2_bomber_element_height_seperation():
+        return OptFormation(value = OptFormation.Values.WW2_BomberElementHeightSeperation, formationIndex = OptFormation.FormationIndex.WW2_BomberElementHeightSeperation)
+
+    @staticmethod
+    def ww2_fighter_vic_close():
+        return OptFormation(value = OptFormation.Values.WW2_FighterVicClose, formationIndex = OptFormation.FormationIndex.WW2_FighterVic, variant_index = OptFormation.VariantIndex.Close)
+
+    @staticmethod
+    def ww2_fighter_vic_open():
+        return OptFormation(value = OptFormation.Values.WW2_FighterVicOpen, formationIndex = OptFormation.FormationIndex.WW2_FighterVic, variant_index = OptFormation.VariantIndex.Open)
 
 
 class OptRTBOnBingoFuel(Option):

--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1691,15 +1691,21 @@ class OptFormation(Option):
         return self.params["action"]["params"]["formationIndex"]
 
     @property
-    def variant_index(self) -> Union[str, int, bool]:
+    def variant_index(self) -> Optional[Union[str, int, bool]]:
         return self.params["action"]["params"]["variantIndex"]
+
+    @property
+    def z_inverse(self) -> Optional[Union[str, int, bool]]:
+        return self.params["action"]["params"]["zInverse"]
 
     # Rotary formation constructors:
     @staticmethod
     def rotary_wedge():
         return OptFormation(
             value=OptFormation.Values.RotaryWedge,
-            formationIndex=OptFormation.FormationIndex.RotaryWedge
+            formationIndex=OptFormation.FormationIndex.RotaryWedge,
+            zInverse=None,
+            variantIndex=None
         )
 
     @staticmethod
@@ -1796,7 +1802,9 @@ class OptFormation(Option):
     def rotary_column():
         return OptFormation(
             value=OptFormation.Values.RotaryColumn,
-            formationIndex=OptFormation.FormationIndex.RotaryColumn
+            formationIndex=OptFormation.FormationIndex.RotaryColumn,
+            zInverse=None,
+            variantIndex=None
         )
 
     # Aircraft formation constructors:
@@ -1805,7 +1813,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.LineAbreastClose,
             formationIndex=OptFormation.FormationIndex.LineAbreast,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1813,7 +1822,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.LineAbreastOpen,
             formationIndex=OptFormation.FormationIndex.LineAbreast,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1821,7 +1831,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.LineAbreastClose,
             formationIndex=OptFormation.FormationIndex.LineAbreast,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1829,7 +1840,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.TrailClose,
             formationIndex=OptFormation.FormationIndex.Trail,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1837,7 +1849,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.TrailOpen,
             formationIndex=OptFormation.FormationIndex.Trail,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1845,7 +1858,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.TrailGroupClose,
             formationIndex=OptFormation.FormationIndex.Trail,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1853,7 +1867,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WedgeClose,
             formationIndex=OptFormation.FormationIndex.Wedge,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1861,7 +1876,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WedgeOpen,
             formationIndex=OptFormation.FormationIndex.Wedge,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1869,7 +1885,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WedgeGroupClose,
             formationIndex=OptFormation.FormationIndex.Wedge,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1877,7 +1894,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonRightClose,
             formationIndex=OptFormation.FormationIndex.EchelonRight,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1885,7 +1903,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonRightOpen,
             formationIndex=OptFormation.FormationIndex.EchelonRight,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1893,7 +1912,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonRightGroupClose,
             formationIndex=OptFormation.FormationIndex.EchelonRight,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1901,7 +1921,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonLeftClose,
             formationIndex=OptFormation.FormationIndex.EchelonLeft,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1909,7 +1930,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonLeftOpen,
             formationIndex=OptFormation.FormationIndex.EchelonLeft,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1917,7 +1939,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.EchelonLeftGroupClose,
             formationIndex=OptFormation.FormationIndex.EchelonLeft,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1925,7 +1948,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.FingerFourClose,
             formationIndex=OptFormation.FormationIndex.FingerFour,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1933,7 +1957,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.FingerFourOpen,
             formationIndex=OptFormation.FormationIndex.FingerFour,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1941,7 +1966,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.FingerFourGroupClose,
             formationIndex=OptFormation.FormationIndex.FingerFour,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1949,7 +1975,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.SpreadFourClose,
             formationIndex=OptFormation.FormationIndex.SpreadFour,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1957,7 +1984,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.SpreadFourOpen,
             formationIndex=OptFormation.FormationIndex.SpreadFour,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
@@ -1965,7 +1993,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.SpreadFourGroupClose,
             formationIndex=OptFormation.FormationIndex.SpreadFour,
-            variant_index=OptFormation.VariantIndex.GroupClose
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.GroupClose
         )
 
     @staticmethod
@@ -1973,7 +2002,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WW2_BomberElementClose,
             formationIndex=OptFormation.FormationIndex.WW2_BomberElement,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -1981,14 +2011,17 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WW2_BomberElementOpen,
             formationIndex=OptFormation.FormationIndex.WW2_BomberElement,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
     @staticmethod
     def ww2_bomber_element_height_seperation():
         return OptFormation(
             value=OptFormation.Values.WW2_BomberElementHeightSeperation,
-            formationIndex=OptFormation.FormationIndex.WW2_BomberElementHeightSeperation
+            formationIndex=OptFormation.FormationIndex.WW2_BomberElementHeightSeperation,
+            zInverse=None,
+            variantIndex=None
         )
 
     @staticmethod
@@ -1996,7 +2029,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WW2_FighterVicClose,
             formationIndex=OptFormation.FormationIndex.WW2_FighterVic,
-            variant_index=OptFormation.VariantIndex.Close
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Close
         )
 
     @staticmethod
@@ -2004,7 +2038,8 @@ class OptFormation(Option):
         return OptFormation(
             value=OptFormation.Values.WW2_FighterVicOpen,
             formationIndex=OptFormation.FormationIndex.WW2_FighterVic,
-            variant_index=OptFormation.VariantIndex.Open
+            zInverse=None,
+            variantIndex=OptFormation.VariantIndex.Open
         )
 
 


### PR DESCRIPTION
I feel like I took an unconventional approach to this when compared to all the other Option Tasks.

DCS has a different formation format for rotary aircraft than fixed wing aircraft.  Some formations have extra options, some do not.

Because there are three different values for each formation, I chose to use static methods be the main method of generating these formations.

Wasn't sure if it was possible/how to test this in the existing tests, so I only tested it by incorporating it into DCS Liberation and checking if the values of the formations I used looked right.

Let me know if you disagree with stuff.  I wasn't sure if I should put `airplane` or `fixed_wing` in front of the fixed wing only options like I did with `rotary`.

This is the mission I made to source the data (changed extension to .zip): 
[FormationDefinitions.zip](https://github.com/pydcs/dcs/files/7852232/FormationDefinitions.zip)