### PR TITLE
Correct value check in Option.

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1485,7 +1485,7 @@ class Option(Task):
         self.params = {
             "action": {"id": "Option", "params": {"name": self.Key}}
         }
-        if value:
+        if value is not None:
             self.params["action"]["params"]["value"] = value
 
     @property


### PR DESCRIPTION
If the Option.Value has a Enum with a 0 value, the option does not get correctly written to the mission file.

Examples include OptROE.Values.WeaponsFree and OptECMUsing.Values.NeverUse.