### PR TITLE
Support for ground vehicle liveries

### DIFF
--- a/dcs/flyingunit.py
+++ b/dcs/flyingunit.py
@@ -15,6 +15,7 @@ class FlyingUnit(Unit):
         super(FlyingUnit, self).__init__(_id, name, _type.id)
         self.unit_type = _type  # for loadout validation
         self.unit_type.load_payloads()
+        self.livery_id = self.unit_type.default_livery(_country.name)
         self.parking = None  # crossroad idx
         self.parking_id = None  # parking slot name (01, 02, ..)
         self.psi = 0

--- a/dcs/flyingunit.py
+++ b/dcs/flyingunit.py
@@ -15,7 +15,6 @@ class FlyingUnit(Unit):
         super(FlyingUnit, self).__init__(_id, name, _type.id)
         self.unit_type = _type  # for loadout validation
         self.unit_type.load_payloads()
-        self.livery_id = self.unit_type.default_livery(_country.name)
         self.parking = None  # crossroad idx
         self.parking_id = None  # parking slot name (01, 02, ..)
         self.psi = 0
@@ -37,7 +36,6 @@ class FlyingUnit(Unit):
 
     def load_from_dict(self, d):
         super(FlyingUnit, self).load_from_dict(d)
-        self.livery_id = d.get("livery_id")
         self.alt_type = d["alt_type"]
         self.alt = d["alt"]
         self.psi = d["psi"]
@@ -194,8 +192,6 @@ class FlyingUnit(Unit):
             d["parking"] = self.parking
         if self.parking_id is not None:
             d["parking_id"] = self.parking_id
-        if self.livery_id:
-            d["livery_id"] = self.livery_id
         d["psi"] = self.psi
         d["onboard_num"] = self.onboard_num
         d["speed"] = round(self.speed, 13)

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -36,7 +36,7 @@ class Unit:
         self.id = _id
         self.skill: Optional[Skill] = Skill.Average
         self.name: str = name if name else ""
-        self.livery_id: Optional[str]
+        self.livery_id: Optional[str] = None
 
     def load_from_dict(self, d):
         self.position = mapping.Point(d["x"], d["y"])

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -36,7 +36,7 @@ class Unit:
         self.id = _id
         self.skill: Optional[Skill] = Skill.Average
         self.name: str = name if name else ""
-        self.livery_id = self.unit_type.default_livery(_country.name)
+        self.livery_id: Optional[str]
 
     def load_from_dict(self, d):
         self.position = mapping.Point(d["x"], d["y"])

--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -36,11 +36,13 @@ class Unit:
         self.id = _id
         self.skill: Optional[Skill] = Skill.Average
         self.name: str = name if name else ""
+        self.livery_id = self.unit_type.default_livery(_country.name)
 
     def load_from_dict(self, d):
         self.position = mapping.Point(d["x"], d["y"])
         self.heading = math.degrees(d["heading"])
         self.skill = Skill(d.get("skill")) if d.get("skill") else None
+        self.livery_id = d.get("livery_id")
 
     def clone(self, _id):
         new = copy.copy(self)
@@ -58,6 +60,8 @@ class Unit:
             "unitId": self.id,
             "name": self.name
         }
+        if self.livery_id:
+            d["livery_id"] = self.livery_id
         if self.skill is not None:
             d["skill"] = self.skill.value
         return d


### PR DESCRIPTION
In order to enable setting custom liveries to ground units in addition to aircraft, moved livery_id from FlyingUnit class to parent Unit class.