### PR TITLE
Add Point API for creating new Points.

### DIFF
--- a/dcs/mapping.py
+++ b/dcs/mapping.py
@@ -112,6 +112,9 @@ class Point(Vector2):
         x, y = terrain._ll_to_point_transformer.transform(latlng.lat, latlng.lng)
         return Point(x, y, terrain)
 
+    def new_in_same_map(self, x: float, y: float) -> Point:
+        return Point(x, y, self._terrain)
+
     def point_from_heading(self, heading: float, distance: float) -> Point:
         x, y = point_from_heading(self.x, self.y, heading, distance)
         return Point(x, y, self._terrain)


### PR DESCRIPTION
A common case I'm finding is that I need to take the X/Y coordinates of
a point, use them in another system (such as shapely), then convert the
result back into a Point. I'm currently doing that by accessing the
(supposedly private) _terrain member. This adds a less invasive method
for doing that.