### PR TITLE
Remove the transportable property from units.

### DIFF
--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -83,24 +83,20 @@ class Vehicle(Unit):
     def __init__(self, terrain: Terrain, id: Optional[int] = None, name: Optional[str] = None, _type="Sandbox"):
         super().__init__(id, terrain, name, _type)
         self.player_can_drive = False
-        self.transportable = {"randomTransportable": False}
 
     def load_from_dict(self, d: Dict[str, Any]) -> None:
         super().load_from_dict(d)
         self.player_can_drive = d["playerCanDrive"]
-        self.transportable = d["transportable"]
 
     def dict(self):
         d = super(Vehicle, self).dict()
         d["playerCanDrive"] = self.player_can_drive
-        d["transportable"] = self.transportable
         return d
 
 
 class Ship(Unit):
     def __init__(self, terrain: Terrain, id=None, name: Optional[str] = None, _type=None):
         super().__init__(id, terrain, name, _type.id)
-        self.transportable = {"randomTransportable": False}
         self.frequency = 127500000
 
     def set_frequency(self, frequency: int) -> None:
@@ -114,12 +110,10 @@ class Ship(Unit):
     def load_from_dict(self, d: Dict[str, Any]) -> None:
         super().load_from_dict(d)
         self.frequency = d.get("frequency", self.frequency)
-        self.transportable = d["transportable"]
 
     def dict(self):
         d = super(Ship, self).dict()
         d["frequency"] = self.frequency
-        d["transportable"] = self.transportable
         return d
 
 


### PR DESCRIPTION
It seems this property is no longer used in the latest miz version.

Fixes https://github.com/pydcs/dcs/issues/214