### PR TITLE
Add terrain.projections package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Programming Language :: Python :: 3 :: Only'
     ],
     keywords='dcs digital combat simulator eagle dynamics mission framework',
-    packages=['dcs', 'dcs/terrain', 'dcs/lua', 'dcs/scripts'],
+    packages=['dcs', 'dcs/terrain', 'dcs/terrain/projections', 'dcs/lua', 'dcs/scripts'],
     package_data={
         'dcs': ['py.typed'],
         'dcs/terrain': ['caucasus.p', 'nevada.p'],


### PR DESCRIPTION
Without this change, PyDCS cannot be used with poetry.

Python's [documentation ](https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages) states:

> (Keep in mind that although `package_dir` applies recursively, you must explicitly list all packages in packages: the Distutils will not recursively scan your source tree looking for any directory with an `__init__.py` file.)

It seems that when installing with `pip`, this limitation doesn't apply. However, when using [Poetry](https://python-poetry.org/) (and possibly other Python package managers?), this limitation is honored. So `dcs.terrain.projections` is never installed, which causes `import dcs` to fail.