### PR TITLE
Add drawing package to setup.py (missed in #231)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'Programming Language :: Python :: 3 :: Only'
     ],
     keywords='dcs digital combat simulator eagle dynamics mission framework',
-    packages=['dcs', 'dcs/terrain', 'dcs/terrain/projections', 'dcs/lua', 'dcs/scripts'],
+    packages=['dcs', 'dcs/terrain', 'dcs/terrain/projections', 'dcs/lua', 'dcs/scripts', 'dcs/drawing'],
     package_data={
         'dcs': ['py.typed'],
         'dcs/terrain': ['caucasus.p', 'nevada.p'],


### PR DESCRIPTION
In #231 I added the `terrain.projections` package to `setup.py`. Unfortunately I missed the fact that there is a `drawing` package that needs to be added as well. This PR adds that to the `package` list in `setup.py` as well.