### PR TITLE
Fix for ship export in pydcs_export.lua

### DIFF
--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -73,6 +73,10 @@ local function has_value (tab, val)
     return false
 end
 
+function ternary ( cond , T , F )
+    if cond then return T else return F end
+end
+
 -------------------------------------------------------------------------------
 -- country to shortname mapping
 -------------------------------------------------------------------------------

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -841,14 +841,19 @@ for i in pairs(db.Units.Ships.Ship) do
     if unit.airWeaponDist then
         air_weapon_dist = unit.airWeaponDist
     end
-    writeln(file, '    detection_range = '..unit.DetectionRange)
-    writeln(file, '    threat_range = '..unit.ThreatRange)
+    local detection_range = ternary((unit.DetectionRange ~= nil), unit.DetectionRange, 0)
+    local threat_range = ternary((unit.ThreatRange ~= nil), unit.ThreatRange, 0)
+    air_weapon_dist = ternary((air_weapon_dist ~= nil), air_weapon_dist, 0)
+    writeln(file, '    detection_range = '..detection_range)
+    writeln(file, '    threat_range = '..threat_range)
     writeln(file, '    air_weapon_dist = '..air_weapon_dist)
     --    writeln(file, '    shape_name = "'..unit.ShapeName..'"')
     --    writeln(file, '    rate = '..unit.Rate)
 end
 
 lookup_map(file, "ship", db.Units.Ships.Ship, false)
+
+file:close()
 
 -------------------------------------------------------------------------------
 -- export country data


### PR DESCRIPTION
When trying to export data, DCS stays stuck at 10% and the logs provide the following error:

ALERT   Dispatcher: Error starting Game GUI: [string "_path_to_pydcs_\tools\pydcs_export.lua"]:844: attempt to concatenate field '?' (a nil value)


This ought to fix the issue, and I also noticed a `file:close()` was missing for ships so I threw that in as well.