### PR TITLE
Remove all mentions of `meters` from scenery actions

### DIFF
--- a/dcs/action.py
+++ b/dcs/action.py
@@ -1713,50 +1713,42 @@ class RemoveSceneObjectsMask(IntEnum):
 class RemoveSceneObjects(Action):
     predicate = "a_remove_scene_objects"
 
-    def __init__(self, objects_mask: RemoveSceneObjectsMask = RemoveSceneObjectsMask.ALL, zone="", meters=1000):
+    def __init__(self, objects_mask: RemoveSceneObjectsMask = RemoveSceneObjectsMask.ALL, zone=""):
         super(RemoveSceneObjects, self).__init__(RemoveSceneObjects.predicate)
         self.objects_mask = objects_mask
         self.params.append(self.objects_mask)
         self.zone = zone
         self.params.append(self.zone)
-        # Note : the parameter meters is in the DCS save file, but seems unused, and not editable from ME
-        self.meters = meters
-        self.params.append(self.meters)
 
     @classmethod
     def create_from_dict(cls, d, mission):
-        return cls(RemoveSceneObjectsMask(d["objects_mask"]), d["zone"], d["meters"])
+        return cls(RemoveSceneObjectsMask(d["objects_mask"]), d["zone"])
 
     def dict(self):
         d = super(RemoveSceneObjects, self).dict()
         d["objects_mask"] = self.objects_mask.value
         d["zone"] = self.zone
-        d["meters"] = self.meters
         return d
 
 
 class SceneryDestructionZone(Action):
     predicate = "a_scenery_destruction_zone"
 
-    def __init__(self, destruction_level=100, zone="", meters=1000):
+    def __init__(self, destruction_level=100, zone=""):
         super(SceneryDestructionZone, self).__init__(SceneryDestructionZone.predicate)
         self.destruction_level = destruction_level
         self.params.append(self.destruction_level)
         self.zone = zone
         self.params.append(self.zone)
-        # Note : the parameter meters is in the DCS save file, but seems unused, and not editable from ME
-        self.meters = meters
-        self.params.append(self.meters)
 
     @classmethod
     def create_from_dict(cls, d, mission):
-        return cls(d["destruction_level"], d["zone"], d["meters"])
+        return cls(d["destruction_level"], d["zone"])
 
     def dict(self):
         d = super(SceneryDestructionZone, self).dict()
         d["destruction_level"] = self.destruction_level
         d["zone"] = self.zone
-        d["meters"] = self.meters
         return d
 
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -591,7 +591,6 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.SceneryDestructionZone)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].destruction_level, 95)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, destruction_zone.id)
 
     def test_remove_trees_in_zone(self):
@@ -618,7 +617,6 @@ class BasicTests(unittest.TestCase):
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask,
                          dcs.action.RemoveSceneObjectsMask.TREES_ONLY)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_remove_objects_in_zone(self):
@@ -645,7 +643,6 @@ class BasicTests(unittest.TestCase):
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask,
                          dcs.action.RemoveSceneObjectsMask.OBJECTS_ONLY)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_remove_trees_and_objects_in_zone(self):
@@ -671,7 +668,6 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.terrain.__class__, dcs.terrain.Caucasus)
         self.assertTrue(type(m2.triggerrules.triggers[0].actions[0]) is dcs.action.RemoveSceneObjects)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].objects_mask, dcs.action.RemoveSceneObjectsMask.ALL)
-        self.assertEqual(m2.triggerrules.triggers[0].actions[0].meters, 1000)
         self.assertEqual(m2.triggerrules.triggers[0].actions[0].zone, removal_zone.id)
 
     def test_bypass_triggers(self):


### PR DESCRIPTION
This attribute seems to be unused in prior versions of DCS, and now no longer added by the mission editor.

Should fix #207.