### PR TITLE
Export didn't include Mi-24P as flyable

### DIFF
--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -2729,6 +2729,7 @@ class AH_64D_BLK_II(HelicopterType):
 
 class Mi_24P(HelicopterType):
     id = "Mi-24P"
+    flyable = True
     height = 4.354
     width = 17.3
     length = 20.953


### PR DESCRIPTION
For some reason the export doesn't recognize the Mi-24P as flyable on my end. Maybe because I don't have the module installed?

One thing's for sure, it should be flyable...