### PR TITLE
Fix Flyables

### DIFF
--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -381,7 +381,6 @@ class F_A_18A(PlaneType):
 
 class F_A_18C(PlaneType):
     id = "F/A-18C"
-    flyable = True
     height = 4.66
     width = 11.43
     length = 17.07
@@ -16855,6 +16854,7 @@ class H_6J(PlaneType):
 
 class Christen_Eagle_II(PlaneType):
     id = "Christen Eagle II"
+    flyable = True
     height = 1.9812
     width = 11.594846
     length = 5.6388
@@ -28215,6 +28215,7 @@ class Hawk(PlaneType):
 
 class I_16(PlaneType):
     id = "I-16"
+    flyable = True
     height = 3.25
     width = 9.004
     length = 6.13
@@ -37266,6 +37267,7 @@ class MiG_21Bis(PlaneType):
 
 class Mirage_F1CE(PlaneType):
     id = "Mirage-F1CE"
+    flyable = True
     height = 4.5
     width = 8.4
     length = 15.3

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -304,11 +304,11 @@ file:close()
 -------------------------------------------------------------------------------
 local flyable = {}
 -- Jet engine
-flyable["AJS37"] = true
-flyable["AV8BNA"] = true
 flyable["A-10A"] = true
 flyable["A-10C"] = true
 flyable["A-10C_2"] = true
+flyable["AJS37"] = true
+flyable["AV8BNA"] = true
 flyable["C-101CC"] = true
 flyable["C-101EB"] = true
 flyable["F-14A-135-GR"] = true

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -303,49 +303,64 @@ file:close()
 -- aircraft export planes and helicopters
 -------------------------------------------------------------------------------
 local flyable = {}
+-- Jet engine
+flyable["AJS37"] = true
+flyable["AV8BNA"] = true
 flyable["A-10A"] = true
 flyable["A-10C"] = true
-flyable["Su-27"] = true
-flyable["Su-33"] = true
-flyable["Su-25"] = true
-flyable["Su-25T"] = true
-flyable["M-2000C"] = true
-flyable["F-15C"] = true
-flyable["MiG-29A"] = true
-flyable["MiG-29S"] = true
-flyable["P-51D"] = true
-flyable["TF-51D"] = true
-flyable["FW-190D9"] = true
-flyable["Bf-109K-4"] = true
+flyable["A-10C_2"] = true
 flyable["C-101CC"] = true
 flyable["C-101EB"] = true
+flyable["F-14A-135-GR"] = true
+flyable["F-14B"] = true
+flyable["F-15C"] = true
+flyable["F-16C_50"] = true
+flyable["FA-18C_hornet"] = true
+flyable["F-5E-3"] = true
 flyable["F-86F Sabre"] = true
 flyable["Hawk"] = true
+flyable["JF-17"] = true
 flyable["L-39C"] = true
 flyable["L-39ZA"] = true
+flyable["M-2000C"] = true
 flyable["MiG-15bis"] = true
+flyable["MiG-19P"] = true
 flyable["MiG-21Bis"] = true
-flyable["Ka-50"] = true
-flyable["Mi-8MT"] = true
-flyable["UH-1H"] = true
+flyable["MiG-29A"] = true
+flyable["MiG-29S"] = true
+flyable["Mirage-F1CE"] = true
+flyable["Su-25"] = true
+flyable["Su-25T"] = true
+flyable["Su-27"] = true
+flyable["Su-33"] = true
+
+-- Piston engine
+flyable["Bf-109K-4"] = true
+flyable["Christen Eagle II"] = true
+flyable["FW-190A8"] = true
+flyable["FW-190D9"] = true
+flyable["I-16"] = true
+flyable["MosquitoFBMkVI"] = true
+flyable["P-51D"] = true
+flyable["P-51D-30-NA"] = true
+flyable["P-47D-30"] = true
+flyable["P-47D-30bl1"] = true
+flyable["P-47D-40"] = true
 flyable["SpitfireLFMkIX"] = true
 flyable["SpitfireLFMkIXCW"] = true
+flyable["TF-51D"] = true
+flyable["Yak-52"] = true
+
+-- Helicopters
+flyable["AH-64D_BLK_II"] = true
+flyable["Ka-50"] = true
+flyable["Mi-8MT"] = true
+flyable["Mi-24P"] = true
 flyable["SA342L"] = true
 flyable["SA342M"] = true
 flyable["SA342Minigun"] = true
 flyable["SA342Mistral"] = true
-flyable["AV8BNA"] = true
-flyable["F/A-18C"] = true
-flyable["AJS37"] = true
-flyable["F-5E-3"] = true
-flyable["Yak-52"] = true
-flyable["FW-190A8"] = true
-flyable["P-47D-30"] = true
-flyable["P-47D-30bl1"] = true
-flyable["P-47D-40"] = true
-flyable["JF-17"] = true
-flyable["MiG-19P"] = true
-flyable["MosquitoFBMkVI"] = true
+flyable["UH-1H"] = true
 
 
 local function export_aircraft(file, aircrafts, export_type, exportplane)


### PR DESCRIPTION
Re-organized the flyables by type (jet engine/piston engine/helicopter) which makes verification a little easier, and sorted them alphabetically. Ran another export to be sure.

Two things I'd like to elaborate:

- Most of the additions in the flyables map don't have any effect, since it was already being exported correctly, I simply added them just to guarantee it stays exporting the flyable types correctly.
- I changed `F/A-18C` into `FA-18C_hornet`, since the former is referring to the AI model. Either way, the hornet (flyable one) was already being exported correctly so this simply removes the "flyable" option for the AI version.