### PR TITLE
Fix mistake in 'default_livery'

### DIFF
--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -437,7 +437,7 @@ class Terrain:
         (-2, 14),
         (-4, 12)
     ]
-    assert(len(temperature) == 12)
+    assert len(temperature) == 12
 
     def __init__(
         self, name: str,

--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -175,5 +175,5 @@ class FlyingType(UnitType):
         else:
             liveries = sorted(filter(lambda x: x.valid_for_country(country_name), cls.Liveries))
             if liveries:
-                return liveries[0].name
+                return liveries[0].id
         return ""


### PR DESCRIPTION
I ran into a little mistake I made regarding the default livery. 

The 'name' is what's shown in DCS' mission editor, the (path) 'id' is what we need for mission generation.

When liberation can't determine a livery for a squadron, it'll use `default_livery` as a fallback at some point, causing missing textures because of a wrong 'livery_id' in the mission file.