### PR TITLE
Delay initialization of livery scanner

### DIFF
--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -64,7 +64,6 @@ class Ka_50(HelicopterType):
     }
 
     livery_name = "KA-50"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
@@ -146,7 +145,6 @@ class Mi_24V(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "MI-24V"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
@@ -320,7 +318,6 @@ class Mi_8MT(HelicopterType):
             id = "NS430allow"
 
     livery_name = "MI-8MT"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
@@ -462,7 +459,6 @@ class Mi_26(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "MI-26"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -479,7 +475,6 @@ class Ka_27(HelicopterType):
     max_speed = 290
 
     livery_name = "KA-27"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -501,7 +496,6 @@ class UH_60A(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "UH-60A"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -524,7 +518,6 @@ class CH_53E(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "CH-53E"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -547,7 +540,6 @@ class CH_47D(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "CH-47D"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -570,7 +562,6 @@ class SH_3W(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "SH-3W"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -592,7 +583,6 @@ class AH_64A(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "AH-64A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE = (1, Weapons.LAU_61_pod___19_x_2_75_Hydra__UnGd_Rkts_M151__HE)
@@ -632,7 +622,6 @@ class AH_64D(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "AH-64D"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         M299___4_x_AGM_114K_Hellfire = (1, Weapons.M299___4_x_AGM_114K_Hellfire)
@@ -696,7 +685,6 @@ class AH_1W(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "AH-1W"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         M299___4_x_AGM_114K_Hellfire = (1, Weapons.M299___4_x_AGM_114K_Hellfire)
@@ -742,7 +730,6 @@ class SH_60B(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "SH-60B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AGM_119B_Penguin_ASM = (1, Weapons.AGM_119B_Penguin_ASM)
@@ -827,7 +814,6 @@ class UH_1H(HelicopterType):
                 Equally_Responsible = -2
 
     livery_name = "UH-1H"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         M134_L = (1, Weapons.M134_L)
@@ -883,7 +869,6 @@ class Mi_28N(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "MI-28N"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         B_8V20A_CM = (1, Weapons.B_8V20A_CM)
@@ -967,7 +952,6 @@ class OH_58D(HelicopterType):
     flare_charge_size = 1
 
     livery_name = "OH-58D"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         M260_HYDRA = (1, Weapons.M260_HYDRA)
@@ -1179,7 +1163,6 @@ class AH_64D_BLK_II(HelicopterType):
             id = "CpgNVG"
 
     livery_name = "AH-64D_BLK_II"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         M261_MK151 = (1, Weapons.M261_MK151)
@@ -1376,7 +1359,6 @@ class Mi_24P(HelicopterType):
                 Realistic = 3
 
     livery_name = "MI-24P"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT = (1, Weapons._2_x_9M114_Shturm_V__AT_6_Spiral____ATGM__SACLOS__HEAT)
@@ -1533,7 +1515,6 @@ class SA342M(HelicopterType):
             id = "NS430allow"
 
     livery_name = "SA342M"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         HOT3_ = (1, Weapons.HOT3_)
@@ -1607,7 +1588,6 @@ class SA342L(HelicopterType):
             id = "SA342RemoveDoors"
 
     livery_name = "SA342L"  # from type
-    Liveries = Liveries()[livery_name]
 #ERRR {GIAT_M621G}
 
     class Pylon2:
@@ -1679,7 +1659,6 @@ class SA342Mistral(HelicopterType):
             id = "NS430allow"
 
     livery_name = "SA342MISTRAL"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Mistral_ = (1, Weapons.Mistral_)
@@ -1749,7 +1728,6 @@ class SA342Minigun(HelicopterType):
             id = "NS430allow"
 
     livery_name = "SA342MINIGUN"  # from type
-    Liveries = Liveries()[livery_name]
 #ERRR {MINIGUN}
 
     class Pylon5:

--- a/dcs/liveries_scanner.py
+++ b/dcs/liveries_scanner.py
@@ -393,34 +393,34 @@ if __name__ == "__main__":
     # # for some reason 'Liveries' in the current scope is a different object
     #
     # f18 = FA_18C_hornet()
-    # print(f18.livery_name, sorted(f18.Liveries))
+    # print(f18.livery_name, sorted(f18.Liveries()))
     # print(f18.default_livery("CAN"))
     # print(f18.default_livery("ISR"))
     # print(f18.default_livery("USA"))
     #
     # f14 = F_14B()
-    # print(f14.livery_name, sorted(f14.Liveries))
+    # print(f14.livery_name, sorted(f14.Liveries()))
     # print(f14.default_livery("USA"))
     # print(f14.default_livery("IRN"))
     # print(f14.default_livery("GRC"))
     # print(f14.default_livery("POL"))
     #
     # f15 = F_15E()
-    # print(f15.livery_name, sorted(f15.Liveries))
+    # print(f15.livery_name, sorted(f15.Liveries()))
     # print(f15.default_livery("USA"))
     # print(f15.default_livery("ISR"))
     # print(f15.default_livery("GRC"))
     # print(f15.default_livery("POL"))
     #
     # a10c2 = A_10C_2()
-    # print(a10c2.livery_name, sorted(a10c2.Liveries))
+    # print(a10c2.livery_name, sorted(a10c2.Liveries()))
     # print(a10c2.default_livery("USA"))
     # print(a10c2.default_livery("ISR"))
     # print(a10c2.default_livery("GRC"))
     # print(a10c2.default_livery("POL"))
     #
     # f16 = F_16C_50()
-    # print(f16.livery_name, sorted(f16.Liveries))
+    # print(f16.livery_name, sorted(f16.Liveries()))
     # print(f16.default_livery("USA"))
     # print(f16.default_livery("ISR"))
     # print(f16.default_livery("GRC"))
@@ -428,14 +428,14 @@ if __name__ == "__main__":
     #
     # from helicopters import AH_64D_BLK_II
     # ah64 = AH_64D_BLK_II()
-    # print(ah64.livery_name, sorted(ah64.Liveries))
+    # print(ah64.livery_name, sorted(ah64.Liveries()))
     # print(ah64.default_livery("USA"))
     # print(ah64.default_livery("ISR"))
     #
     # print(Liveries.A_10A)
-    # print(Liveries.F_16C_50.x14th_Fighter_Squadron)
-    # print(Liveries.F_16C_50.x14th_Fighter_Squadron.order)
-    # print(Liveries.F_16C_50.x14th_Fighter_Squadron.countries)
+    # print(Liveries.F_16C_50.x_14th_Fighter_Squadron)
+    # print(Liveries.F_16C_50.x_14th_Fighter_Squadron.order)
+    # print(Liveries.F_16C_50.x_14th_Fighter_Squadron.countries)
     # print(Liveries.map[Liveries.LEOPARD_2.unit_livery_id])
     #
     # from dcs.liveries_scanner import Livery

--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -26,7 +26,6 @@ class Tornado_GR4(PlaneType):
     eplrs = True
 
     livery_name = "TORNADO GR4"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         BOZ_107___Countermeasure_Dispenser = (1, Weapons.BOZ_107___Countermeasure_Dispenser)
@@ -108,7 +107,6 @@ class Tornado_IDS(PlaneType):
     eplrs = True
 
     livery_name = "TORNADO IDS"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         BOZ_107___Countermeasure_Dispenser = (1, Weapons.BOZ_107___Countermeasure_Dispenser)
@@ -185,7 +183,6 @@ class F_A_18A(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "F_A-18A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (1, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
@@ -355,7 +352,6 @@ class F_A_18C(PlaneType):
     }
 
     livery_name = "F_A-18C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9L_Sidewinder_IR_AAM = (1, Weapons.AIM_9L_Sidewinder_IR_AAM)
@@ -559,7 +555,6 @@ class F_14A(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "F-14A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (1, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
@@ -628,7 +623,6 @@ class Tu_22M3(PlaneType):
     flare_charge_size = 1
 
     livery_name = "TU-22M3"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr = (1, Weapons.Kh_22__AS_4_Kitchen____1000kg__AShM__IN__Act_Pas_Rdr)
@@ -670,7 +664,6 @@ class F_4E(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "F-4E"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         GBU_10___2000lb_Laser_Guided_Bomb = (1, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
@@ -783,7 +776,6 @@ class B_52H(PlaneType):
     }
 
     livery_name = "B-52H"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons.MER12_with_12_x_Mk_82___500lb_GP_Bombs_LD)
@@ -824,7 +816,6 @@ class MiG_27K(PlaneType):
     flare_charge_size = 1
 
     livery_name = "MIG-27K"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon2:
         Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (2, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
@@ -924,7 +915,6 @@ class Su_27(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "SU-27"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -1157,7 +1147,6 @@ class MiG_23MLD(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "MIG-23MLD"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon2:
         R_24R__AA_7_Apex_SA____Semi_Act_Rdr = (2, Weapons.R_24R__AA_7_Apex_SA____Semi_Act_Rdr)
@@ -1252,7 +1241,6 @@ class Su_25(PlaneType):
     radio_frequency = 124
 
     livery_name = "SU-25"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -1515,7 +1503,6 @@ class Su_25TM(PlaneType):
     flare_charge_size = 1
 
     livery_name = "SU-25TM"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -1811,7 +1798,6 @@ class Su_25T(PlaneType):
     radio_frequency = 124
 
     livery_name = "SU-25T"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -2100,7 +2086,6 @@ class Su_33(PlaneType):
     radio_frequency = 124
 
     livery_name = "SU-33"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -2389,7 +2374,6 @@ class MiG_25PD(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "MIG-25PD"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_40R__AA_6_Acrid____Semi_Act_Rdr = (1, Weapons.R_40R__AA_6_Acrid____Semi_Act_Rdr)
@@ -2424,7 +2408,6 @@ class MiG_25RBT(PlaneType):
     max_speed = 3000
 
     livery_name = "MIG-25RBT"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red)
@@ -2501,7 +2484,6 @@ class Su_30(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "SU-30"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -2708,7 +2690,6 @@ class Su_17M4(PlaneType):
     flare_charge_size = 1
 
     livery_name = "SU-17M4"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         B_8M1___20_S_8OFP2 = (1, Weapons.B_8M1___20_S_8OFP2)
@@ -2897,7 +2878,6 @@ class MiG_31(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "MIG-31"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_40R__AA_6_Acrid____Semi_Act_Rdr = (1, Weapons.R_40R__AA_6_Acrid____Semi_Act_Rdr)
@@ -2942,7 +2922,6 @@ class Tu_95MS(PlaneType):
     flare_charge_size = 1
 
     livery_name = "TU-95MS"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _6_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC = (1, Weapons._6_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC)
@@ -2967,7 +2946,6 @@ class Su_24M(PlaneType):
     flare_charge_size = 1
 
     livery_name = "SU-24M"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid____Infra_Red)
@@ -3156,7 +3134,6 @@ class Su_24MR(PlaneType):
     flare_charge_size = 1
 
     livery_name = "SU-24MR"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid____Infra_Red)
@@ -3196,7 +3173,6 @@ class Tu_160(PlaneType):
     flare_charge_size = 1
 
     livery_name = "TU-160"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _6_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC = (1, Weapons._6_x_Kh_65__AS_15B_Kent____1250kg__ASM__IN__MCC)
@@ -3219,7 +3195,6 @@ class F_117A(PlaneType):
     max_speed = 1000
 
     livery_name = "F-117A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         GBU_10___2000lb_Laser_Guided_Bomb = (1, Weapons.GBU_10___2000lb_Laser_Guided_Bomb)
@@ -3261,7 +3236,6 @@ class B_1B(PlaneType):
     }
 
     livery_name = "B-1B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         MK_82_28 = (1, Weapons.MK_82_28)
@@ -3315,7 +3289,6 @@ class S_3B(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "S-3B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (1, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
@@ -3382,7 +3355,6 @@ class S_3B_Tanker(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "S-3B TANKER"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -3406,7 +3378,6 @@ class Mirage_2000_5(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "MIRAGE 2000-5"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_2_IR_AAM = (1, Weapons.R550_Magic_2_IR_AAM)
@@ -3469,7 +3440,6 @@ class F_15C(PlaneType):
     radio_frequency = 124
 
     livery_name = "F-15C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -3596,7 +3566,6 @@ class F_15E(PlaneType):
     }
 
     livery_name = "F-15E"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -3869,7 +3838,6 @@ class MiG_29A(PlaneType):
     radio_frequency = 124
 
     livery_name = "MIG-29A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -4039,7 +4007,6 @@ class MiG_29G(PlaneType):
     radio_frequency = 124
 
     livery_name = "MIG-29G"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -4209,7 +4176,6 @@ class MiG_29S(PlaneType):
     radio_frequency = 124
 
     livery_name = "MIG-29S"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_60M__AA_8_Aphid____Infra_Red = (1, Weapons.R_60M__AA_8_Aphid____Infra_Red)
@@ -4383,7 +4349,6 @@ class Tu_142(PlaneType):
     flare_charge_size = 1
 
     livery_name = "TU-142"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr = (1, Weapons._6_x_Kh_35__AS_20_Kayak____520kg__AShM__IN__Act_Rdr)
@@ -4409,7 +4374,6 @@ class C_130(PlaneType):
     flare_charge_size = 2
 
     livery_name = "C-130"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4432,7 +4396,6 @@ class An_26B(PlaneType):
     flare_charge_size = 1
 
     livery_name = "AN-26B"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4455,7 +4418,6 @@ class An_30M(PlaneType):
     flare_charge_size = 1
 
     livery_name = "AN-30M"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4478,7 +4440,6 @@ class C_17A(PlaneType):
     flare_charge_size = 2
 
     livery_name = "C-17A"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4502,7 +4463,6 @@ class A_50(PlaneType):
     category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     livery_name = "A-50"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4527,7 +4487,6 @@ class E_3A(PlaneType):
     category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     livery_name = "E-3A"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4551,7 +4510,6 @@ class IL_78M(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "IL-78M"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4576,7 +4534,6 @@ class E_2C(PlaneType):
     category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     livery_name = "E-2C"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4599,7 +4556,6 @@ class IL_76MD(PlaneType):
     flare_charge_size = 1
 
     livery_name = "IL-76MD"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -4640,7 +4596,6 @@ class F_16C_bl_50(PlaneType):
     }
 
     livery_name = "F-16C BL.50"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -4840,7 +4795,6 @@ class F_16C_bl_52d(PlaneType):
     }
 
     livery_name = "F-16C BL.52D"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -5028,7 +4982,6 @@ class F_16A(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "F-16A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -5147,7 +5100,6 @@ class F_16A_MLU(PlaneType):
     category = "Interceptor"  #{78EFB7A2-FD52-4b57-A6A6-3BF0E1D6555F}
 
     livery_name = "F-16A MLU"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_120B_AMRAAM___Active_Rdr_AAM = (1, Weapons.AIM_120B_AMRAAM___Active_Rdr_AAM)
@@ -5299,7 +5251,6 @@ class RQ_1A_Predator(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "RQ-1A PREDATOR"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AGM_114K = (1, Weapons.AGM_114K)
@@ -5323,7 +5274,6 @@ class Yak_40(PlaneType):
     max_speed = 570
 
     livery_name = "YAK-40"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -5343,7 +5293,6 @@ class KC_135(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "KC-135"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -5389,7 +5338,6 @@ class FW_190D9(PlaneType):
                 B_4_Gasoline = 2
 
     livery_name = "FW-190D9"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         FW109_FUEL_TANK = (1, Weapons.FW109_FUEL_TANK)
@@ -5447,7 +5395,6 @@ class FW_190A8(PlaneType):
                 Additional_fuel = 2
 
     livery_name = "FW-190A8"  # from type
-    Liveries = Liveries()[livery_name]
 #ERRR <CLEAN>
 
     class Pylon1:
@@ -5521,7 +5468,6 @@ class Bf_109K_4(PlaneType):
                 Flare_Gun = 1
 
     livery_name = "BF-109K-4"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         SC_501_SC500 = (1, Weapons.SC_501_SC500)
@@ -5558,7 +5504,6 @@ class SpitfireLFMkIX(PlaneType):
     }
 
     livery_name = "SPITFIRELFMKIX"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
@@ -5605,7 +5550,6 @@ class SpitfireLFMkIXCW(PlaneType):
     }
 
     livery_name = "SPITFIRELFMKIXCW"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier = (1, Weapons.British_GP_250LBS_Bomb_MK4_on_LH_Spitfire_Wing_Carrier)
@@ -5655,7 +5599,6 @@ class P_51D(PlaneType):
     }
 
     livery_name = "P-51D"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         HVAR__UnGd_Rkt = (1, Weapons.HVAR__UnGd_Rkt)
@@ -5726,7 +5669,6 @@ class P_51D_30_NA(PlaneType):
     }
 
     livery_name = "P-51D"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         HVAR__UnGd_Rkt = (1, Weapons.HVAR__UnGd_Rkt)
@@ -5811,7 +5753,6 @@ class P_47D_30(PlaneType):
                 Water = 1
 
     livery_name = "P-47D-30"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AN_M30A1___100lb_GP_Bomb_LD = (1, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -5899,7 +5840,6 @@ class P_47D_30bl1(PlaneType):
                 Water = 1
 
     livery_name = "P-47D-30"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AN_M30A1___100lb_GP_Bomb_LD = (1, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -5973,7 +5913,6 @@ class P_47D_40(PlaneType):
                 Water = 1
 
     livery_name = "P-47D-30"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AN_M30A1___100lb_GP_Bomb_LD = (1, Weapons.AN_M30A1___100lb_GP_Bomb_LD)
@@ -6119,7 +6058,6 @@ class MosquitoFBMkVI(PlaneType):
                 White = 0.05
 
     livery_name = "MOSQUITOFBMKVI"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _250_lb_GP_Mk_IV = (1, Weapons._250_lb_GP_Mk_IV)
@@ -6206,7 +6144,6 @@ class A_20G(PlaneType):
     }
 
     livery_name = "A-20G"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _4_x_AN_M64___500lb_GP_Bomb_LD = (1, Weapons._4_x_AN_M64___500lb_GP_Bomb_LD)
@@ -6245,7 +6182,6 @@ class A_10A(PlaneType):
     }
 
     livery_name = "A-10A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_105_2_AIM_9L = (1, Weapons.LAU_105_2_AIM_9L)
@@ -6549,7 +6485,6 @@ class A_10C(PlaneType):
     }
 
     livery_name = "A-10C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM = (1, Weapons.LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM)
@@ -7027,7 +6962,6 @@ class A_10C_2(PlaneType):
     }
 
     livery_name = "A-10CII"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM = (1, Weapons.LAU_105_with_2_x_AIM_9M_Sidewinder_IR_AAM)
@@ -7619,7 +7553,6 @@ class AJS37(PlaneType):
                 Disallow_cartridge_switching = 3
 
     livery_name = "AJS37"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Rb_24J__AIM_9P__Sidewinder_IR_AAM = (1, Weapons.Rb_24J__AIM_9P__Sidewinder_IR_AAM)
@@ -7946,7 +7879,6 @@ class AV8BNA(PlaneType):
             id = "AAR_Zone3"
 
     livery_name = "AV8BNA"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -8218,7 +8150,6 @@ class KC130(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "KC130"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -8243,7 +8174,6 @@ class KC135MPRS(PlaneType):
     category = "Tankers"  #{8A302789-A55D-4897-B647-66493FA6826F}
 
     livery_name = "KC135MPRS"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -8326,7 +8256,6 @@ class C_101EB(PlaneType):
             id = "SmokeOnGround"
 
     livery_name = "C-101EB"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_System__White_Smoke_ = (1, Weapons.Smoke_System__White_Smoke_)
@@ -8421,7 +8350,6 @@ class C_101CC(PlaneType):
                 Rear_seat = 2
 
     livery_name = "C-101CC"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -8520,7 +8448,6 @@ class J_11A(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "J-11A"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -8772,7 +8699,6 @@ class JF_17(PlaneType):
             id = "AARProbe"
 
     livery_name = "JF-17"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         DIS_PL_5EII = (1, Weapons.DIS_PL_5EII)
@@ -8934,7 +8860,6 @@ class KJ_2000(PlaneType):
     category = "AWACS"  #{D2BC159C-5B7D-40cf-92CD-44DF3E99FAA9}
 
     livery_name = "KJ-2000"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -8954,7 +8879,6 @@ class WingLoong_I(PlaneType):
     radio_frequency = 127.5
 
     livery_name = "WINGLOONG-I"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         DIS_AKD_10 = (1, Weapons.DIS_AKD_10)
@@ -8992,7 +8916,6 @@ class H_6J(PlaneType):
             id = "Belly Bay Door"
 
     livery_name = "H-6J"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         DIS_GDJ_YJ83K = (1, Weapons.DIS_GDJ_YJ83K)
@@ -9116,7 +9039,6 @@ class Christen_Eagle_II(PlaneType):
             id = "NS430allow"
 
     livery_name = "CHRISTEN EAGLE II"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_for_Christen_Eagle_II__white = (1, Weapons.Smoke_for_Christen_Eagle_II__white)
@@ -9247,7 +9169,6 @@ class F_16C_50(PlaneType):
                 NVG = 2
 
     livery_name = "F-16C_50"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -9520,7 +9441,6 @@ class F_5E(PlaneType):
     radio_frequency = 305
 
     livery_name = "F-5E"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -9847,7 +9767,6 @@ class F_5E_3(PlaneType):
                 x_10s = 4
 
     livery_name = "F-5E-3"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -10064,7 +9983,6 @@ class F_86F_Sabre(PlaneType):
     }
 
     livery_name = "F-86F SABRE"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Fuel_Tank_200_gallons = (1, Weapons.Fuel_Tank_200_gallons)
@@ -10269,7 +10187,6 @@ class F_14B(PlaneType):
             id = "LGB1"
 
     livery_name = "F-14B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_138_AIM_9M = (1, Weapons.LAU_138_AIM_9M)
@@ -10635,7 +10552,6 @@ class F_14A_135_GR(PlaneType):
             id = "LGB1"
 
     livery_name = "F-14A-135-GR"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_138_AIM_9M = (1, Weapons.LAU_138_AIM_9M)
@@ -10968,7 +10884,6 @@ class FA_18C_hornet(PlaneType):
                 NVG = 2
 
     livery_name = "FA-18C_HORNET"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
@@ -11355,7 +11270,6 @@ class Hawk(PlaneType):
     }
 
     livery_name = "HAWK"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LAU_7_with_AIM_9M_Sidewinder_IR_AAM = (1, Weapons.LAU_7_with_AIM_9M_Sidewinder_IR_AAM)
@@ -11421,7 +11335,6 @@ class I_16(PlaneType):
             id = "landingTorch"
 
     livery_name = "I-16"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         I16_RS_82 = (1, Weapons.I16_RS_82)
@@ -11529,7 +11442,6 @@ class L_39C(PlaneType):
             id = "DismountGunSight"
 
     livery_name = "L-39C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
@@ -11643,7 +11555,6 @@ class L_39ZA(PlaneType):
             id = "DismountIFRHood"
 
     livery_name = "L-39ZA"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
@@ -11853,7 +11764,6 @@ class M_2000C(PlaneType):
             id = "DisableVTBExport"
 
     livery_name = "M-2000C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Matra_Magic_II = (1, Weapons.Matra_Magic_II)
@@ -11997,7 +11907,6 @@ class MQ_9_Reaper(PlaneType):
     eplrs = True
 
     livery_name = "MQ-9 REAPER"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         GBU_12___500lb_Laser_Guided_Bomb = (1, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
@@ -12039,7 +11948,6 @@ class MiG_15bis(PlaneType):
     radio_frequency = 3.75
 
     livery_name = "MIG-15BIS"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         FAB_50 = (1, Weapons.FAB_50)
@@ -12119,7 +12027,6 @@ class MiG_19P(PlaneType):
                 NEAR = 2
 
     livery_name = "MIG-19P"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         K_13A = (1, Weapons.K_13A)
@@ -12208,7 +12115,6 @@ class MiG_21Bis(PlaneType):
     }
 
     livery_name = "MIG-21BIS"  # from livery_entry
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         UB_16UM___16_S_5M = (1, Weapons.UB_16UM___16_S_5M)
@@ -12517,7 +12423,6 @@ class Mirage_F1C(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1C"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -12867,7 +12772,6 @@ class Mirage_F1CE(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CE"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -13245,7 +13149,6 @@ class Mirage_F1EE(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1EE"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -13623,7 +13526,6 @@ class Mirage_F1M_EE(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1M-EE"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -13972,7 +13874,6 @@ class Mirage_F1M_CE(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1M-CE"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -14321,7 +14222,6 @@ class Mirage_F1C_200(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1C-200"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -14670,7 +14570,6 @@ class Mirage_F1EH(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1EH"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -15019,7 +14918,6 @@ class Mirage_F1CH(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CH"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -15368,7 +15266,6 @@ class Mirage_F1JA(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1JA"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -15717,7 +15614,6 @@ class Mirage_F1CG(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CG"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -16076,7 +15972,6 @@ class Mirage_F1CZ(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CZ"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -16425,7 +16320,6 @@ class Mirage_F1CJ(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CJ"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -16774,7 +16668,6 @@ class Mirage_F1CK(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CK"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -17123,7 +17016,6 @@ class Mirage_F1EQ(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1EQ"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -17491,7 +17383,6 @@ class Mirage_F1ED(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1ED"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -17859,7 +17750,6 @@ class Mirage_F1EDA(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1EDA"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -18224,7 +18114,6 @@ class Mirage_F1CR(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CR"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -18575,7 +18464,6 @@ class Mirage_F1CT(PlaneType):
             id = "LaserCode1"
 
     livery_name = "MIRAGE-F1CT"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -18871,7 +18759,6 @@ class Mirage_F1B(PlaneType):
             id = "SoloFlight"
 
     livery_name = "MIRAGE-F1B"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -19196,7 +19083,6 @@ class Mirage_F1BE(PlaneType):
             id = "SoloFlight"
 
     livery_name = "MIRAGE-F1BE"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         AIM_9B_Sidewinder_IR_AAM = (1, Weapons.AIM_9B_Sidewinder_IR_AAM)
@@ -19527,7 +19413,6 @@ class Mirage_F1BQ(PlaneType):
             id = "SoloFlight"
 
     livery_name = "MIRAGE-F1BQ"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -19848,7 +19733,6 @@ class Mirage_F1BD(PlaneType):
             id = "SoloFlight"
 
     livery_name = "MIRAGE-F1BD"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -20169,7 +20053,6 @@ class Mirage_F1DDA(PlaneType):
             id = "SoloFlight"
 
     livery_name = "MIRAGE-F1DDA"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R550_Magic_1_IR_AAM = (1, Weapons.R550_Magic_1_IR_AAM)
@@ -20357,7 +20240,6 @@ class Su_34(PlaneType):
     flare_charge_size = 1
 
     livery_name = "SU-34"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
@@ -20693,7 +20575,6 @@ class Yak_52(PlaneType):
                 Equally_Responsible = -2
 
     livery_name = "YAK-52"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         Smoke_Generator___red_ = (1, Weapons.Smoke_Generator___red_)
@@ -20726,7 +20607,6 @@ class B_17G(PlaneType):
     }
 
     livery_name = "B-17G"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         _12_AN_M64___500lb_GP_Bomb_LD = (1, Weapons._12_AN_M64___500lb_GP_Bomb_LD)
@@ -20754,7 +20634,6 @@ class Ju_88A4(PlaneType):
     }
 
     livery_name = "JU-88A4"  # from type
-    Liveries = Liveries()[livery_name]
 
     class Pylon1:
         LTF_5b_Aerial_Torpedo = (1, Weapons.LTF_5b_Aerial_Torpedo)
@@ -20803,7 +20682,6 @@ class C_47(PlaneType):
     }
 
     livery_name = "C-47"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 
@@ -20838,7 +20716,6 @@ class TF_51D(PlaneType):
     }
 
     livery_name = "TF-51D"  # from type
-    Liveries = Liveries()[livery_name]
 
     pylons: Set[int] = set()
 

--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -1,5 +1,5 @@
 import dcs.lua as lua
-from dcs.liveries_scanner import LiverySet
+from dcs.liveries_scanner import Liveries, LiverySet
 from dcs.payloads import PayloadDirectories
 import re
 import sys
@@ -84,8 +84,7 @@ class FlyingType(UnitType):
     property_defaults: Optional[Dict[str, Any]] = None
 
     pylons: Set[int] = set()
-    livery_name: Optional[str] = None
-    Liveries: LiverySet = LiverySet()
+    livery_name: str = ""  # Aircraft's liveries folder, e.g.: "A-10C II"
     # Dict from payload name to the DCS payload structure. None if not yet initialized.
     payloads: Optional[Dict[str, Dict[str, Any]]] = None
 
@@ -94,6 +93,10 @@ class FlyingType(UnitType):
 
     _payload_cache = None
     _UnitPayloadGlobals = None
+
+    @classmethod
+    def Liveries(cls) -> LiverySet:
+        return Liveries()[cls.livery_name]
 
     @classmethod
     def scan_payload_dir(cls):
@@ -173,7 +176,7 @@ class FlyingType(UnitType):
         if cls.id + "." + country_name in LiveryOverwrites.map:
             return LiveryOverwrites.map[cls.id + "." + country_name]
         else:
-            liveries = sorted(filter(lambda x: x.valid_for_country(country_name), cls.Liveries))
+            liveries = sorted(filter(lambda x: x.valid_for_country(country_name), cls.Liveries()))
             if liveries:
                 return liveries[0].id
         return ""

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -448,11 +448,9 @@ from dcs.liveries_scanner import Liveries
         if plane.livery_entry ~= nil then
             local name = string.upper(plane.livery_entry)
             writeln(file, '    livery_name = "'..name..'"  # from livery_entry')
-            writeln(file, '    Liveries = Liveries()[livery_name]')
         else if plane.type ~= nil then
             local name = string.upper(string.gsub(plane.type, '/', '_'))
             writeln(file, '    livery_name = "'..name..'"  # from type')
-            writeln(file, '    Liveries = Liveries()[livery_name]')
         end end
 
         local pylons = {}


### PR DESCRIPTION
By replacing the 'Liveries' class-variable with a class-method we can delay the the initialization of the livery scanner.
This is particularly helpful for Liberation since the livery scanner was initializing before Liberation could finish its logging setup.
Thus, none of the logging in the livery scanner would show up in Liberation's logs.

The second commit is a single line to ensure the Liveries-map is initialized before attempting to generate the stub, something I seem to have missed...