### PR TITLE
Triggers: Re-expose radius

### DIFF
--- a/dcs/triggers.py
+++ b/dcs/triggers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, List, Dict, Any
+from typing import TYPE_CHECKING, List, Dict, Any, Tuple
 from enum import Enum, IntEnum
 
 from dcs import mapping
@@ -18,8 +18,9 @@ class TriggerZoneType(IntEnum):
 
 
 class TriggerZone:
-    def __init__(self, _id, position: mapping.Point, hidden=False, name="", color=None, properties=None):
+    def __init__(self, _id, position: mapping.Point, hidden=False, name="", color=None, properties=None, radius=1500):
         self.id = _id
+        self.radius = radius
         self.position = copy.copy(position)
         self.hidden = hidden
         self.name = name
@@ -33,6 +34,7 @@ class TriggerZone:
             "x": self.position.x,
             "y": self.position.y,
             "zoneId": self.id,
+            "radius": self.radius,
             "color": self.color,
             "properties": self.properties
         }
@@ -40,14 +42,12 @@ class TriggerZone:
 
 class TriggerZoneCircular(TriggerZone):
     def __init__(self, _id, position: mapping.Point, radius=1500, hidden=False, name="", color=None, properties=None):
-        super(TriggerZoneCircular, self).__init__(_id, position, hidden, name, color, properties)
+        super(TriggerZoneCircular, self).__init__(_id, position, hidden, name, color, properties, radius)
         self.type = TriggerZoneType.Circular
-        self.radius = radius
 
     def dict(self):
         d = super(TriggerZoneCircular, self).dict()
         d["type"] = int(self.type)
-        d["radius"] = self.radius
         return d
 
     def __repr__(self):


### PR DESCRIPTION
A conversation was started in #243 explaining why this PR is needed.

In short, we need the `radius` in the base-class `TriggerZone` in order to serialize the mission correctly. The second commit adds a polymorphic method `is_point_in_zone` that returns `True` if a given point is inside the zone, `False` otherwise.

For a circular trigger zone this is pretty straight forward, but for quad-points that was a little trickier. I think I provided enough comments in the code to explain what's happening, but feel free to point out if something else is worth mentioning.