### PR TITLE
Fix runway data for some maps.

### DIFF
--- a/dcs/terrain/caucasus/airports.py
+++ b/dcs/terrain/caucasus/airports.py
@@ -18,7 +18,7 @@ class Anapa_Vityazevo(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-5412.409668, 243128.820313, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=1, name='22-04', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-4829.5249882422, 244622.06661236, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='40', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -309,7 +309,7 @@ class Krasnodar_Center(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(11685.205078, 367933.515625, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=1, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(10890.094726563, 368483.28125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='54', length=26.0, width=22.0, height=8.0, shelter=False))
@@ -492,7 +492,7 @@ class Novorossiysk(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-40917.535156, 279256.0625, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=1, name='22-04', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-40106.0234375, 279575.75, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='09', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -621,7 +621,7 @@ class Krymsk(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-6576.524658, 294388.125, terrain), terrain)
 
-        self.runways.append(Runway(220))
+        self.runways.append(Runway(id=1, name='04-22', heading=40, opposite_heading=220))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-6138.9926757813, 295188.6875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='53', length=26.0, width=22.0, height=8.0, shelter=False))
@@ -807,7 +807,7 @@ class Maykop_Khanskaya(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-26437.275391, 458048.84375, terrain), terrain)
 
-        self.runways.append(Runway(220))
+        self.runways.append(Runway(id=1, name='04-22', heading=40, opposite_heading=220))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-26260.4609375, 459009.125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='53', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -993,7 +993,7 @@ class Gelendzhik(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-50378.611328, 298406.15625, terrain), terrain)
 
-        self.runways.append(Runway(190))
+        self.runways.append(Runway(id=1, name='01-19', heading=10, opposite_heading=190))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-50574.20703125, 298005.59375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=20.5, width=18.0, height=11.0, shelter=False))
@@ -1047,7 +1047,7 @@ class Sochi_Adler(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-164496.46875, 462218.921875, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=1, name='06-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-164362.125, 463237.3125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='55', length=26.0, width=22.0, height=8.0, shelter=False))
@@ -1266,7 +1266,7 @@ class Krasnodar_Pashkovsky(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(7717.637452, 387878.803876, terrain), terrain)
 
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=1, name='23L-05R', heading=230, opposite_heading=50))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(8852.1181640625, 388779.3125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='19', length=43.057953, width=40.0, height=None, shelter=False))
@@ -1338,7 +1338,7 @@ class Sukhumi_Babushara(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-220592.328125, 564391.96875, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-219883.625, 563502.8125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='23', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1422,7 +1422,7 @@ class Gudauta(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-196710.085938, 516451.6875, terrain), terrain)
 
-        self.runways.append(Runway(330))
+        self.runways.append(Runway(id=1, name='15-33', heading=150, opposite_heading=330))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-196497.375, 515476.09375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='11', length=26.0, width=22.0, height=8.0, shelter=False))
@@ -1530,7 +1530,7 @@ class Batumi(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-355810.6875, 617386.1875, terrain), terrain)
 
-        self.runways.append(Runway(130))
+        self.runways.append(Runway(id=1, name='31-13', heading=310, opposite_heading=130))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-356069.625, 618234.9375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='06', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1575,7 +1575,7 @@ class Senaki_Kolkhi(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-281782.46875, 647279.46875, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=1, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-281607.28417614, 646373.17498617, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1794,7 +1794,7 @@ class Kobuleti(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-317962.296875, 635632.96875, terrain), terrain)
 
-        self.runways.append(Runway(70))
+        self.runways.append(Runway(id=1, name='25-07', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-317882.375, 635012.9375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='42', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1935,7 +1935,7 @@ class Kutaisi(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-284887.375, 683858.71875, terrain), terrain)
 
-        self.runways.append(Runway(70))
+        self.runways.append(Runway(id=1, name='25-07', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-284604.8125, 682356.25, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='16', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -2124,7 +2124,7 @@ class Mineralnye_Vody(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-51259.983985, 705734.026899, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-52132.26171875, 706676.875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='28', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -2223,7 +2223,7 @@ class Nalchik(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-124932.167279, 760421.182617, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=1, name='06-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-125485.39736555, 760349.87924914, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='14', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -2283,7 +2283,7 @@ class Mozdok(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-83450.417969, 834461.78125, terrain), terrain)
 
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=1, name='26-08', heading=260, opposite_heading=80))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-84047.34375, 833973.125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -2415,7 +2415,7 @@ class Tbilisi_Lochini(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-315671.078125, 896629.78125, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=1, name='13R-31L', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-315166.34375, 897212.5, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='36', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -2652,7 +2652,7 @@ class Soganlug(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-317828.046875, 895407.1875, terrain), terrain)
 
-        self.runways.append(Runway(320))
+        self.runways.append(Runway(id=1, name='14-32', heading=140, opposite_heading=320))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-318023.51732654, 895394.57452592, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='03', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -2682,7 +2682,7 @@ class Vaziani(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-319064.875, 903148.53125, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=1, name='13R-31L', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-318059.6875, 902639.0625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='10', length=26.0, width=22.0, height=8.0, shelter=False))
@@ -2973,7 +2973,7 @@ class Beslan(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-148590.171875, 843668.625, terrain), terrain)
 
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-148875.828125, 844108.375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='15', length=43.057953, width=40.0, height=None, shelter=False))

--- a/dcs/terrain/falklands/airports.py
+++ b/dcs/terrain/falklands/airports.py
@@ -18,7 +18,7 @@ class Port_Stanley(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(89025.222656, 93868.265625, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=1, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(88872.890625, 93596.390625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -81,8 +81,8 @@ class Mount_Pleasant(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(73318.320313, 47168.748047, terrain), terrain)
 
-        self.runways.append(Runway(280))
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=2, name='23-05', heading=230, opposite_heading=50))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(73289.8359375, 46269.83984375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='E01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -208,7 +208,7 @@ class San_Carlos_FOB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(107939.375, 8484.390625, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=1, name='11-27', heading=110, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(107926.41685133, 8629.698241451, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='01', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -262,7 +262,7 @@ class Rio_Gallegos(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(25718.329375, -703408.191242, terrain), terrain)
 
-        self.runways.append(Runway(70))
+        self.runways.append(Runway(id=1, name='25-07', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(26473.5, -701737.125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='F01', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -349,7 +349,7 @@ class Rio_Grande(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-197144.468784, -559487.57478, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-197547.51280997, -559618.60822941, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='B01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -385,7 +385,7 @@ class Ushuaia(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-320586.703125, -576144.78125, terrain), terrain)
 
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=1, name='07-25', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-320280.0625, -576962.3125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -424,7 +424,7 @@ class Ushuaia_Helo_Port(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-318409.578125, -577046.9375, terrain), terrain)
 
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=1, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-317890.73417401, -577297.15930203, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='H06', length=42.0, width=34.0, height=14.0, shelter=False))
@@ -463,9 +463,9 @@ class Punta_Arenas(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-147785.300936, -779608.568689, terrain), terrain)
 
-        self.runways.append(Runway(120))
-        self.runways.append(Runway(80))
-        self.runways.append(Runway(10))
+        self.runways.append(Runway(id=1, name='25-8', heading=250, opposite_heading=80))
+        self.runways.append(Runway(id=3, name='19-01', heading=190, opposite_heading=10))
+        self.runways.append(Runway(id=2, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=6, position=mapping.Point(-148739.765625, -778607, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='QRF01', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -630,7 +630,7 @@ class Pampa_Guanaco(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-238408.351563, -623774.96875, terrain), terrain)
 
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=1, name='26-08', heading=260, opposite_heading=80))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-238432.22280699, -623479.90424008, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -651,7 +651,7 @@ class San_Julian(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(297477.765625, -636918.15625, terrain), terrain)
 
-        self.runways.append(Runway(70))
+        self.runways.append(Runway(id=1, name='25-07', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(298061.05416072, -636079.75084617, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='F05', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -693,7 +693,7 @@ class Puerto_Williams(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-323519.353789, -531926.173104, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-323574.27915013, -531349.32468435, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -723,7 +723,7 @@ class Puerto_Natales(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-24058.357422, -923008.125, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=1, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-23851.2734375, -923026.375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -750,7 +750,7 @@ class El_Calafate(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(136356.9375, -922477.96875, terrain), terrain)
 
-        self.runways.append(Runway(70))
+        self.runways.append(Runway(id=1, name='25-07', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(135948.5625, -922618.875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H01', length=60.0, width=52.0, height=18.0, shelter=False))

--- a/dcs/terrain/marianaislands/airports.py
+++ b/dcs/terrain/marianaislands/airports.py
@@ -18,7 +18,7 @@ class Rota_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(75884.859375, 48589.876953, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='9-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(75707.6015625, 49014.63671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='05', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -60,7 +60,7 @@ class Saipan_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(180035.4375, 101855.960938, terrain), terrain)
 
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=1, name='07-25', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=3, position=mapping.Point(180180.15625, 101120.2890625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=60.0, width=60.0, height=18.0, shelter=False))
@@ -132,7 +132,7 @@ class Tinian_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(166859.859375, 89956.625, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=2, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(166417.98813301, 90821.756445869, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=60.0, width=60.0, height=18.0, shelter=False))
@@ -159,8 +159,8 @@ class Antonio_B__Won_Pat_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-23.656158, -77.940308, terrain), terrain)
 
-        self.runways.append(Runway(240))
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=2, name='06R-24L', heading=60, opposite_heading=240))
+        self.runways.append(Runway(id=1, name='06L-24R', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(624.08526611328, 668.80841064453, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=60.0, width=60.0, height=18.0, shelter=False))
@@ -244,8 +244,8 @@ class Andersen_AFB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(10574.989746, 14548.833496, terrain), terrain)
 
-        self.runways.append(Runway(240))
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=1, name='06L-24R', heading=60, opposite_heading=240))
+        self.runways.append(Runway(id=2, name='06R-24L', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(9766.2216796875, 13546.32421875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='23', length=40.0, width=40.0, height=12.0, shelter=False))

--- a/dcs/terrain/nevada/airports.py
+++ b/dcs/terrain/nevada/airports.py
@@ -18,8 +18,8 @@ class Creech(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-360507.203125, -75590.070313, terrain), terrain)
 
-        self.runways.append(Runway(260))
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=2, name='13-31', heading=130, opposite_heading=310))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-359540.25, -74552.5390625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='D15', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -187,7 +187,7 @@ class Groom_Lake(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-288604.671875, -86870.445313, terrain), terrain)
 
-        self.runways.append(Runway(140))
+        self.runways.append(Runway(id=1, name='32-14', heading=320, opposite_heading=140))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-287726.5625, -88658.625, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='H04', length=42.0, width=34.0, height=14.0, shelter=False))
@@ -358,8 +358,8 @@ class McCarran_International(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-416011.359375, -26929.336914, terrain), terrain)
 
-        self.runways.append(Runway(250))
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=1, name='7R-25L', heading=70, opposite_heading=250))
+        self.runways.append(Runway(id=2, name='7L-25R', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-415461.59375, -25559.572265625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='04', length=39.857483, width=40.0, height=18.0, shelter=False))
@@ -419,8 +419,8 @@ class Nellis(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-398195.375, -17233.236816, terrain), terrain)
 
-        self.runways.append(Runway(210))
-        self.runways.append(Runway(210))
+        self.runways.append(Runway(id=1, name='03L-21R', heading=30, opposite_heading=210))
+        self.runways.append(Runway(id=2, name='03R-21L', heading=30, opposite_heading=210))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-399382, -19269.263671875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='F164', length=23.076286, width=14.5, height=8.0, shelter=False))
@@ -1176,7 +1176,7 @@ class Beatty(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-330553.625, -174958.53125, terrain), terrain)
 
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=1, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-329737.78125, -174776.515625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1200,8 +1200,8 @@ class Boulder_City(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-429660.09375, -1148.724518, terrain), terrain)
 
-        self.runways.append(Runway(150))
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=1, name='27L-9', heading=270, opposite_heading=90))
+        self.runways.append(Runway(id=1, name='33-15', heading=330, opposite_heading=150))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-429671, -475.66937255859, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='B03', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1327,7 +1327,7 @@ class Echo_Bay(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-388592.34375, 33697.310547, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=1, name='6-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-388552.3125, 33604.30078125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H02', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -1348,8 +1348,8 @@ class Henderson_Executive(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-427352.71875, -25668.716797, terrain), terrain)
 
-        self.runways.append(Runway(170))
-        self.runways.append(Runway(170))
+        self.runways.append(Runway(id=1, name='35L-17R', heading=350, opposite_heading=170))
+        self.runways.append(Runway(id=2, name='35R-17L', heading=350, opposite_heading=170))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-428026.78125, -26065.75, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H02', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1493,8 +1493,8 @@ class Jean(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-450392.859375, -43000.460938, terrain), terrain)
 
-        self.runways.append(Runway(20))
-        self.runways.append(Runway(20))
+        self.runways.append(Runway(id=1, name='20L-2R', heading=200, opposite_heading=20))
+        self.runways.append(Runway(id=2, name='20R-2L', heading=200, opposite_heading=20))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(-450104.78125, -42994.28515625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='A01', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1521,7 +1521,7 @@ class Laughlin(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-516946.421875, 28306.30957, terrain), terrain)
 
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=1, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-516446.90625, 28580.93359375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='A02', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1584,7 +1584,7 @@ class Lincoln_County(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-224670.351563, 33199.935547, terrain), terrain)
 
-        self.runways.append(Runway(350))
+        self.runways.append(Runway(id=1, name='17-35', heading=170, opposite_heading=350))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-224143.265625, 33338.26953125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1617,7 +1617,7 @@ class Mesquite(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-329622.09375, 68561.148438, terrain), terrain)
 
-        self.runways.append(Runway(190))
+        self.runways.append(Runway(id=1, name='1-19', heading=10, opposite_heading=190))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-329683.28125, 68345.796875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='A10', length=22.727446, width=18.0, height=6.0, shelter=False))
@@ -1665,7 +1665,7 @@ class Mina(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-161504.46875, -289784.765625, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=1, name='13-31', heading=130, opposite_heading=310))
 
 
 class North_Las_Vegas(Airport):
@@ -1680,9 +1680,9 @@ class North_Las_Vegas(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-400891.484375, -31726.952148, terrain), terrain)
 
-        self.runways.append(Runway(70))
-        self.runways.append(Runway(120))
-        self.runways.append(Runway(300))
+        self.runways.append(Runway(id=1, name='30L-12R', heading=300, opposite_heading=120))
+        self.runways.append(Runway(id=2, name='12L-30R', heading=120, opposite_heading=300))
+        self.runways.append(Runway(id=3, name='25-7', heading=250, opposite_heading=70))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-401630.4375, -32211.359375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='B17', length=22.727446, width=18.0, height=6.0, shelter=False))
@@ -1838,7 +1838,7 @@ class Pahute_Mesa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-303620, -132937.929688, terrain), terrain)
 
-        self.runways.append(Runway(180))
+        self.runways.append(Runway(id=1, name='36-18', heading=360, opposite_heading=180))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-303524.92167696, -133026.1164952, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='05', length=30.5, width=20.5, height=6.0, shelter=False))
@@ -1868,8 +1868,8 @@ class Tonopah(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-197282.898438, -201302.882813, terrain), terrain)
 
-        self.runways.append(Runway(110))
-        self.runways.append(Runway(150))
+        self.runways.append(Runway(id=1, name='33-15', heading=330, opposite_heading=150))
+        self.runways.append(Runway(id=2, name='29-11', heading=290, opposite_heading=110))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(-198277.78125, -202084.4375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='A01', length=39.857483, width=40.0, height=18.0, shelter=False))
@@ -1959,7 +1959,7 @@ class Tonopah_Test_Range(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-226505.273438, -174698.484375, terrain), terrain)
 
-        self.runways.append(Runway(140))
+        self.runways.append(Runway(id=1, name='32-14', heading=320, opposite_heading=140))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-225679.28125, -174488.90625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='D14', length=78.722809, width=67.096466, height=18.0, shelter=False))

--- a/dcs/terrain/normandy/airports.py
+++ b/dcs/terrain/normandy/airports.py
@@ -18,7 +18,7 @@ class Saint_Pierre_du_Mont(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-11938.055664, -47277.988281, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-9', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-11861.235351563, -46465.25390625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='63', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -384,7 +384,7 @@ class Lignerolles(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-35526.060547, -34407.238281, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-35437.69140625, -35072.56640625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='32', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -597,7 +597,7 @@ class Cretteville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-18675.582031, -77791.164063, terrain), terrain)
 
-        self.runways.append(Runway(130))
+        self.runways.append(Runway(id=None, name='31-13', heading=310, opposite_heading=130))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-19256.740234375, -77253.203125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='39', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -780,7 +780,7 @@ class Maupertus(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(16010.684042, -84863.223212, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(15957.225585938, -84030.5546875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=39.857483, width=42.0, height=13.0, shelter=False))
@@ -816,7 +816,7 @@ class Brucheville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-14857.000488, -66027.34375, terrain), terrain)
 
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=None, name='7-25', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-14501.358398438, -65514.94921875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='90', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -1152,7 +1152,7 @@ class Meautis(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-24484.185547, -71902.113281, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=None, name='8-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-24512.439453125, -71203.234375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='45', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -1305,7 +1305,7 @@ class Cricqueville_en_Bessin(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-14917.461426, -50815.857422, terrain), terrain)
 
-        self.runways.append(Runway(350))
+        self.runways.append(Runway(id=None, name='17-35', heading=170, opposite_heading=350))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-15036.99609375, -51188.1875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='28', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -1539,8 +1539,8 @@ class Lessay(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-33862.595703, -86418.007813, terrain), terrain)
 
-        self.runways.append(Runway(60))
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=None, name='30-12', heading=300, opposite_heading=120))
+        self.runways.append(Runway(id=None, name='24-6', heading=240, opposite_heading=60))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-33662.57421875, -86710.5703125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='28', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -1726,7 +1726,7 @@ class Sainte_Laurent_sur_Mer(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-14665.532227, -41130.955078, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-14792.571289063, -40413.9765625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='36', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -1867,7 +1867,7 @@ class Biniville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-7680.428545, -84526.999232, terrain), terrain)
 
-        self.runways.append(Runway(320))
+        self.runways.append(Runway(id=None, name='14-32', heading=140, opposite_heading=320))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-8033.611328125, -84135.671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -1978,7 +1978,7 @@ class Cardonville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-16508.699707, -53979.537109, terrain), terrain)
 
-        self.runways.append(Runway(150))
+        self.runways.append(Runway(id=None, name='33-15', heading=330, opposite_heading=150))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-15586.537109375, -54800.81640625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='61', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -2341,7 +2341,7 @@ class Deux_Jumeaux(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-16784.448242, -48871.496094, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-16293.255859375, -48417.40234375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='23', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -2674,7 +2674,7 @@ class Chippelle(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-28484.011719, -47891.75, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=None, name='6-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-27995.6875, -47895.3359375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='07', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -2803,7 +2803,7 @@ class Beuzeville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-9213.708321, -72131.675455, terrain), terrain)
 
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=None, name='5-23', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-9549.2371128719, -72743.202755871, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='35', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -2926,7 +2926,7 @@ class Azeville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-2525.192392, -73664.185534, terrain), terrain)
 
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=None, name='7-25', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-2123.7131347656, -73153.453125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='15', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3034,7 +3034,7 @@ class Picauville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-12078.898926, -80241.097656, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-11705.821289063, -80830.46875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='35', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3157,7 +3157,7 @@ class Le_Molay(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-26123.464844, -41403.646484, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-4', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-25710.234375, -40841.69921875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='35', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3280,7 +3280,7 @@ class Longues_sur_Mer(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-16733.196289, -28909.375977, terrain), terrain)
 
-        self.runways.append(Runway(300))
+        self.runways.append(Runway(id=None, name='12-30', heading=120, opposite_heading=300))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-16807.962890625, -28363.375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='55', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3433,7 +3433,7 @@ class Carpiquet(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-34782.396484, -9983.634766, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=None, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-34197.03515625, -9833.6513671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='37', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3589,7 +3589,7 @@ class Bazenville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-20712.899414, -18498.402344, terrain), terrain)
 
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=None, name='5-23', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-20335.234375, -18316.857421875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='13', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3784,7 +3784,7 @@ class Sainte_Croix_sur_Mer(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-18787.417239, -15106.744633, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-9', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-18935.797506538, -14425.181352241, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='35', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -3907,7 +3907,7 @@ class Beny_sur_Mer(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-21040.570313, -8437.482422, terrain), terrain)
 
-        self.runways.append(Runway(170))
+        self.runways.append(Runway(id=None, name='35-17', heading=350, opposite_heading=170))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-20698.400390625, -8236.490234375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='60', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -4069,7 +4069,7 @@ class Rucqueville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-26589.313477, -19444.007813, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-9', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-26680.033203125, -20166.484375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='36', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -4204,7 +4204,7 @@ class Sommervieu(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-21371.758789, -26206.679688, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='9-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-21503.513671875, -25766.630859375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='24', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -4291,7 +4291,7 @@ class Lantheuil(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-24264.160156, -16467.212402, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=None, name='6-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-24663.552734375, -16906.71875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='72', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -4504,8 +4504,8 @@ class Evreux(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-45898.34375, 112233.773438, terrain), terrain)
 
-        self.runways.append(Runway(160))
-        self.runways.append(Runway(30))
+        self.runways.append(Runway(id=None, name='21-3', heading=210, opposite_heading=30))
+        self.runways.append(Runway(id=None, name='34-16', heading=340, opposite_heading=160))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-46294.63671875, 112935.03125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='24', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -4592,8 +4592,8 @@ class Chailey(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(163729.554688, 11866.79248, terrain), terrain)
 
-        self.runways.append(Runway(170))
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=None, name='5-23', heading=50, opposite_heading=230))
+        self.runways.append(Runway(id=None, name='35-17', heading=350, opposite_heading=170))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(163935.828125, 12154.985351562, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='28', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -4779,8 +4779,8 @@ class Needs_Oar_Point(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(141296.390625, -84372.234375, terrain), terrain)
 
-        self.runways.append(Runway(340))
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=None, name='23-5', heading=230, opposite_heading=50))
+        self.runways.append(Runway(id=None, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(141049.53125, -84626.5390625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='28', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -4966,8 +4966,8 @@ class Funtington(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(152367.835938, -45975.689453, terrain), terrain)
 
-        self.runways.append(Runway(190))
-        self.runways.append(Runway(250))
+        self.runways.append(Runway(id=None, name='7-25', heading=70, opposite_heading=250))
+        self.runways.append(Runway(id=None, name='1-19', heading=10, opposite_heading=190))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(152473.796875, -45637.49609375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='28', length=26.0, width=24.0, height=7.0, shelter=False))
@@ -5150,8 +5150,8 @@ class Tangmere(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(150158.65625, -33957.914063, terrain), terrain)
 
-        self.runways.append(Runway(290))
-        self.runways.append(Runway(60))
+        self.runways.append(Runway(id=None, name='24-6', heading=240, opposite_heading=60))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(149939.671875, -33095.33984375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='19', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5226,8 +5226,8 @@ class Ford_AF(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(147498.585938, -25722.724609, terrain), terrain)
 
-        self.runways.append(Runway(270))
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-4', heading=220, opposite_heading=40))
+        self.runways.append(Runway(id=None, name='9-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(147609.515625, -24839.732421875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='19', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5302,7 +5302,7 @@ class Argentan(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-78808.039063, 22665.379883, terrain), terrain)
 
-        self.runways.append(Runway(300))
+        self.runways.append(Runway(id=None, name='12-30', heading=120, opposite_heading=300))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-78984.9453125, 23166.23046875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5413,7 +5413,7 @@ class Goulet(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-81156.757813, 16794.293945, terrain), terrain)
 
-        self.runways.append(Runway(30))
+        self.runways.append(Runway(id=None, name='21-3', heading=210, opposite_heading=30))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-81659.4765625, 16622.775390625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5524,8 +5524,8 @@ class Barville(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-109934.789063, 49091.34375, terrain), terrain)
 
-        self.runways.append(Runway(100))
-        self.runways.append(Runway(330))
+        self.runways.append(Runway(id=None, name='15-33', heading=150, opposite_heading=330))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-109506.859375, 49616.75, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='24', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5591,7 +5591,7 @@ class Essay(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-105527.957031, 45008.003906, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='9-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-105499.4375, 45538.40234375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5702,7 +5702,7 @@ class Hauterive(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-107997.585938, 40856.037109, terrain), terrain)
 
-        self.runways.append(Runway(140))
+        self.runways.append(Runway(id=None, name='32-14', heading=320, opposite_heading=140))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-107626.625, 40475.87109375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5813,7 +5813,7 @@ class Vrigny(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-89449.566406, 25165.529297, terrain), terrain)
 
-        self.runways.append(Runway(140))
+        self.runways.append(Runway(id=None, name='32-14', heading=320, opposite_heading=140))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-89126.6328125, 24743.80078125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=16.0, width=16.0, height=6.0, shelter=False))
@@ -5924,7 +5924,7 @@ class Conches(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-57019.595703, 94577.890625, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-4', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-57231.17578125, 95025.9140625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='05', length=24.0, width=33.0, height=7.0, shelter=False))

--- a/dcs/terrain/persiangulf/airports.py
+++ b/dcs/terrain/persiangulf/airports.py
@@ -18,7 +18,7 @@ class Abu_Musa_Island(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-31505.274308, -121335.307759, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-31265.763702393, -121984.875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -57,7 +57,7 @@ class Bandar_Abbas_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(115765.882813, 14257.968262, terrain), terrain)
 
-        self.runways.append(Runway(210))
+        self.runways.append(Runway(id=1, name='03R-21L', heading=30, opposite_heading=210))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(117866.46875, 15125.918945312, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='H06', length=25.0, width=20.0, height=11.0, shelter=False))
@@ -222,7 +222,7 @@ class Bandar_Lengeh(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(41536.408234, -140987.327942, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(41385.64441061, -140533.0625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='05', length=20.5, width=18.0, height=11.0, shelter=False))
@@ -252,8 +252,8 @@ class Al_Dhafra_AFB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-211027.78125, -173240.007813, terrain), terrain)
 
-        self.runways.append(Runway(310))
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=2, name='13R-31L', heading=130, opposite_heading=310))
+        self.runways.append(Runway(id=1, name='13L-31R', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-210753.59375, -174987.828125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='101', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -1018,8 +1018,8 @@ class Dubai_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-100594.371094, -88875.371094, terrain), terrain)
 
-        self.runways.append(Runway(120))
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30L-12R', heading=300, opposite_heading=120))
+        self.runways.append(Runway(id=2, name='30R-12L', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=3, position=mapping.Point(-101536.4765625, -88944.609375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='21', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1322,7 +1322,7 @@ class Al_Maktoum_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-140127.671875, -110068.890625, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-140247.46875, -111218.859375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='14', length=42.0, width=34.0, height=14.0, shelter=False))
@@ -1544,7 +1544,7 @@ class Fujairah_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-117531.972946, 7939.275818, terrain), terrain)
 
-        self.runways.append(Runway(110))
+        self.runways.append(Runway(id=1, name='29-11', heading=290, opposite_heading=110))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-117293.855896, 8304.8382568359, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -1571,7 +1571,7 @@ class Tunb_Island_AFB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(10515.440918, -92440.328125, terrain), terrain)
 
-        self.runways.append(Runway(210))
+        self.runways.append(Runway(id=1, name='03-21', heading=30, opposite_heading=210))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(10327.60546875, -92808.609375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='03', length=20.5, width=18.0, height=11.0, shelter=False))
@@ -1598,7 +1598,7 @@ class Havadarya(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(109297.824219, -6278.723145, terrain), terrain)
 
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=1, name='26-08', heading=260, opposite_heading=80))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(109336.5078125, -6856.7319335937, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='11', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -1679,7 +1679,7 @@ class Khasab(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-219.726892, -177.707709, terrain), terrain)
 
-        self.runways.append(Runway(10))
+        self.runways.append(Runway(id=1, name='19-01', heading=190, opposite_heading=10))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-1017.2598266602, -602.64483642578, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -1730,7 +1730,7 @@ class Lar(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(168977.578922, -182359.639734, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=1, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(168556.390625, -182527.234375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -1760,7 +1760,7 @@ class Al_Minhad_AFB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-126013.714844, -89133.46875, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=1, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-126253.0859375, -89660.171875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='23', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -1961,7 +1961,7 @@ class Qeshm_Island(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(64800.714844, -33383.481445, terrain), terrain)
 
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=1, name='23-05', heading=230, opposite_heading=50))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(65148.21875, -33696.6328125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='09', length=43.057953, width=40.0, height=None, shelter=False))
@@ -2012,8 +2012,8 @@ class Sharjah_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-92544.089844, -73373.601563, terrain), terrain)
 
-        self.runways.append(Runway(120))
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30L-12R', heading=300, opposite_heading=120))
+        self.runways.append(Runway(id=2, name='30R-12L', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(-93511.0078125, -72815.6015625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='46', length=43.057953, width=40.0, height=None, shelter=False))
@@ -2169,7 +2169,7 @@ class Sirri_Island(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-26946.104553, -170745.015625, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-27713.302612305, -170052.375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -2190,7 +2190,7 @@ class Tunb_Kochak(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(9023.430176, -109467.078125, terrain), terrain)
 
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=1, name='26-08', heading=260, opposite_heading=80))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(8992.48046875, -109345.625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='01', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -2211,7 +2211,7 @@ class Sir_Abu_Nuayr(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-103102.871094, -202973.078125, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-103019.671875, -203136.546875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=25.0, width=20.0, height=11.0, shelter=False))
@@ -2238,7 +2238,7 @@ class Kerman(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(454116.796875, 71096.085938, terrain), terrain)
 
-        self.runways.append(Runway(160))
+        self.runways.append(Runway(id=1, name='34-16', heading=340, opposite_heading=160))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(452845.03125, 71861.46875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='09', length=43.057953, width=40.0, height=None, shelter=False))
@@ -2379,8 +2379,8 @@ class Shiraz_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(381101.03125, -351636.515625, terrain), terrain)
 
-        self.runways.append(Runway(110))
-        self.runways.append(Runway(110))
+        self.runways.append(Runway(id=1, name='29L-11R', heading=290, opposite_heading=110))
+        self.runways.append(Runway(id=1, name='29R-11L', heading=290, opposite_heading=110))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(379150.96875, -350239.96875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='E06', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -2752,7 +2752,7 @@ class Sas_Al_Nakheel(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-189610.296875, -175974.140625, terrain), terrain)
 
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=None, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-189181.9375, -176242.109375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='23', length=30.096436, width=23.0, height=10.0, shelter=False))
@@ -3028,7 +3028,7 @@ class Bandar_e_Jask(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-57247.5, 156196.507813, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=None, name='6-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-57597.375, 154792.71875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='02', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -3055,9 +3055,9 @@ class Abu_Dhabi_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-188457.460938, -162030.984375, terrain), terrain)
 
-        self.runways.append(Runway(310))
-        self.runways.append(Runway(130))
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=None, name='31-13', heading=310, opposite_heading=130))
+        self.runways.append(Runway(id=None, name='13-31', heading=130, opposite_heading=310))
+        self.runways.append(Runway(id=None, name='13-31', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-189270.15625, -164756.421875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='16', length=78.722809, width=67.096466, height=18.0, shelter=False))
@@ -3450,7 +3450,7 @@ class Al_Bateen(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-190946.55263, -181928.271658, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=None, name='13-31', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-190337.921875, -183074.21875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='11', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -3609,8 +3609,8 @@ class Kish_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(42784.291016, -225094.046875, terrain), terrain)
 
-        self.runways.append(Runway(280))
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=None, name='10-28', heading=100, opposite_heading=280))
+        self.runways.append(Runway(id=None, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(43106.234375, -226229.578125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=43.057953, width=40.0, height=None, shelter=False))
@@ -3763,7 +3763,7 @@ class Al_Ain_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-211058.15625, -65421.177734, terrain), terrain)
 
-        self.runways.append(Runway(10))
+        self.runways.append(Runway(id=None, name='19-1', heading=190, opposite_heading=10))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-209643.34375, -64532.62890625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='6', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -4000,7 +4000,7 @@ class Lavan_Island(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(75789.741687, -286801.46313, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(75569.2578125, -286948.1875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='03', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -4024,7 +4024,7 @@ class Jiroft(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(282607.962896, 141685.262108, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=None, name='13-31', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(282949.9375, 141762.96875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='02', length=20.5, width=14.5, height=11.0, shelter=False))
@@ -4048,7 +4048,7 @@ class Ras_Al_Khaimah_Intl(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-61624.488064, -30795.647521, terrain), terrain)
 
-        self.runways.append(Runway(170))
+        self.runways.append(Runway(id=None, name='35-17', heading=350, opposite_heading=170))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-61266.6328125, -30535.677734375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='12', length=43.057953, width=40.0, height=None, shelter=False))
@@ -4117,7 +4117,7 @@ class Liwa_AFB(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-275765.53125, -248213.578125, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=None, name='13-31', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-275178.9375, -249924.1875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='05', length=43.057953, width=40.0, height=None, shelter=False))

--- a/dcs/terrain/syria/airports.py
+++ b/dcs/terrain/syria/airports.py
@@ -18,7 +18,7 @@ class Abu_al_Duhur(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(76048.957031, 111344.925781, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(76278.421875, 112793.0546875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='26', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -141,7 +141,7 @@ class Adana_Sakirpasa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(219468.65625, -48332.732422, terrain), terrain)
 
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=1, name='23-05', heading=230, opposite_heading=50))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(219900.59375, -46846.515625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='A02', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -273,7 +273,7 @@ class Al_Qusayr(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-51906.964844, 60013.205078, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-52056.5390625, 61770.86328125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='12', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -390,7 +390,7 @@ class An_Nasiriyah(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-124683.738281, 85510.820313, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-04', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-123598.528425, 86827.54997916, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='16', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -465,7 +465,7 @@ class Tha_lah(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-258434.929688, 40368.677734, terrain), terrain)
 
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=1, name='05R-23L', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-259523.38051049, 39014.499141368, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='15', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -528,9 +528,9 @@ class Beirut_Rafic_Hariri(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-131310.8125, -42286.496094, terrain), terrain)
 
-        self.runways.append(Runway(350))
-        self.runways.append(Runway(210))
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=3, name='03-21', heading=30, opposite_heading=210))
+        self.runways.append(Runway(id=1, name='16-34', heading=160, opposite_heading=340))
+        self.runways.append(Runway(id=2, name='17-35', heading=170, opposite_heading=350))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=6, position=mapping.Point(-131575.125, -41971.7890625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='G20', length=60.0, width=52.0, height=18.0, shelter=False))
@@ -668,8 +668,8 @@ class Damascus(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-178652.320313, 52081.296875, terrain), terrain)
 
-        self.runways.append(Runway(230))
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=2, name='05R-23L', heading=50, opposite_heading=230))
+        self.runways.append(Runway(id=1, name='05L-23R', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-182103.921875, 50133.484375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='027', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -897,7 +897,7 @@ class Marj_as_Sultan_South(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-171711.336701, 48243.74032, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-171652.453125, 48101.5703125, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='09', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -972,7 +972,7 @@ class Al_Dumayr(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-158713.039063, 73973.316406, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=None, name='06-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-158242.609375, 75715.703125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='43', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -1158,7 +1158,7 @@ class Eyn_Shemer(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-283538.6875, -92619.707031, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-283520.1875, -92408.5234375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='04', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -1188,7 +1188,7 @@ class Gaziantep(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(210314.796875, 147379.28125, terrain), terrain)
 
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=None, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(210293.453125, 146533.125, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='11', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -1239,7 +1239,7 @@ class H4(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-279366.765625, 207219.265625, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-279326.53125, 205884.96875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='02', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -1290,7 +1290,7 @@ class Haifa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-242620.8125, -87704.417969, terrain), terrain)
 
-        self.runways.append(Runway(160))
+        self.runways.append(Runway(id=1, name='34-16', heading=340, opposite_heading=160))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-242230.96875, -87918.015625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='G5', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -1353,7 +1353,7 @@ class Hama(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(8662.594238, 74333.1875, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(8969.19140625, 73061.1796875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='08', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -1506,7 +1506,7 @@ class Hatay(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(147687.484375, 39418.742188, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-04', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(147685.390625, 38910.453125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='04', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -1551,7 +1551,7 @@ class Incirlik(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(221207.773438, -35240.347656, terrain), terrain)
 
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=1, name='05-23', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(221611.203125, -35769.89453125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='49', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -1944,7 +1944,7 @@ class Jirah(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(115359.652344, 187020.734375, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(115251.65625, 188431.671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='15', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -2043,8 +2043,8 @@ class Khalkhalah(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-218620.25, 56161.078125, terrain), terrain)
 
-        self.runways.append(Runway(250))
-        self.runways.append(Runway(330))
+        self.runways.append(Runway(id=2, name='15-33', heading=150, opposite_heading=330))
+        self.runways.append(Runway(id=1, name='07-25', heading=70, opposite_heading=250))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-216011.40625, 52803.390625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='12', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -2224,7 +2224,7 @@ class King_Hussein_Air_College(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-296592.405413, 24944.355658, terrain), terrain)
 
-        self.runways.append(Runway(130))
+        self.runways.append(Runway(id=None, name='31-13', heading=310, opposite_heading=130))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-296640.80960449, 24183.058325481, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='44', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -2395,7 +2395,7 @@ class Kiryat_Shmona(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-199486.164063, -34500.691406, terrain), terrain)
 
-        self.runways.append(Runway(210))
+        self.runways.append(Runway(id=None, name='03-21', heading=30, opposite_heading=210))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-199734.375, -34826.63671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='03', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -2425,7 +2425,7 @@ class Bassel_Al_Assad(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(41994.498047, 5841.909424, terrain), terrain)
 
-        self.runways.append(Runway(350))
+        self.runways.append(Runway(id=1, name='17L-35R', heading=170, opposite_heading=350))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(43002.09375, 5465.603515625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -2599,7 +2599,7 @@ class Marj_as_Sultan_North(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-170244.028992, 47506.718825, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=None, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-170310.71875, 47426.27734375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='14', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -2656,8 +2656,8 @@ class Marj_Ruhayyil(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-194233.6875, 46043.976563, terrain), terrain)
 
-        self.runways.append(Runway(240))
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=1, name='06L-24R', heading=60, opposite_heading=240))
+        self.runways.append(Runway(id=2, name='06R-24L', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-194252.21875, 44232.859375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='11', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -2831,7 +2831,7 @@ class Megiddo(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-266965.015625, -71068.832031, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=1, position=mapping.Point(-266855.78894767, -70709.252965942, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='08', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -2873,7 +2873,7 @@ class Mezzeh(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-172160.453125, 24865.682617, terrain), terrain)
 
-        self.runways.append(Runway(60))
+        self.runways.append(Runway(id=None, name='24-06', heading=240, opposite_heading=60))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-171953.078125, 25448.814453125, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='14', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -3008,8 +3008,8 @@ class Minakh(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(163697.53125, 107430.609375, terrain), terrain)
 
-        self.runways.append(Runway(280))
-        self.runways.append(Runway(220))
+        self.runways.append(Runway(id=2, name='04-22', heading=40, opposite_heading=220))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(163441.59375, 107169.1796875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='07', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -3084,7 +3084,7 @@ class Aleppo(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(125576.863281, 123125.304688, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(125126.828125, 124845.09375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='14', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -3165,7 +3165,7 @@ class Palmyra(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-55704.023438, 220114.742188, terrain), terrain)
 
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=None, name='26-08', heading=260, opposite_heading=80))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-55613.91796875, 218666.296875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='01', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -3246,7 +3246,7 @@ class Qabr_as_Sitt(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-174597.761535, 37221.970678, terrain), terrain)
 
-        self.runways.append(Runway(230))
+        self.runways.append(Runway(id=1, name='05-23', heading=50, opposite_heading=230))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-174752.078125, 37094.52734375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='07', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -3288,9 +3288,9 @@ class Ramat_David(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-259102.132813, -75789.410156, terrain), terrain)
 
-        self.runways.append(Runway(270))
-        self.runways.append(Runway(330))
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=3, name='15-33', heading=150, opposite_heading=330))
+        self.runways.append(Runway(id=2, name='11-29', heading=110, opposite_heading=290))
+        self.runways.append(Runway(id=1, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=6, position=mapping.Point(-258930.734375, -75766.90625, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='11', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -3431,7 +3431,7 @@ class Kuweires(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(125810.890625, 155253.8125, terrain), terrain)
 
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=None, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(125533.8359375, 154375.15625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='31', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -3557,7 +3557,7 @@ class Rayak(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-130132.492188, 4053.336304, terrain), terrain)
 
-        self.runways.append(Runway(220))
+        self.runways.append(Runway(id=None, name='04-22', heading=40, opposite_heading=220))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-129373.9453125, 5490.4599609375, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='06', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -3608,7 +3608,7 @@ class Rene_Mouawad(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-48306.007813, 8690.693604, terrain), terrain)
 
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=None, name='06-24', heading=60, opposite_heading=240))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-47948.4140625, 8702.654296875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='05', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -3662,7 +3662,7 @@ class Rosh_Pina(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-225277.733943, -37687.536255, terrain), terrain)
 
-        self.runways.append(Runway(150))
+        self.runways.append(Runway(id=None, name='33-15', heading=330, opposite_heading=150))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-225774.390625, -37479.33203125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -3704,7 +3704,7 @@ class Sayqal(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-151781.367188, 117529.734375, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-150767.75, 118082.6875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='56', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -3896,7 +3896,7 @@ class Shayrat(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-61368.207031, 90675.136719, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=None, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-62254.8671875, 92263.546875, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='48', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -4082,7 +4082,7 @@ class Tabqa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(76964.6875, 243605.210938, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(77222.4375, 244747.03125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='13', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -4184,7 +4184,7 @@ class Taftanaz(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(103485.980469, 82766.671875, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(103153.3359375, 82645.1796875, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='17', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -4343,7 +4343,7 @@ class Tiyas(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-58907.53125, 157071.484375, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-58583.79296875, 154749.203125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='10', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -4604,7 +4604,7 @@ class Wujah_Al_Hajar(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-81524.375, -22832.533203, terrain), terrain)
 
-        self.runways.append(Runway(20))
+        self.runways.append(Runway(id=None, name='20-02', heading=200, opposite_heading=20))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-81061.453125, -22970.05078125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='04', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -4637,7 +4637,7 @@ class Gazipasa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(158144.617188, -319392.546875, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(158006.0625, -318795.21875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='06', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -4670,7 +4670,7 @@ class Deir_ez_Zor(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(25465.167969, 389747.03125, terrain), terrain)
 
-        self.runways.append(Runway(100))
+        self.runways.append(Runway(id=None, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(25592.66796875, 390510.75, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='03', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -4733,7 +4733,7 @@ class Akrotiri(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-35778.628906, -268906.125, terrain), terrain)
 
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-36358.76953125, -268523, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='C1', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -4883,7 +4883,7 @@ class Kingsfield(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(7596.761963, -199426.492188, terrain), terrain)
 
-        self.runways.append(Runway(60))
+        self.runways.append(Runway(id=None, name='24-06', heading=240, opposite_heading=60))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(7760.2595443036, -198874.52124089, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='02', length=18.449999, width=13.049999, height=8.0, shelter=False))
@@ -4904,7 +4904,7 @@ class Paphos(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-18696.34668, -314208.375, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=1, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-18519.71875, -313559.09375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='20', length=42.0, width=34.0, height=14.0, shelter=False))
@@ -5048,7 +5048,7 @@ class Larnaca(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-7674.737061, -208843.625, terrain), terrain)
 
-        self.runways.append(Runway(220))
+        self.runways.append(Runway(id=1, name='04-22', heading=40, opposite_heading=220))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-7843.2055664062, -210062.46875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='42', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -5198,7 +5198,7 @@ class Lakatamia(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(19561.164063, -234985.75, terrain), terrain)
 
-        self.runways.append(Runway(350))
+        self.runways.append(Runway(id=None, name='17-35', heading=170, opposite_heading=350))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(19755.73828125, -234857.359375, self._terrain), large=False, heli=True,
                 airplanes=False, slot_name='H5', length=30.0, width=23.0, height=10.0, shelter=False))
@@ -5237,7 +5237,7 @@ class Ercan(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(24250.327148, -218240.28125, terrain), terrain)
 
-        self.runways.append(Runway(290))
+        self.runways.append(Runway(id=1, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(24540.85546875, -218264.890625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -5273,7 +5273,7 @@ class Gecitkale(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(32144.729634, -197767.51907, terrain), terrain)
 
-        self.runways.append(Runway(270))
+        self.runways.append(Runway(id=None, name='09-27', heading=90, opposite_heading=270))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(31787.678962334, -196740.64115297, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -5297,7 +5297,7 @@ class Pinarbashi(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(38639.882813, -238774.6875, terrain), terrain)
 
-        self.runways.append(Runway(340))
+        self.runways.append(Runway(id=None, name='16-34', heading=160, opposite_heading=340))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(39076.5546875, -238808.8125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -5368,8 +5368,8 @@ class H3(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-235405.664063, 352522.65625, terrain), terrain)
 
-        self.runways.append(Runway(290))
-        self.runways.append(Runway(240))
+        self.runways.append(Runway(id=2, name='06-24', heading=60, opposite_heading=240))
+        self.runways.append(Runway(id=1, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-236204.984375, 353533.625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='44', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -5588,7 +5588,7 @@ class H3_Northwest(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-220000.35156, 338483.561903, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-220580.53125, 338708.875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='13', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -5690,7 +5690,7 @@ class H3_Southwest(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-256859.445313, 339219.1875, terrain), terrain)
 
-        self.runways.append(Runway(120))
+        self.runways.append(Runway(id=1, name='30-12', heading=300, opposite_heading=120))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-256947.3125, 339964.3125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='06', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -5795,7 +5795,7 @@ class Ruwayshid(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-294533.859375, 295074.640625, terrain), terrain)
 
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=None, name='27-09', heading=270, opposite_heading=90))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(-294232.71875, 293663.8125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='03', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -5882,7 +5882,7 @@ class Sanliurfa(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(264719.125, 273812.4375, terrain), terrain)
 
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=None, name='22-04', heading=220, opposite_heading=40))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(264257.1139012, 274104.38323455, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='03', length=40.0, width=40.0, height=12.0, shelter=False))
@@ -5977,7 +5977,7 @@ class Tal_Siman(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(133191.875, 276361.453125, terrain), terrain)
 
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(133191.78125, 276637.3125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=26.0, width=22.0, height=11.0, shelter=False))

--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -1,5 +1,6 @@
 # terrain module
 from __future__ import annotations
+from dataclasses import dataclass
 
 from pyproj import CRS, Transformer
 
@@ -49,20 +50,35 @@ class ParkingSlot:
         )
 
 
+@dataclass(frozen=True)
 class Runway:
-    def __init__(self, heading, ils=None, leftright=0):
-        """
+    id: Optional[int]
+    name: str
+    heading: int
+    opposite_heading: int
 
-        :param heading: Compass direction of runway
-        :param ils:
-        :param leftright: 0 only 1 runway
-                          1 left runway
-                          2 right runway
-        :return: None
-        """
-        self.heading = heading
-        self.ils = ils
-        self.leftright = leftright
+    @staticmethod
+    def from_lua(data: Dict[str, Any]) -> Runway:
+        # Example data:
+        # {
+        #     ["start"] = "13R",
+        #     ["id"] = 2,
+        #     ["name"] = "13R-31L",
+        #     ["end"] = "31L",
+        # }
+
+        # For some airfields (Sir Abu Nuayr in the gulf, for example), the runway ID is
+        # -1. I have no idea what that means, but since it certainly isn't a valid
+        # index, we translate that to None.
+        runway_id: Optional[int] = data["id"]
+        if runway_id == -1:
+            runway_id = None
+        return Runway(
+            runway_id,
+            data["name"],
+            int(data["start"].rstrip("LR")) * 10,
+            int(data["end"].rstrip("LR")) * 10,
+        )
 
 
 class RunwayOccupiedError(RuntimeError):

--- a/dcs/terrain/thechannel/airports.py
+++ b/dcs/terrain/thechannel/airports.py
@@ -18,8 +18,8 @@ class Abbeville_Drucat(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-81655.472418, 15915.37745, terrain), terrain)
 
-        self.runways.append(Runway(20))
-        self.runways.append(Runway(90))
+        self.runways.append(Runway(id=2, name='27-09', heading=270, opposite_heading=90))
+        self.runways.append(Runway(id=1, name='20-02', heading=200, opposite_heading=20))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-80735.7109375, 16925.8671875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='02', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -115,8 +115,8 @@ class Merville_Calonne(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-29311.714574, 73776.745175, terrain), terrain)
 
-        self.runways.append(Runway(140))
-        self.runways.append(Runway(80))
+        self.runways.append(Runway(id=2, name='26-08', heading=260, opposite_heading=80))
+        self.runways.append(Runway(id=1, name='32-14', heading=320, opposite_heading=140))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(-29541.197265625, 74560.453125, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='13', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -284,7 +284,7 @@ class Saint_Omer_Longuenesse(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(-16951.693085, 45167.689101, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(-16750.32421875, 44658.95703125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='03', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -410,7 +410,7 @@ class Dunkirk_Mardyck(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(16496.0384, 46954.354309, terrain), terrain)
 
-        self.runways.append(Runway(260))
+        self.runways.append(Runway(id=1, name='08-26', heading=80, opposite_heading=260))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(16624.70932447, 47046.241339207, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='01', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -482,9 +482,9 @@ class Manston(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(52264.839844, -15815.91748, terrain), terrain)
 
-        self.runways.append(Runway(280))
-        self.runways.append(Runway(230))
-        self.runways.append(Runway(280))
+        self.runways.append(Runway(id=3, name='04-23', heading=40, opposite_heading=230))
+        self.runways.append(Runway(id=2, name='10-28', heading=100, opposite_heading=280))
+        self.runways.append(Runway(id=1, name='10-28', heading=100, opposite_heading=280))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=3, position=mapping.Point(53415.3984375, -15004.037109375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='68', length=26.0, width=24.0, height=11.0, shelter=False))
@@ -703,8 +703,8 @@ class Hawkinge(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(26989.935547, -29402.577148, terrain), terrain)
 
-        self.runways.append(Runway(10))
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=2, name='22-04', heading=220, opposite_heading=40))
+        self.runways.append(Runway(id=1, name='19-01', heading=190, opposite_heading=10))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(26914.8359375, -29944.03515625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='22', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -881,7 +881,7 @@ class Lympne(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(23776.552734, -39519.908203, terrain), terrain)
 
-        self.runways.append(Runway(310))
+        self.runways.append(Runway(id=1, name='13-31', heading=130, opposite_heading=310))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=0, position=mapping.Point(23345.6953125, -39134.62890625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='22', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -962,7 +962,7 @@ class Detling(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(49594.240234, -67923.304688, terrain), terrain)
 
-        self.runways.append(Runway(50))
+        self.runways.append(Runway(id=1, name='23-05', heading=230, opposite_heading=50))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=2, position=mapping.Point(50092, -67870.7734375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='21', length=26.0, width=22.0, height=11.0, shelter=False))
@@ -1073,8 +1073,8 @@ class Eastchurch(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(58521.96875, -50427.826172, terrain), terrain)
 
-        self.runways.append(Runway(100))
-        self.runways.append(Runway(200))
+        self.runways.append(Runway(id=1, name='02-20', heading=20, opposite_heading=200))
+        self.runways.append(Runway(id=2, name='28-10', heading=280, opposite_heading=100))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(59137.21484375, -49839.74609375, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='01', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -1215,8 +1215,8 @@ class High_Halden(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(28992.266602, -62020.105469, terrain), terrain)
 
-        self.runways.append(Runway(290))
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=2, name='22-04', heading=220, opposite_heading=40))
+        self.runways.append(Runway(id=1, name='11-29', heading=110, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(29893.033203125, -60978.265625, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='56', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -1468,8 +1468,8 @@ class Headcorn(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(35780.818359, -62104.404297, terrain), terrain)
 
-        self.runways.append(Runway(290))
-        self.runways.append(Runway(190))
+        self.runways.append(Runway(id=2, name='01-19', heading=10, opposite_heading=190))
+        self.runways.append(Runway(id=1, name='10-29', heading=100, opposite_heading=290))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(35068.98046875, -62497.76171875, self._terrain), large=False, heli=True,
                 airplanes=True, slot_name='26', length=21.0, width=15.0, height=8.0, shelter=False))
@@ -1715,9 +1715,9 @@ class Biggin_Hill(Airport):
     def __init__(self, terrain: Terrain) -> None:
         super().__init__(mapping.Point(53454.535156, -107463.621094, terrain), terrain)
 
-        self.runways.append(Runway(50))
-        self.runways.append(Runway(120))
-        self.runways.append(Runway(40))
+        self.runways.append(Runway(id=3, name='30-12', heading=300, opposite_heading=120))
+        self.runways.append(Runway(id=1, name='22-04', heading=220, opposite_heading=40))
+        self.runways.append(Runway(id=2, name='23-05', heading=230, opposite_heading=50))
         self.parking_slots.append(ParkingSlot(
                 crossroad_idx=4, position=mapping.Point(53541.765625, -107856.4453125, self._terrain), large=False, heli=False,
                 airplanes=True, slot_name='54', length=26.0, width=24.0, height=11.0, shelter=False))

--- a/tools/airport_import.py
+++ b/tools/airport_import.py
@@ -47,6 +47,7 @@ from pathlib import Path
 
 import dcs.lua
 from dcs.atcradio import AtcRadio
+from dcs.terrain.terrain import Runway
 
 
 THIS_DIR = Path(__file__).parent.resolve()
@@ -116,14 +117,9 @@ class {sname}(Airport):
         super().__init__(mapping.Point({x}, {y}, terrain), terrain)
 """, file=output)
 
-            i = 0
-            for runway in airport['airport']["runwayName"]:
-                i += 1
-                if not i % 2:
-                    continue  # pydcs code only needs one direction runway
-                runway = airport['airport']["runwayName"][runway]
-                hdg = int(runway) * 10 if runway[-1].isdigit() else int(runway[:-1]) * 10
-                print("        self.runways.append(Runway({hdg}))".format(hdg=hdg), file=output)
+            for runway_data in airport["airport"]["runways"].values():
+                runway = Runway.from_lua(runway_data)
+                print(f"        self.runways.append({repr(runway)})", file=output)
 
             for standid in sorted(airport["standlist"]):
                 slot = airport["standlist"][standid]


### PR DESCRIPTION
The existing code was working for some maps, but the code that skipped the opposite heading sides of the same physical runway was dependent on the ordering of the runway names. For airports that had both a left and right runway, this resulted in two indistinguishable runways.

I've also removed the unset `ils` and `leftright` properties (ILS will be making a comeback once we have beacon data), and added additional data from the lua dump.