### PR TITLE
Add missing UnitType to AllOfCoalition in/out zone conditions

### DIFF
--- a/dcs/condition.py
+++ b/dcs/condition.py
@@ -50,42 +50,48 @@ class Condition:
 class AllOfCoalitionInZone(Condition):
     predicate = "c_all_of_coalition_in_zone"
 
-    def __init__(self, coalitionlist, zone):
+    def __init__(self, coalitionlist, zone, unit_type="ALL"):
         super(AllOfCoalitionInZone, self).__init__(AllOfCoalitionInZone.predicate)
         self.coalitionlist = coalitionlist
         self.params.append(self.coalitionlist)
         self.zone = zone
         self.params.append(self.zone)
+        self.unitType = unit_type
+        self.params.append(self.unitType)
 
     @classmethod
     def create_from_dict(cls, d, mission):
-        return cls(d["coalitionlist"], d["zone"])
+        return cls(d["coalitionlist"], d["zone"], d["unitType"] if "unitType" in d.keys() else "ALL")
 
     def dict(self):
         d = super(AllOfCoalitionInZone, self).dict()
         d["coalitionlist"] = self.coalitionlist
         d["zone"] = self.zone
+        d["unitType"] = self.unitType
         return d
 
 
 class AllOfCoalitionOutsideZone(Condition):
     predicate = "c_all_of_coalition_out_zone"
 
-    def __init__(self, coalitionlist, zone):
+    def __init__(self, coalitionlist, zone, unit_type="ALL"):
         super(AllOfCoalitionOutsideZone, self).__init__(AllOfCoalitionOutsideZone.predicate)
         self.coalitionlist = coalitionlist
         self.params.append(self.coalitionlist)
         self.zone = zone
         self.params.append(self.zone)
+        self.unitType = unit_type
+        self.params.append(self.unitType)
 
     @classmethod
     def create_from_dict(cls, d, mission):
-        return cls(d["coalitionlist"], d["zone"])
+        return cls(d["coalitionlist"], d["zone"], d["unitType"] if "unitType" in d.keys() else "ALL")
 
     def dict(self):
         d = super(AllOfCoalitionOutsideZone, self).dict()
         d["coalitionlist"] = self.coalitionlist
         d["zone"] = self.zone
+        d["unitType"] = self.unitType
         return d
 
 


### PR DESCRIPTION
Copy/Paste from the PartOfCoalition Condition to add the missing unit type parameter which can be set in the mission editor:

![grafik](https://user-images.githubusercontent.com/6678803/208887611-6b27ef00-ace5-46b7-aa55-0958bed8c4cd.png)
