### PR TITLE
Don't delete effect presets for smoke effects

### DIFF
--- a/dcs/unit.py
+++ b/dcs/unit.py
@@ -128,12 +128,14 @@ class Static(Unit):
             _id = _type.id
 
         super().__init__(unit_id, terrain, name, _id)
-        self.skill = None
+        self.skill: Optional[Skill] = None
         self.shape_name: Optional[str] = None
-        self.rate = None
-        self.mass = None
-        self.category = None
-        self.can_cargo = None
+        self.rate: Optional[int] = None
+        self.mass: Optional[int] = None
+        self.category: Optional[str] = None
+        self.can_cargo: Optional[bool] = None
+        self.effect_preset: Optional[int] = None
+        self.effect_transparency: Optional[float] = None
 
         if not isinstance(_type, str):
             if issubclass(_type, StaticType):
@@ -162,19 +164,23 @@ class Static(Unit):
         self.shape_name = d.get("shape_name", None)
         self.rate = d.get("rate")
         self.mass = d.get("mass")
+        self.effect_preset = d.get("effectPreset", None)
+        self.effect_transparency = d.get("effectTransparency", None)
 
     def dict(self):
         d = super(Static, self).dict()
-        if self.category is not None:
-            d["category"] = self.category
-        if self.can_cargo is not None:
-            d["canCargo"] = self.can_cargo
-        if self.shape_name is not None:
-            d["shape_name"] = self.shape_name
-        if self.rate is not None:
-            d["rate"] = self.rate
-        if self.mass is not None:
-            d["mass"] = self.mass
+        fields = [
+            (self.category, "category"),
+            (self.can_cargo, "canCargo"),
+            (self.shape_name, "shape_name"),
+            (self.rate, "rate"),
+            (self.mass, "mass"),
+            (self.effect_preset, "effectPreset"),
+            (self.effect_transparency, "effectTransparency")
+        ]
+        for attr, keyName in fields:
+            if attr is not None:
+                d[keyName] = attr
         return d
 
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -848,3 +848,27 @@ class BasicTests(unittest.TestCase):
         self.assertTrue(
             any(g.name == "rail_car"
                 for g in m2.coalition["blue"].countries["USA"].static_group))
+
+    def test_smoke_preset(self) -> None:
+        m = dcs.mission.Mission()
+        usa = m.coalition["blue"].country("USA")
+        batumi = m.terrain.airports["Batumi"]
+
+        smoke = m.static_group(usa, "some smoke", "big_smoke",
+                               batumi.unit_zones[0].center())
+        u = smoke.units[0]
+        u.effect_preset = 3
+        u.category = "Effects"
+        mizname = "missions/test_smoke_preset.miz"
+        m.save(mizname)
+        m2 = dcs.mission.Mission()
+        m2.load_file(mizname)
+
+        def preset_preserved(group: dcs.unitgroup.StaticGroup,
+                             preset_number: int):
+            u = group.units[0]
+            is_effect = u.category == "Effects"
+            return is_effect and u.effect_preset == preset_number
+
+        static_groups = m2.coalition["blue"].countries["USA"].static_group
+        self.assertTrue(any(preset_preserved(g, 3) for g in static_groups))


### PR DESCRIPTION
Prior to this change, PyDCS would remove custom smoke effect attributes, effectively resetting all of their sizes to the default effect.

This change adds optional fields that appear for smoke effect in-game static objects.