### PR TITLE
Factor out wingreg usage to simplify.

### DIFF
--- a/dcs/winreg.py
+++ b/dcs/winreg.py
@@ -1,0 +1,25 @@
+"""Wrapper around the stdlib winreg that fails gracefully on non-Windows."""
+import logging
+import sys
+from typing import Any, Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+def read_current_user_value(
+    key: str, value: str, ctor: Callable[[Any], T] = lambda x: x
+) -> Optional[T]:
+    if sys.platform == "win32":
+        import winreg
+
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key) as hkey:
+                # QueryValueEx returns a tuple of (value, type ID).
+                return ctor(winreg.QueryValueEx(hkey, value)[0])
+        except FileNotFoundError:
+            return None
+    else:
+        logging.getLogger("pydcs").error(
+            "Cannot read registry keys on non-Windows OS, returning None"
+        )
+        return None


### PR DESCRIPTION
Querying the registry in each caller made the test mocks quite messy. Factor that out so we can clean up the implementation and the tests. This also removes the "is standalone" and "is steam" APIs since those don't seem useful and they complicated the implementation. The other cleanup this makes easy is switching to the contextmanager OpenKey, which fixes the bug I found when writing the test in the previous PR.