### PR TITLE
Fix bug in block comment parsing.

### DIFF
--- a/dcs/lua/parse.py
+++ b/dcs/lua/parse.py
@@ -347,10 +347,10 @@ def loads(
                 self.pos += 1
 
         def eat_block_comment(self) -> None:
-            while not self.eob() and self.next_n_chars(4) != "--]]":
+            while not self.eob() and self.next_n_chars(2) != "]]":
                 self.pos += 1
             if not self.eob():
-                self.pos += 4
+                self.pos += 2
 
         def eat_ws(self):
             """

--- a/dcs/lua/test_parse.py
+++ b/dcs/lua/test_parse.py
@@ -304,6 +304,16 @@ return unitPayloads
 
         loads("--[[ Old Bort Calls For 1.5.3 and Older ]]--")
 
+        r = loads(
+            textwrap.dedent(
+                """\
+                --[[ Comment ]]
+                foo = "bar"
+                """
+            )
+        )
+        self.assertEqual(r["foo"], "bar")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`--]]` is just a convention, apparnelty. `]]` is what actually ends the block.