### PR TITLE
Force livery IDs to lower case.

### DIFF
--- a/dcs/liveries/livery.py
+++ b/dcs/liveries/livery.py
@@ -96,7 +96,7 @@ class Livery:
             except ValueError:
                 order = 0
 
-        return Livery(path_id, livery_name, order, countries)
+        return Livery(path_id.lower(), livery_name, order, countries)
 
     @staticmethod
     def from_path(path: str) -> Optional[Livery]:

--- a/tests/liveries/test_livery.py
+++ b/tests/liveries/test_livery.py
@@ -85,3 +85,13 @@ def test_find_zipped_livery(tmp_path: Path) -> None:
         with zip_file.open("description.lua", "w") as description:
             pass
     assert Livery.from_path(str(zip_path)) is not None
+
+
+def test_livery_id_forced_lower_case(tmp_path: Path) -> None:
+    path = tmp_path / "FOO"
+    path.mkdir()
+    description = path / "description.lua"
+    description.touch()
+    livery = Livery.from_path(str(path))
+    assert livery is not None
+    assert livery.id.islower()


### PR DESCRIPTION
Experimentally via the ME this appears to be required.