### PR TITLE
Livery parser fix.

### DIFF
--- a/dcs/liveries/livery.py
+++ b/dcs/liveries/livery.py
@@ -80,7 +80,11 @@ class Livery:
         # liveries to be suddenly unparseable), and so far we aren't interested in the
         # values of liveries that rely on undefined variables, just assume those are all
         # the empty string and move on.
-        data = dcs.lua.loads(code, unknown_variable_lookup=lambda _: "")
+        try:
+            data = dcs.lua.loads(code, unknown_variable_lookup=lambda _: "")
+        except SyntaxError:
+            logging.exception("Could not parse livery definition at %s", path)
+            return None
         livery_name = data.get("name", path_id)
         countries_table = data.get("countries")
         if countries_table is None:


### PR DESCRIPTION
Make the livery parser tolerant of its own failures. Our lua parser is not robust enough to have failures be fatal since DCS can arbitrarily push an update that will find our bugs. I've added an xfail test for the new failure case, but haven't implemented the fix in the parser.