### PR TITLE
Use lupa to parse liveries.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+lupa
 pyproj


### PR DESCRIPTION
*Much* faster, and doesn't have any errors on the default liveries.

https://github.com/pydcs/dcs/issues/317