### PR TITLE
Add support for the new unlimited fuel command.

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1360,6 +1360,21 @@ class SetImmortalCommand(WrappedAction):
         }
 
 
+class SetUnlimitedFuelCommand(WrappedAction):
+    Key = "SetUnlimitedFuel"
+
+    def __init__(self, value: bool = True) -> None:
+        super().__init__()
+        self.params = {
+            "action": {
+                "id": SetUnlimitedFuelCommand.Key,
+                "params": {
+                    "value": value,
+                }
+            }
+        }
+
+
 class SetCallsignCommand(WrappedAction):
     Key = "SetCallsign"
 


### PR DESCRIPTION
There's some nuance to this that's called out in the changelog (https://www.digitalcombatsimulator.com/en/news/changelog/openbeta/2.9.0.46801/):

> NEW: Advanced Waypoint Action for Unlimited Fuel Option for AI. Please
> note the task must be at the top of Advanced Waypoint Actions list to
> make sure it works properly.

I've got no idea if that's a bug in the current implementation or if that's always going to be how it is. In any case, I haven't handled it directly here. It'll be up to the caller to make sure they prepend rather than append this task.