### PR TITLE
Fix AttributeError in Point.__eq__.

### DIFF
--- a/dcs/mapping.py
+++ b/dcs/mapping.py
@@ -171,6 +171,8 @@ class Point(Vector2):
         return self * (1 / other)
 
     def __eq__(self, other):
+        if not isinstance(other, Point):
+            return False
         return self.x == other.x and self.y == other.y
 
     def __ne__(self, other: object) -> bool:

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -43,6 +43,13 @@ class PointTests(unittest.TestCase):
         self.assertAlmostEqual(p2.x, 0)
         self.assertAlmostEqual(p2.y, 0)
 
+    def test_point_eq(self) -> None:
+        terrain = Caucasus()
+        self.assertEqual(Point(0, 0, terrain), Point(0, 0, terrain))
+        self.assertNotEqual(Point(0, 0, terrain), Point(0, 1, terrain))
+        self.assertNotEqual(Point(0, 0, terrain), Point(1, 0, terrain))
+        self.assertNotEqual(Point(0, 0, terrain), None)
+
 
 class RectangleTests(unittest.TestCase):
     def test_rectangle(self) -> None:


### PR DESCRIPTION
The other type this is compared to might not be Point, and that shouldn't raise an error. It's often a programming mistake to write that comparison, but there's a way to run into this without the caller having a bug: comparing two instances of a dataclass with an `Point | None` member where the rhs has None and the lhs has a Point.