### PR TITLE
Data export for DCS 2.9.2.49629 Open Beta.

### DIFF
--- a/dcs/planes.py
+++ b/dcs/planes.py
@@ -425,12 +425,16 @@ class MiG_27K(PlaneType):
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (2, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (2, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (2, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (2, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (2, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon3:
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (3, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (3, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (3, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (3, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon4:
         FAB_250___250kg_GP_Bomb_LD = (4, Weapons.FAB_250___250kg_GP_Bomb_LD)
@@ -452,6 +456,8 @@ class MiG_27K(PlaneType):
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (7, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (7, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (7, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (7, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (7, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon8:
         Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_ = (8, Weapons.Kh_25ML__AS_10_Karen____300kg__ASM__Semi_Act_Laser_)
@@ -476,6 +482,8 @@ class MiG_27K(PlaneType):
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (8, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (8, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (8, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (8, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (8, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     pylons: Set[int] = {2, 3, 4, 5, 6, 7, 8}
 
@@ -753,7 +761,6 @@ class MiG_23MLD(PlaneType):
     class Pylon3:
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (3, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (3, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (3, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (3, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (3, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (3, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -766,6 +773,8 @@ class MiG_23MLD(PlaneType):
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (3, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (3, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (3, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (3, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (3, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon4:
         Fuel_tank_800L = (4, Weapons.Fuel_tank_800L)
@@ -773,7 +782,6 @@ class MiG_23MLD(PlaneType):
     class Pylon5:
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (5, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (5, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
-        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (5, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
         S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__ = (5, Weapons.S_24B___240mm_UnGd_Rkt__235kg__HE_Frag___Low_Smk__)
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag = (5, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8KOM_HEAT_Frag)
         UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag = (5, Weapons.UB_32A_pod___32_x_S_5KO__57mm_UnGd_Rkts__HEAT_Frag)
@@ -786,6 +794,8 @@ class MiG_23MLD(PlaneType):
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (5, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         FAB_500_M_62___500kg_GP_Bomb_LD = (5, Weapons.FAB_500_M_62___500kg_GP_Bomb_LD)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (5, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (5, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (5, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon6:
         R_24R__AA_7_Apex_SA____Semi_Act_Rdr = (6, Weapons.R_24R__AA_7_Apex_SA____Semi_Act_Rdr)
@@ -835,6 +845,7 @@ class Su_25(PlaneType):
         Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
+        R_60__AA_8_Aphid____IR_AAM = (1, Weapons.R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon2:
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8OM_IL = (2, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8OM_IL)
@@ -1083,6 +1094,7 @@ class Su_25(PlaneType):
         Smoke_Generator___white = (10, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (10, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (10, Weapons.Smoke_Generator___orange)
+        R_60__AA_8_Aphid____IR_AAM = (10, Weapons.R_60__AA_8_Aphid____IR_AAM)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
@@ -1408,6 +1420,7 @@ class Su_25T(PlaneType):
         Smoke_Generator___white = (1, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (1, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (1, Weapons.Smoke_Generator___orange)
+        R_60__AA_8_Aphid____IR_AAM = (1, Weapons.R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon2:
         B_8M1___20_x_UnGd_Rkts__80_mm_S_8OM_IL = (2, Weapons.B_8M1___20_x_UnGd_Rkts__80_mm_S_8OM_IL)
@@ -1678,6 +1691,7 @@ class Su_25T(PlaneType):
         Smoke_Generator___white = (11, Weapons.Smoke_Generator___white)
         Smoke_Generator___yellow = (11, Weapons.Smoke_Generator___yellow)
         Smoke_Generator___orange = (11, Weapons.Smoke_Generator___orange)
+        R_60__AA_8_Aphid____IR_AAM = (11, Weapons.R_60__AA_8_Aphid____IR_AAM)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
@@ -2026,7 +2040,6 @@ class MiG_25RBT(PlaneType):
     livery_name = "MIG-25RBT"  # from type
 
     class Pylon1:
-        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         FAB_100___100kg_GP_Bomb_LD = (1, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100MN___100_kg_Illumination_Bomb = (1, Weapons.SAB_100MN___100_kg_Illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
@@ -2038,6 +2051,8 @@ class MiG_25RBT(PlaneType):
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (1, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (1, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (1, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM)
 
     class Pylon2:
         FAB_100___100kg_GP_Bomb_LD = (2, Weapons.FAB_100___100kg_GP_Bomb_LD)
@@ -2066,7 +2081,6 @@ class MiG_25RBT(PlaneType):
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (3, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
 
     class Pylon4:
-        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (4, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         FAB_100___100kg_GP_Bomb_LD = (4, Weapons.FAB_100___100kg_GP_Bomb_LD)
         SAB_100MN___100_kg_Illumination_Bomb = (4, Weapons.SAB_100MN___100_kg_Illumination_Bomb)
         MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD = (4, Weapons.MBD2_67U_with_4_x_FAB_100___100kg_GP_Bombs_LD)
@@ -2078,6 +2092,8 @@ class MiG_25RBT(PlaneType):
         RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP = (4, Weapons.RBK_500___268_x_PTAB_1M__500kg_CBU_Light_HEAT_AP)
         BetAB_500___500kg_Concrete_Piercing_Bomb_LD = (4, Weapons.BetAB_500___500kg_Concrete_Piercing_Bomb_LD)
         BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb = (4, Weapons.BetAB_500ShP___500kg_Concrete_Piercing_HD_w_booster_Bomb)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (4, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM_ = (4, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM_)
 
     pylons: Set[int] = {1, 2, 3, 4}
 
@@ -2339,6 +2355,7 @@ class Su_17M4(PlaneType):
 
     class Pylon2:
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (2, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (2, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon3:
         B_8M1___20_S_8OFP2 = (3, Weapons.B_8M1___20_S_8OFP2)
@@ -2446,6 +2463,7 @@ class Su_17M4(PlaneType):
 
     class Pylon7:
         APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (7, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (7, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon8:
         B_8M1___20_S_8OFP2 = (8, Weapons.B_8M1___20_S_8OFP2)
@@ -2498,6 +2516,7 @@ class MiG_31(PlaneType):
         R_40RD__AA_6_Acrid____Semi_Act_Rdr = (1, Weapons.R_40RD__AA_6_Acrid____Semi_Act_Rdr)
         R_40TD__AA_6_Acrid____Infra_Red = (1, Weapons.R_40TD__AA_6_Acrid____Infra_Red)
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon2:
         R_33__AA_9_Amos____Semi_Act_Rdr = (2, Weapons.R_33__AA_9_Amos____Semi_Act_Rdr)
@@ -2515,6 +2534,7 @@ class MiG_31(PlaneType):
         R_40RD__AA_6_Acrid____Semi_Act_Rdr = (6, Weapons.R_40RD__AA_6_Acrid____Semi_Act_Rdr)
         R_40TD__AA_6_Acrid____Infra_Red = (6, Weapons.R_40TD__AA_6_Acrid____Infra_Red)
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___ = (6, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM___)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (6, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6}
 
@@ -2563,7 +2583,6 @@ class Su_24M(PlaneType):
     livery_name = "SU-24M"  # from type
 
     class Pylon1:
-        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (1, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (1, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (1, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -2580,6 +2599,10 @@ class Su_24M(PlaneType):
         Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (1, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (1, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (1, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM)
+        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
 
     class Pylon2:
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (2, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
@@ -2711,7 +2734,6 @@ class Su_24M(PlaneType):
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (7, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
 
     class Pylon8:
-        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (8, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
         MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD = (8, Weapons.MBD3_U6_68_with_6_x_FAB_100___100kg_GP_Bombs_LD)
         RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP = (8, Weapons.RBK_250___42_x_PTAB_2_5M__250kg_CBU_Medium_HEAT_AP)
         RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag = (8, Weapons.RBK_250_275___150_x_AO_1SCh__250kg_CBU_HE_Frag)
@@ -2728,6 +2750,10 @@ class Su_24M(PlaneType):
         Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr = (8, Weapons.Kh_25MPU__Updated_AS_12_Kegler____320kg__ARM__IN__Pas_Rdr)
         Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided = (8, Weapons.Kh_25MR__AS_10_Karen____300kg__ASM__10km__RC_Guided)
         Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr = (8, Weapons.Kh_25MP__AS_12_Kegler____320kg__ARM__Pas_Rdr)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_ = (8, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM_)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (8, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM_ = (8, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM_)
+        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (8, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
 
     pylons: Set[int] = {1, 2, 3, 4, 5, 6, 7, 8}
 
@@ -2752,6 +2778,9 @@ class Su_24MR(PlaneType):
 
     class Pylon1:
         APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__ = (1, Weapons.APU_60_2M_with_2_x_R_60M__AA_8_Aphid_B____IR_AAM__)
+        APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_ = (1, Weapons.APU_60_1M_with_R_60M__AA_8_Aphid_B____IR_AAM_)
+        APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_2M_with_2_x_R_60__AA_8_Aphid____IR_AAM)
+        APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM = (1, Weapons.APU_60_1M_with_R_60__AA_8_Aphid____IR_AAM)
 
     class Pylon2:
         Fuel_tank_3000L = (2, Weapons.Fuel_tank_3000L)
@@ -3404,6 +3433,7 @@ class MiG_29A(PlaneType):
 
     class Pylon1:
         R_60M__AA_8_Aphid_B____IR_AAM = (1, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (1, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
@@ -3415,6 +3445,7 @@ class MiG_29A(PlaneType):
 
     class Pylon2:
         R_60M__AA_8_Aphid_B____IR_AAM = (2, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (2, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
@@ -3441,6 +3472,7 @@ class MiG_29A(PlaneType):
 
     class Pylon3:
         R_60M__AA_8_Aphid_B____IR_AAM = (3, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (3, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (3, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (3, Weapons.Smoke_Generator___green)
@@ -3481,6 +3513,7 @@ class MiG_29A(PlaneType):
 
     class Pylon5:
         R_60M__AA_8_Aphid_B____IR_AAM = (5, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (5, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (5, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (5, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (5, Weapons.Smoke_Generator___green)
@@ -3512,6 +3545,7 @@ class MiG_29A(PlaneType):
 
     class Pylon6:
         R_60M__AA_8_Aphid_B____IR_AAM = (6, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (6, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (6, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (6, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (6, Weapons.Smoke_Generator___green)
@@ -3538,6 +3572,7 @@ class MiG_29A(PlaneType):
 
     class Pylon7:
         R_60M__AA_8_Aphid_B____IR_AAM = (7, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (7, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (7, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
@@ -3573,6 +3608,7 @@ class MiG_29G(PlaneType):
 
     class Pylon1:
         R_60M__AA_8_Aphid_B____IR_AAM = (1, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (1, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
@@ -3584,6 +3620,7 @@ class MiG_29G(PlaneType):
 
     class Pylon2:
         R_60M__AA_8_Aphid_B____IR_AAM = (2, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (2, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
@@ -3610,6 +3647,7 @@ class MiG_29G(PlaneType):
 
     class Pylon3:
         R_60M__AA_8_Aphid_B____IR_AAM = (3, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (3, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (3, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (3, Weapons.Smoke_Generator___green)
@@ -3650,6 +3688,7 @@ class MiG_29G(PlaneType):
 
     class Pylon5:
         R_60M__AA_8_Aphid_B____IR_AAM = (5, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (5, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (5, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (5, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (5, Weapons.Smoke_Generator___green)
@@ -3681,6 +3720,7 @@ class MiG_29G(PlaneType):
 
     class Pylon6:
         R_60M__AA_8_Aphid_B____IR_AAM = (6, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (6, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (6, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (6, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (6, Weapons.Smoke_Generator___green)
@@ -3707,6 +3747,7 @@ class MiG_29G(PlaneType):
 
     class Pylon7:
         R_60M__AA_8_Aphid_B____IR_AAM = (7, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (7, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (7, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
@@ -3742,6 +3783,7 @@ class MiG_29S(PlaneType):
 
     class Pylon1:
         R_60M__AA_8_Aphid_B____IR_AAM = (1, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (1, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (1, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (1, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (1, Weapons.Smoke_Generator___green)
@@ -3754,6 +3796,7 @@ class MiG_29S(PlaneType):
 
     class Pylon2:
         R_60M__AA_8_Aphid_B____IR_AAM = (2, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (2, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (2, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (2, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (2, Weapons.Smoke_Generator___green)
@@ -3781,6 +3824,7 @@ class MiG_29S(PlaneType):
 
     class Pylon3:
         R_60M__AA_8_Aphid_B____IR_AAM = (3, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (3, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (3, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (3, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (3, Weapons.Smoke_Generator___green)
@@ -3822,6 +3866,7 @@ class MiG_29S(PlaneType):
 
     class Pylon5:
         R_60M__AA_8_Aphid_B____IR_AAM = (5, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (5, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (5, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (5, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (5, Weapons.Smoke_Generator___green)
@@ -3854,6 +3899,7 @@ class MiG_29S(PlaneType):
 
     class Pylon6:
         R_60M__AA_8_Aphid_B____IR_AAM = (6, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (6, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (6, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (6, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (6, Weapons.Smoke_Generator___green)
@@ -3881,6 +3927,7 @@ class MiG_29S(PlaneType):
 
     class Pylon7:
         R_60M__AA_8_Aphid_B____IR_AAM = (7, Weapons.R_60M__AA_8_Aphid_B____IR_AAM)
+        R_60__AA_8_Aphid____IR_AAM = (7, Weapons.R_60__AA_8_Aphid____IR_AAM)
         R_73__AA_11_Archer____Infra_Red = (7, Weapons.R_73__AA_11_Archer____Infra_Red)
         Smoke_Generator___red = (7, Weapons.Smoke_Generator___red)
         Smoke_Generator___green = (7, Weapons.Smoke_Generator___green)
@@ -6365,7 +6412,7 @@ class S_3B(PlaneType):
     height = 6.93
     width = 20.93
     length = 16.26
-    fuel_max = 5500
+    fuel_max = 5962
     max_speed = 834.12
     chaff = 30
     flare = 30
@@ -6483,7 +6530,7 @@ class S_3B_Tanker(PlaneType):
     height = 6.93
     width = 20.93
     length = 16.26
-    fuel_max = 5500
+    fuel_max = 6887
     max_speed = 834.12
     chaff = 30
     flare = 30
@@ -7075,6 +7122,8 @@ class A_10C(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (3, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
@@ -7120,6 +7169,22 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (3, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (3, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BRU_42_LS = (3, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
@@ -7133,13 +7198,19 @@ class A_10C(PlaneType):
         LAU_117_TGM_65H = (3, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (3, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (3, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
 
     class Pylon4:
         Mk_82___500lb_GP_Bomb_LD = (4, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -7190,16 +7261,38 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (4, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (4, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         MXU_648_TP = (4, Weapons.MXU_648_TP)
         BRU_42_LS = (4, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (4, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (4, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
 
     class Pylon5:
         Mk_82___500lb_GP_Bomb_LD = (5, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -7221,7 +7314,11 @@ class A_10C(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (5, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (5, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (5, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
 
     class Pylon6:
         Mk_82___500lb_GP_Bomb_LD = (6, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -7259,7 +7356,11 @@ class A_10C(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (7, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (7, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (7, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
 
     class Pylon8:
         Mk_82___500lb_GP_Bomb_LD = (8, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -7310,16 +7411,38 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (8, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (8, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
         MXU_648_TP = (8, Weapons.MXU_648_TP)
         BRU_42_LS = (8, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (8, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (8, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (8, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (8, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (8, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (8, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
 
     class Pylon9:
         LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_ = (9, Weapons.LAU_117_with_AGM_65K___Maverick_K__CCD_Imp_ASM_)
@@ -7330,6 +7453,8 @@ class A_10C(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (9, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (9, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (9, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (9, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
@@ -7375,6 +7500,22 @@ class A_10C(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (9, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (9, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
         MXU_648_TP = (9, Weapons.MXU_648_TP)
         BRU_42_LS = (9, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (9, Weapons.BRU_42_3_BDU_33)
@@ -7388,13 +7529,19 @@ class A_10C(PlaneType):
         LAU_117_TGM_65H = (9, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (9, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (9, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (9, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (9, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (9, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_ = (9, Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_)
+        BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
 
     class Pylon10:
         Mk_82___500lb_GP_Bomb_LD = (10, Weapons.Mk_82___500lb_GP_Bomb_LD)
@@ -7679,6 +7826,8 @@ class A_10C_2(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (3, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (3, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (3, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (3, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (3, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
@@ -7724,6 +7873,22 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (3, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (3, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         MXU_648_TP = (3, Weapons.MXU_648_TP)
         BRU_42_LS = (3, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (3, Weapons.BRU_42_3_BDU_33)
@@ -7737,17 +7902,25 @@ class A_10C_2(PlaneType):
         LAU_117_TGM_65H = (3, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (3, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (3, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (3, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (3, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (3, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (3, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (3, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (3, Weapons.BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (3, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (3, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon4:
@@ -7799,20 +7972,44 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (4, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (4, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk)
         MXU_648_TP = (4, Weapons.MXU_648_TP)
         BRU_42_LS = (4, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (4, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (4, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (4, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (4, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (4, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (4, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (4, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (4, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (4, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (4, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (4, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (4, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon5:
@@ -7835,7 +8032,11 @@ class A_10C_2(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (5, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (5, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (5, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = (5, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (5, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (5, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (5, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (5, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon6:
@@ -7874,7 +8075,11 @@ class A_10C_2(PlaneType):
         CBU_103___202_x_CEM__CBU_with_WCMD = (7, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (7, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (7, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (7, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (7, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (7, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (7, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (7, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (7, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon8:
@@ -7926,20 +8131,44 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (8, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (8, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (8, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
         MXU_648_TP = (8, Weapons.MXU_648_TP)
         BRU_42_LS = (8, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (8, Weapons.BRU_42_3_BDU_33)
         BRU_42_3_GBU_12 = (8, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (8, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (8, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (8, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (8, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (8, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (8, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (8, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (8, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (8, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (8, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (8, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (8, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (8, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_ = (8, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (8, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon9:
@@ -7952,6 +8181,8 @@ class A_10C_2(PlaneType):
         Mk_84___2000lb_GP_Bomb_LD = (9, Weapons.Mk_84___2000lb_GP_Bomb_LD)
         Mk_82___500lb_GP_Bomb_LD = (9, Weapons.Mk_82___500lb_GP_Bomb_LD)
         BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD = (9, Weapons.BRU_42_with_3_x_Mk_82___500lb_GP_Bombs_LD)
+        BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = (9, Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_)
+        BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = (9, Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD)
         GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.GBU_12___500lb_Laser_Guided_Bomb)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (9, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
@@ -7997,6 +8228,22 @@ class A_10C_2(PlaneType):
         LAU_131x3_HYDRA_70_M257 = (9, Weapons.LAU_131x3_HYDRA_70_M257)
         LAU_131x3_HYDRA_70_M274 = (9, Weapons.LAU_131x3_HYDRA_70_M274)
 #ERRR LAU_131x3_HYDRA_70_M278
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (9, Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_)
         MXU_648_TP = (9, Weapons.MXU_648_TP)
         BRU_42_LS = (9, Weapons.BRU_42_LS)
         BRU_42_3_BDU_33 = (9, Weapons.BRU_42_3_BDU_33)
@@ -8010,17 +8257,25 @@ class A_10C_2(PlaneType):
         LAU_117_TGM_65H = (9, Weapons.LAU_117_TGM_65H)
         LAU_117_CATM_65K = (9, Weapons.LAU_117_CATM_65K)
         BRU_42_3_GBU_12 = (9, Weapons.BRU_42_3_GBU_12)
+        BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = (9, Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_)
+        BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = (9, Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb)
         CBU_97___10_x_SFW_Cluster_Bomb = (9, Weapons.CBU_97___10_x_SFW_Cluster_Bomb)
         CBU_105___10_x_SFW__CBU_with_WCMD = (9, Weapons.CBU_105___10_x_SFW__CBU_with_WCMD)
         CBU_103___202_x_CEM__CBU_with_WCMD = (9, Weapons.CBU_103___202_x_CEM__CBU_with_WCMD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (9, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
         SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.SUU_25_x_8_LUU_2___Target_Marker_Flares)
         BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD = (9, Weapons.BRU_42_with_3_x_Mk_82_AIR_Ballute___500lb_GP_Bombs_HD)
+        BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (9, Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
+        BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (9, Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_3_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
+        BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_ = (9, Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_)
+        BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = (9, Weapons.BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
         LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (9, Weapons.LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = (9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_)
         BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = (9, Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS)
+        BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_ = (9, Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (9, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
 
     class Pylon10:
@@ -10141,8 +10396,8 @@ class Christen_Eagle_II(PlaneType):
             identifier="SoloFlight",
             control="checkbox",
             label="Solo Flight",
+            player_only=True,
             default=False,
-            weight_when_on=-85,
         ),
         "NetCrewControlPriority": UnitPropertyDescription(
             identifier="NetCrewControlPriority",
@@ -10495,6 +10750,7 @@ class F_15ESE(PlaneType):
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (2, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (2, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (2, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
+        AGM_154A___JSOW_CEB__CBU_type_ = (2, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (2, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (2, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
@@ -10550,6 +10806,7 @@ class F_15ESE(PlaneType):
         GBU_31_V_3_B___2 = (4, Weapons.GBU_31_V_3_B___2)
         GBU_38___3 = (4, Weapons.GBU_38___3)
         GBU_54B___3 = (4, Weapons.GBU_54B___3)
+        AGM_154A___JSOW_CEB__CBU_type_ = (4, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (4, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
@@ -10600,6 +10857,7 @@ class F_15ESE(PlaneType):
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (8, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (8, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (8, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
+        AGM_154A___JSOW_CEB__CBU_type_ = (8, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (8, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (8, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
@@ -10666,6 +10924,7 @@ class F_15ESE(PlaneType):
         GBU_31_V_3_B___2_ = (12, Weapons.GBU_31_V_3_B___2_)
         GBU_38___3_ = (12, Weapons.GBU_38___3_)
         GBU_54B___3_ = (12, Weapons.GBU_54B___3_)
+        AGM_154A___JSOW_CEB__CBU_type_ = (12, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (12, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (12, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (12, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
@@ -10706,6 +10965,7 @@ class F_15ESE(PlaneType):
         GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb = (14, Weapons.GBU_31_V_3_B___JDAM__2000lb_GPS_Guided_Penetrator_Bomb)
         GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb = (14, Weapons.GBU_38_V_1_B___JDAM__500lb_GPS_Guided_Bomb)
         GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD = (14, Weapons.GBU_54_V_1_B___LJDAM__500lb_Laser__GPS_Guided_Bomb_LD)
+        AGM_154A___JSOW_CEB__CBU_type_ = (14, Weapons.AGM_154A___JSOW_CEB__CBU_type_)
         BDU_50LD___500lb_Inert_Practice_Bomb_LD = (14, Weapons.BDU_50LD___500lb_Inert_Practice_Bomb_LD)
         BDU_50HD___500lb_Inert_Practice_Bomb_HD = (14, Weapons.BDU_50HD___500lb_Inert_Practice_Bomb_HD)
         BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (14, Weapons.BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
@@ -10947,6 +11207,9 @@ class F_16C_50(PlaneType):
     livery_name = "F-16C_50"  # from type
 
     class Pylon1:
+        AIM_9P_Sidewinder_IR_AAM = (1, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (1, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (1, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (1, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (1, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (1, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -10956,6 +11219,9 @@ class F_16C_50(PlaneType):
         AN_ASQ_T50_TCTS_Pod___ACMI_Pod = (1, Weapons.AN_ASQ_T50_TCTS_Pod___ACMI_Pod)
 
     class Pylon2:
+        AIM_9P_Sidewinder_IR_AAM = (2, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (2, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (2, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (2, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (2, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (2, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -10966,6 +11232,9 @@ class F_16C_50(PlaneType):
 #ERRR <CLEAN>
 
     class Pylon3:
+        AIM_9P_Sidewinder_IR_AAM = (3, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (3, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (3, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (3, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (3, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (3, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -11030,6 +11299,16 @@ class F_16C_50(PlaneType):
         TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb = (3, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_ = (3, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM_)
         LAU_88_AGM_65H_2_L = (3, Weapons.LAU_88_AGM_65H_2_L)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = (3, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = (3, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = (3, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = (3, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = (3, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice)
         TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (3, Weapons.TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
 
     class Pylon4:
@@ -11069,7 +11348,6 @@ class F_16C_50(PlaneType):
         TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = (4, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD)
         TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb)
         TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb = (4, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb)
-        TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD = (4, Weapons.TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD)
 
     class Pylon5:
         Fuel_tank_300_gal = (5, Weapons.Fuel_tank_300_gal)
@@ -11116,9 +11394,11 @@ class F_16C_50(PlaneType):
         TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = (6, Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_)
         TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_87___202_x_CEM_Cluster_Bomb_)
         TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = (6, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_)
-        TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD_ = (6, Weapons.TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD_)
 
     class Pylon7:
+        AIM_9P_Sidewinder_IR_AAM = (7, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (7, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (7, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (7, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (7, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (7, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -11183,9 +11463,22 @@ class F_16C_50(PlaneType):
         TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = (7, Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_)
         LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__ = (7, Weapons.LAU_88_with_2_x_AGM_65D___Maverick_D__IIR_ASM__)
         LAU_88_AGM_65H_2_R = (7, Weapons.LAU_88_AGM_65H_2_R)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (7, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (7, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (7, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (7, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (7, Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = (7, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = (7, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = (7, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = (7, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_)
+        TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = (7, Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_)
         TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD_ = (7, Weapons.TER_9A_with_2_x_BDU_50LGB___500lb_Laser_Guided_Inert_Practice_Bomb_LD_)
 
     class Pylon8:
+        AIM_9P_Sidewinder_IR_AAM = (8, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (8, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (8, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (8, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (8, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (8, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -11196,6 +11489,9 @@ class F_16C_50(PlaneType):
 #ERRR <CLEAN>
 
     class Pylon9:
+        AIM_9P_Sidewinder_IR_AAM = (9, Weapons.AIM_9P_Sidewinder_IR_AAM)
+        AIM_9P3_Sidewinder_IR_AAM = (9, Weapons.AIM_9P3_Sidewinder_IR_AAM)
+        AIM_9P5_Sidewinder_IR_AAM = (9, Weapons.AIM_9P5_Sidewinder_IR_AAM)
         AIM_9M_Sidewinder_IR_AAM = (9, Weapons.AIM_9M_Sidewinder_IR_AAM)
         AIM_9L_Sidewinder_IR_AAM = (9, Weapons.AIM_9L_Sidewinder_IR_AAM)
         AIM_9X_Sidewinder_IR_AAM = (9, Weapons.AIM_9X_Sidewinder_IR_AAM)
@@ -14509,46 +14805,19 @@ class M_2000C(PlaneType):
     }
 
     property_defaults: Dict[str, Any] = {
-        "RocketBurst": 6,
-        "GunBurst": 1,
-        "LaserCode100": 6,
-        "LaserCode10": 8,
-        "LaserCode1": 8,
+        "IFF_M2_CODE": None,
         "WpBullseye": 0,
         "ForceINSRules": False,
         "ReadyALCM": True,
         "LoadNVGCase": False,
         "InitHotDrift": 0,
         "EnableTAF": True,
-        "DisableVTBExport": False,
     }
 
     class Properties:
 
-        class RocketBurst:
-            id = "RocketBurst"
-
-            class Values:
-                x_1_Rocket = 1
-                x_3_Rockets = 3
-                x_6_Rockets = 6
-                x_18_Rockets = 18
-
-        class GunBurst:
-            id = "GunBurst"
-
-            class Values:
-                x_0_5_Second = 1
-                x_1_0_Second = 2
-
-        class LaserCode100:
-            id = "LaserCode100"
-
-        class LaserCode10:
-            id = "LaserCode10"
-
-        class LaserCode1:
-            id = "LaserCode1"
+        class IFF_M2_CODE:
+            id = "IFF_M2_CODE"
 
         class WpBullseye:
             id = "WpBullseye"
@@ -14568,60 +14837,26 @@ class M_2000C(PlaneType):
         class EnableTAF:
             id = "EnableTAF"
 
-        class DisableVTBExport:
-            id = "DisableVTBExport"
-
     properties = {
-        "RocketBurst": UnitPropertyDescription(
-            identifier="RocketBurst",
-            control="comboList",
-            label="Rocket Burst Count",
-            default=6,
-            w_ctrl=150,
-            values={
-                1: "1 Rocket",
-                3: "3 Rockets",
-                6: "6 Rockets",
-                18: "18 Rockets",
-            },
+        "iff_Label": UnitPropertyDescription(
+            identifier="iff_Label",
+            control="label",
+            label="IFF",
+            player_only=True,
+            x_lbl=150,
         ),
-        "GunBurst": UnitPropertyDescription(
-            identifier="GunBurst",
-            control="comboList",
-            label="Gun Burst Length (Seconds)",
-            default=1,
-            w_ctrl=150,
-            values={
-                1: "0.5 Second",
-                2: "1.0 Second",
-            },
+        "IFF_M2_CODE": UnitPropertyDescription(
+            identifier="IFF_M2_CODE",
+            control="editbox",
+            label="IFF Mode 2 code",
+            player_only=True,
         ),
-        "LaserCode100": UnitPropertyDescription(
-            identifier="LaserCode100",
-            control="spinbox",
-            label="Laser code for GBUs, 1x11",
-            minimum=1,
-            maximum=8,
-            default=6,
-            dimension=" ",
-        ),
-        "LaserCode10": UnitPropertyDescription(
-            identifier="LaserCode10",
-            control="spinbox",
-            label="Laser code for GBUs, 11x1",
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
-        ),
-        "LaserCode1": UnitPropertyDescription(
-            identifier="LaserCode1",
-            control="spinbox",
-            label="Laser code for GBUs, 111x",
-            minimum=1,
-            maximum=8,
-            default=8,
-            dimension=" ",
+        "misc_Label": UnitPropertyDescription(
+            identifier="misc_Label",
+            control="label",
+            label="MISC.",
+            player_only=True,
+            x_lbl=150,
         ),
         "WpBullseye": UnitPropertyDescription(
             identifier="WpBullseye",
@@ -14664,12 +14899,6 @@ class M_2000C(PlaneType):
             control="checkbox",
             label="Enable TAF (GCI link)",
             default=True,
-        ),
-        "DisableVTBExport": UnitPropertyDescription(
-            identifier="DisableVTBExport",
-            control="checkbox",
-            label="Disable VTB Export",
-            default=False,
         ),
     }
 

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -226,9 +226,57 @@ class Weapons:
     BRU_42_3_BDU_33 = {"clsid": "BRU-42_3*BDU-33", "name": "BRU-42 with 3 x BDU-33 - 25lb Practice Bombs LD", "weight": 90.15}
     BRU_42_3_GBU_12 = {"clsid": "BRU-42_3*GBU-12", "name": "BRU-42 with 3 x GBU-12 - 500lb Laser Guided Bombs", "weight": 887.25}
     BRU_42_LS = {"clsid": "BRU-42_LS", "name": "BRU-42 - Triple Ejector Rack (TER)", "weight": 56.25}
+    BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{BRU42_1X_GBU-12}", "name": "BRU-42 with 1 x GBU-12 - 500lb Laser Guided Bomb", "weight": 333.25}
+    BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{BRU42_1X_MK-82AIR}", "name": "BRU-42 with 1 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 298.25}
+    BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD = {"clsid": "{BRU42_1X_MK-82}", "name": "BRU-42 with 1 x Mk-82 - 500lb GP Bomb LD", "weight": 284.25}
+    BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = {"clsid": "{BRU-42_LS_1*SUU-25_8*LUU-2}", "name": "BRU-42 with 1 x SUU-25 x 8 LUU-2 - Target Marker Flares", "weight": 283.05}
     BRU_42_with_2_x_ADM_141A_TALD = {"clsid": "{BRU_42A_x2_ADM_141A}", "name": "BRU-42 with 2 x ADM-141A TALD", "weight": 410.8}
     BRU_42_with_2_x_GBU_10___2000lb_Laser_Guided_Bombs = {"clsid": "{62BE78B1-9258-48AE-B882-279534C0D278}", "name": "BRU-42 with 2 x GBU-10 - 2000lb Laser Guided Bombs", "weight": 1974.25}
+    BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{BRU42_2X_GBU-12_L}", "name": "BRU-42 with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 610.25}
+    BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = {"clsid": "{BRU42_2X_GBU-12_R}", "name": "BRU-42 with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 610.25}
     BRU_42_with_2_x_GBU_27___2000lb_Laser_Guided_Penetrator_Bombs = {"clsid": "{EB969276-1922-4ED1-A5CB-18590F45D7FE}", "name": "BRU-42 with 2 x GBU-27 - 2000lb Laser Guided Penetrator Bombs", "weight": 2038.25}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = {"clsid": "{LAU-131x2 - 7 AGR-20A L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, Laser Guided Rkts M151, HE APKWS", "weight": 325.25}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_ = {"clsid": "{LAU-131x2 - 7 AGR-20A R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, Laser Guided Rkts M151, HE APKWS", "weight": 325.25}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS = {"clsid": "{LAU-131x2 - 7 AGR-20 M282 L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, Laser Guided Rkts M282, MPP APKWS", "weight": 353.25}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_ = {"clsid": "{LAU-131x2 - 7 AGR-20 M282 R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, Laser Guided Rkts M282, MPP APKWS", "weight": 353.25}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M151_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 260.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M151_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 260.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M156_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 263.45}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M156_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 263.45}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M257_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M257, Para Illum", "weight": 272.05}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M257_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M257, Para Illum", "weight": 272.05}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M274_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M274, Practice Smk", "weight": 260.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_M274_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M274, Practice Smk", "weight": 260.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK1_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk1, Practice", "weight": 242.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK1_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk1, Practice", "weight": 242.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK5_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 238.65}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK5_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 238.65}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK61_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 242.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_MK61_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 242.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_WTU1B_L}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 260.85}
+    BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = {"clsid": "{BRU42LS_2*LAU131_HYDRA_70_WTU1B_R}", "name": "BRU-42 with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 260.85}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M151_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 284.05}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M151_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 284.05}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M156_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 285.25}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M156_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 285.25}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M257_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M257, Para Illum", "weight": 293.85}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M257_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M257, Para Illum", "weight": 293.85}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M274_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M274, Practice Smk", "weight": 282.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_M274_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M274, Practice Smk", "weight": 282.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK1_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk1, Practice", "weight": 264.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK1_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk1, Practice", "weight": 264.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK5_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 260.45}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK5_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 260.45}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK61_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 264.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_MK61_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 264.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_WTU1B_L}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 282.65}
+    BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = {"clsid": "{BRU42LS_2*LAU68_HYDRA_70_WTU1B_R}", "name": "BRU-42 with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 282.65}
+    BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{BRU42_2X_MK-82AIR_L}", "name": "BRU-42 with 2 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 540.25}
+    BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = {"clsid": "{BRU42_2X_MK-82AIR_R}", "name": "BRU-42 with 2 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 540.25}
+    BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD = {"clsid": "{BRU42_2X_MK-82_L}", "name": "BRU-42 with 2 x Mk-82 - 500lb GP Bomb LD", "weight": 512.25}
+    BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_ = {"clsid": "{BRU42_2X_MK-82_R}", "name": "BRU-42 with 2 x Mk-82 - 500lb GP Bomb LD", "weight": 512.25}
+    BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares = {"clsid": "{BRU-42_LS_2*SUU-25_8*LUU-2_L}", "name": "BRU-42 with 2 x SUU-25 x 8 LUU-2 - Target Marker Flares", "weight": 509.85}
+    BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_ = {"clsid": "{BRU-42_LS_2*SUU-25_8*LUU-2_R}", "name": "BRU-42 with 2 x SUU-25 x 8 LUU-2 - Target Marker Flares", "weight": 509.85}
     BRU_42_with_3_x_ADM_141A_TALD = {"clsid": "{BRU_42A_x3_ADM_141A}", "name": "BRU-42 with 3 x ADM-141A TALD", "weight": 590.8}
     BRU_42_with_3_x_GBU_16___1000lb_Laser_Guided_Bombs = {"clsid": "{88D49E04-78DF-4F08-B47E-B81247A9E3C5}", "name": "BRU-42 with 3 x GBU-16 - 1000lb Laser Guided Bombs", "weight": 1595.25}
     BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS = {"clsid": "{LAU-131x3 - 7 AGR-20A}", "name": "BRU-42 with 3 x LAU-131 pods - 7 x 2.75\" Hydra, Laser Guided Rkts M151, HE APKWS", "weight": 454.3}
@@ -375,7 +423,7 @@ class Weapons:
     DIS_PL_8A = {"clsid": "DIS_PL-8A", "name": "PL-8A", "weight": 115}
     DIS_PL_8B = {"clsid": "DIS_PL-8B", "name": "PL-8B", "weight": 115}
     DIS_RKT_90_UG = {"clsid": "DIS_RKT_90_UG", "name": "UG_90MM", "weight": 462.5}
-    DIS_SD_10 = {"clsid": "DIS_SD-10", "name": "SD-10", "weight": 289}
+    DIS_SD_10 = {"clsid": "DIS_SD-10", "name": "SD-10A", "weight": 289}
     DIS_SD_10_DUAL_L = {"clsid": "DIS_SD-10_DUAL_L", "name": "SD-10 x 2", "weight": 558}
     DIS_SD_10_DUAL_R = {"clsid": "DIS_SD-10_DUAL_R", "name": "SD-10 x 2", "weight": 558}
     DIS_SMOKE_GENERATOR_B = {"clsid": "DIS_SMOKE_GENERATOR_B", "name": "Smoke Generator - blue", "weight": 0}
@@ -1092,6 +1140,26 @@ class Weapons:
     TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_ = {"clsid": "{TER_9A_2R*CBU-97}", "name": "TER-9A with 2 x CBU-97 - 10 x SFW Cluster Bomb", "weight": 887}
     TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb = {"clsid": "{TER_9A_2L*GBU-12}", "name": "TER-9A with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 607}
     TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_ = {"clsid": "{TER_9A_2R*GBU-12}", "name": "TER-9A with 2 x GBU-12 - 500lb Laser Guided Bomb", "weight": 607}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = {"clsid": "{TER_9A_2L*LAU-131_M151}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 257.6}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = {"clsid": "{TER_9A_2R*LAU-131_M151}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 257.6}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = {"clsid": "{TER_9A_2L*LAU-131_M156}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 260.2}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = {"clsid": "{TER_9A_2R*LAU-131_M156}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 260.2}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = {"clsid": "{TER_9A_2L*LAU-131_MK5}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 235.4}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = {"clsid": "{TER_9A_2R*LAU-131_MK5}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 235.4}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = {"clsid": "{TER_9A_2L*LAU-131_MK61}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 239.6}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = {"clsid": "{TER_9A_2R*LAU-131_MK61}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 239.6}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = {"clsid": "{TER_9A_2L*LAU-131_WTU-1/B}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 257.6}
+    TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = {"clsid": "{TER_9A_2R*LAU-131_WTU-1/B}", "name": "TER-9A with 2 x LAU-131 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 257.6}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE = {"clsid": "{TER_9A_2L*LAU-68_M151}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 280.8}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_ = {"clsid": "{TER_9A_2R*LAU-68_M151}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M151, HE", "weight": 280.8}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos = {"clsid": "{TER_9A_2L*LAU-68_M156}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 282}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_ = {"clsid": "{TER_9A_2R*LAU-68_M156}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 282}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT = {"clsid": "{TER_9A_2L*LAU-68_MK5}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 257.2}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_ = {"clsid": "{TER_9A_2R*LAU-68_MK5}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 257.2}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice = {"clsid": "{TER_9A_2L*LAU-68_MK61}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 261.4}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_ = {"clsid": "{TER_9A_2R*LAU-68_MK61}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk61, Practice", "weight": 261.4}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice = {"clsid": "{TER_9A_2L*LAU-68_WTU-1/B}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 279.4}
+    TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_ = {"clsid": "{TER_9A_2R*LAU-68_WTU-1/B}", "name": "TER-9A with 2 x LAU-68 pod - 7 x 2.75\" Hydra, UnGd Rkts WTU-1/B, Practice", "weight": 279.4}
     TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD = {"clsid": "{TER_9A_2L*MK-82AIR}", "name": "TER-9A with 2 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 537}
     TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_ = {"clsid": "{TER_9A_2R*MK-82AIR}", "name": "TER-9A with 2 x Mk-82 AIR Ballute - 500lb GP Bomb HD", "weight": 537}
     TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD = {"clsid": "{TER_9A_2L*MK-82_Snakeye}", "name": "TER-9A with 2 x Mk-82 Snakeye - 500lb GP Bomb HD", "weight": 552}
@@ -1597,9 +1665,57 @@ weapon_ids = {
     "BRU-42_3*BDU-33": Weapons.BRU_42_3_BDU_33,
     "BRU-42_3*GBU-12": Weapons.BRU_42_3_GBU_12,
     "BRU-42_LS": Weapons.BRU_42_LS,
+    "{BRU42_1X_GBU-12}": Weapons.BRU_42_with_1_x_GBU_12___500lb_Laser_Guided_Bomb,
+    "{BRU42_1X_MK-82AIR}": Weapons.BRU_42_with_1_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+    "{BRU42_1X_MK-82}": Weapons.BRU_42_with_1_x_Mk_82___500lb_GP_Bomb_LD,
+    "{BRU-42_LS_1*SUU-25_8*LUU-2}": Weapons.BRU_42_with_1_x_SUU_25_x_8_LUU_2___Target_Marker_Flares,
     "{BRU_42A_x2_ADM_141A}": Weapons.BRU_42_with_2_x_ADM_141A_TALD,
     "{62BE78B1-9258-48AE-B882-279534C0D278}": Weapons.BRU_42_with_2_x_GBU_10___2000lb_Laser_Guided_Bombs,
+    "{BRU42_2X_GBU-12_L}": Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
+    "{BRU42_2X_GBU-12_R}": Weapons.BRU_42_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_,
     "{EB969276-1922-4ED1-A5CB-18590F45D7FE}": Weapons.BRU_42_with_2_x_GBU_27___2000lb_Laser_Guided_Penetrator_Bombs,
+    "{LAU-131x2 - 7 AGR-20A L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS,
+    "{LAU-131x2 - 7 AGR-20A R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS_,
+    "{LAU-131x2 - 7 AGR-20 M282 L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS,
+    "{LAU-131x2 - 7 AGR-20 M282 R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__Laser_Guided_Rkts_M282__MPP_APKWS_,
+    "{BRU42LS_2*LAU131_HYDRA_70_M151_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+    "{BRU42LS_2*LAU131_HYDRA_70_M151_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_,
+    "{BRU42LS_2*LAU131_HYDRA_70_M156_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+    "{BRU42LS_2*LAU131_HYDRA_70_M156_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_,
+    "{BRU42LS_2*LAU131_HYDRA_70_M257_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+    "{BRU42LS_2*LAU131_HYDRA_70_M257_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_,
+    "{BRU42LS_2*LAU131_HYDRA_70_M274_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+    "{BRU42LS_2*LAU131_HYDRA_70_M274_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK1_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK1_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK5_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK5_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK61_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+    "{BRU42LS_2*LAU131_HYDRA_70_MK61_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_,
+    "{BRU42LS_2*LAU131_HYDRA_70_WTU1B_L}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
+    "{BRU42LS_2*LAU131_HYDRA_70_WTU1B_R}": Weapons.BRU_42_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_,
+    "{BRU42LS_2*LAU68_HYDRA_70_M151_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+    "{BRU42LS_2*LAU68_HYDRA_70_M151_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_,
+    "{BRU42LS_2*LAU68_HYDRA_70_M156_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+    "{BRU42LS_2*LAU68_HYDRA_70_M156_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_,
+    "{BRU42LS_2*LAU68_HYDRA_70_M257_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum,
+    "{BRU42LS_2*LAU68_HYDRA_70_M257_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M257__Para_Illum_,
+    "{BRU42LS_2*LAU68_HYDRA_70_M274_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk,
+    "{BRU42LS_2*LAU68_HYDRA_70_M274_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M274__Practice_Smk_,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK1_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK1_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk1__Practice_,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK5_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK5_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK61_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+    "{BRU42LS_2*LAU68_HYDRA_70_MK61_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_,
+    "{BRU42LS_2*LAU68_HYDRA_70_WTU1B_L}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
+    "{BRU42LS_2*LAU68_HYDRA_70_WTU1B_R}": Weapons.BRU_42_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_,
+    "{BRU42_2X_MK-82AIR_L}": Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
+    "{BRU42_2X_MK-82AIR_R}": Weapons.BRU_42_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_,
+    "{BRU42_2X_MK-82_L}": Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD,
+    "{BRU42_2X_MK-82_R}": Weapons.BRU_42_with_2_x_Mk_82___500lb_GP_Bomb_LD_,
+    "{BRU-42_LS_2*SUU-25_8*LUU-2_L}": Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares,
+    "{BRU-42_LS_2*SUU-25_8*LUU-2_R}": Weapons.BRU_42_with_2_x_SUU_25_x_8_LUU_2___Target_Marker_Flares_,
     "{BRU_42A_x3_ADM_141A}": Weapons.BRU_42_with_3_x_ADM_141A_TALD,
     "{88D49E04-78DF-4F08-B47E-B81247A9E3C5}": Weapons.BRU_42_with_3_x_GBU_16___1000lb_Laser_Guided_Bombs,
     "{LAU-131x3 - 7 AGR-20A}": Weapons.BRU_42_with_3_x_LAU_131_pods___7_x_2_75_Hydra__Laser_Guided_Rkts_M151__HE_APKWS,
@@ -2463,6 +2579,26 @@ weapon_ids = {
     "{TER_9A_2R*CBU-97}": Weapons.TER_9A_with_2_x_CBU_97___10_x_SFW_Cluster_Bomb_,
     "{TER_9A_2L*GBU-12}": Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb,
     "{TER_9A_2R*GBU-12}": Weapons.TER_9A_with_2_x_GBU_12___500lb_Laser_Guided_Bomb_,
+    "{TER_9A_2L*LAU-131_M151}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+    "{TER_9A_2R*LAU-131_M151}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_,
+    "{TER_9A_2L*LAU-131_M156}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+    "{TER_9A_2R*LAU-131_M156}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_,
+    "{TER_9A_2L*LAU-131_MK5}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+    "{TER_9A_2R*LAU-131_MK5}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_,
+    "{TER_9A_2L*LAU-131_MK61}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+    "{TER_9A_2R*LAU-131_MK61}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_,
+    "{TER_9A_2L*LAU-131_WTU-1/B}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
+    "{TER_9A_2R*LAU-131_WTU-1/B}": Weapons.TER_9A_with_2_x_LAU_131_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_,
+    "{TER_9A_2L*LAU-68_M151}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE,
+    "{TER_9A_2R*LAU-68_M151}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M151__HE_,
+    "{TER_9A_2L*LAU-68_M156}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos,
+    "{TER_9A_2R*LAU-68_M156}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_M156__Wht_Phos_,
+    "{TER_9A_2L*LAU-68_MK5}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT,
+    "{TER_9A_2R*LAU-68_MK5}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk5__HEAT_,
+    "{TER_9A_2L*LAU-68_MK61}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice,
+    "{TER_9A_2R*LAU-68_MK61}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_Mk61__Practice_,
+    "{TER_9A_2L*LAU-68_WTU-1/B}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice,
+    "{TER_9A_2R*LAU-68_WTU-1/B}": Weapons.TER_9A_with_2_x_LAU_68_pod___7_x_2_75_Hydra__UnGd_Rkts_WTU_1_B__Practice_,
     "{TER_9A_2L*MK-82AIR}": Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD,
     "{TER_9A_2R*MK-82AIR}": Weapons.TER_9A_with_2_x_Mk_82_AIR_Ballute___500lb_GP_Bomb_HD_,
     "{TER_9A_2L*MK-82_Snakeye}": Weapons.TER_9A_with_2_x_Mk_82_Snakeye___500lb_GP_Bomb_HD,


### PR DESCRIPTION
This includes new AIM-9s and rockets for the F-16, and JSOW for the F-15E.

The M-2000 no longer has some of the properties for configuring LGB codes and gun/rocket ripple settings which looks odd, but the mission editor agrees. Those are configurable via the kneeboard in cockpit so I suppose razbam doesn't think they're needed any more.

There are some other changes as well but those are the highlights.