### PR TITLE
Support for briefing pictures for neutral side

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -116,6 +116,7 @@ class Mission:
         self._sortie = self.string("")
         self.pictureFileNameR: List[Union[ResourceKey, str]] = []
         self.pictureFileNameB: List[Union[ResourceKey, str]] = []
+        self.pictureFileNameN: List[Union[ResourceKey, str]] = []
         self.version = Mission._CURRENT_MIZ_VERSION
         self.currentKey = 0
         self.start_time = datetime.fromtimestamp(1306886400 + 43200, timezone.utc)  # 01-06-2011 12:00:00 UTC
@@ -314,6 +315,9 @@ class Mission:
             self.pictureFileNameR.append(imp_mission["pictureFileNameR"][pic])
         for pic in sorted(imp_mission["pictureFileNameB"]):
             self.pictureFileNameB.append(imp_mission["pictureFileNameB"][pic])
+        if "pictureFileNameN" in imp_mission:
+            for pic in sorted(imp_mission["pictureFileNameN"]):
+                self.pictureFileNameN.append(imp_mission["pictureFileNameN"][pic])
         self.version = imp_mission["version"]
         self.currentKey = imp_mission["currentKey"]
         imp_date = imp_mission.get("date", {"Year": 2011, "Month": 6, "Day": 1})
@@ -474,6 +478,19 @@ class Mission:
         """
         reskey = self.map_resource.add_resource_file(filepath)
         self.pictureFileNameB.append(reskey)
+        return reskey
+
+    def add_picture_neutral(self, filepath: str) -> ResourceKey:
+        """Adds a new briefing picture to the neutral coalition.
+
+        Args:
+            filepath: path to the image, jpg or bmp.
+
+        Returns:
+            the resource key of the picture
+        """
+        reskey = self.map_resource.add_resource_file(filepath)
+        self.pictureFileNameN.append(reskey)
         return reskey
 
     def next_group_id(self):
@@ -2052,6 +2069,9 @@ class Mission:
         m["pictureFileNameB"] = {}
         for i in range(0, len(self.pictureFileNameB)):
             m["pictureFileNameB"][i + 1] = str(self.pictureFileNameB[i])
+        m["pictureFileNameN"] = {}
+        for i in range(0, len(self.pictureFileNameN)):
+            m["pictureFileNameN"][i + 1] = str(self.pictureFileNameN[i])
         m["descriptionBlueTask"] = self._description_bluetask.id
         m["descriptionRedTask"] = self._description_redtask.id
         if self.init_script_file is not None:

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -730,6 +730,7 @@ class BasicTests(unittest.TestCase):
         image_path = 'tests/images/blue.png'
         reskey_b = m.add_picture_blue(image_path)
         reskey_r = m.add_picture_red(image_path)
+        reskey_n = m.add_picture_neutral(image_path)
 
         mission_path = 'missions/test_mission_pictureFileName.miz'
         m.save(mission_path)
@@ -741,6 +742,8 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(m2.pictureFileNameB[0], reskey_b.key)
         self.assertEqual(len(m2.pictureFileNameR), 1)
         self.assertEqual(m2.pictureFileNameR[0], reskey_r.key)
+        self.assertEqual(len(m2.pictureFileNameN), 1)
+        self.assertEqual(m2.pictureFileNameN[0], reskey_n.key)
 
     def test_create_quad_point_zone(self):
         caucasus = dcs.terrain.Caucasus()


### PR DESCRIPTION
Mission.load_file() uses a check for "pictureFileNameN" since old mission files might not have it defined.