### PR TITLE
Fix for setting password for Unit Groups

### DIFF
--- a/dcs/password.py
+++ b/dcs/password.py
@@ -1,0 +1,38 @@
+"""
+The password module generates DCS compliant passwords from input string
+"""
+
+import hashlib
+import base64
+import string
+import random
+
+
+def password_hash(password: str) -> str:
+    # see https://www.reddit.com/r/hoggit/comments/uf2sh0/psa_creating_the_new_slot_passwords_outside_of_dcs/
+
+    # encode from https://github.com/simonwhitaker/base64url
+    def encode(b: bytes, trim: bool = False, break_at: int = 0) -> str:
+        encoded_string = base64.urlsafe_b64encode(b).decode("utf-8")
+        if trim:
+            encoded_string = encoded_string.rstrip("=")
+
+        if break_at > 0:
+            i = 0
+            result = ""
+            while i < len(encoded_string):
+                result += encoded_string[i: i + break_at] + "\n"
+                i += break_at
+            return result
+        else:
+            return encoded_string
+
+    SALT_SIZE = 11
+    DIGEST_SIZE = 32
+
+    key = ''.join(random.sample(string.digits + string.ascii_letters, SALT_SIZE))
+    p_hash = hashlib.blake2b(key=key.encode(), digest_size=DIGEST_SIZE)
+    p_hash.update(password.encode())
+    b64url_hash = encode(p_hash.digest(), trim=True)
+
+    return key + ":" + b64url_hash

--- a/dcs/unitgroup.py
+++ b/dcs/unitgroup.py
@@ -20,9 +20,7 @@ import dcs.action as action
 import dcs.condition as condition
 import dcs.task as task
 import dcs.mapping as mapping
-import hashlib
-import base64
-import string
+from dcs.password import password_hash
 
 PointT = TypeVar("PointT", bound=StaticPoint)
 UnitT = TypeVar("UnitT", bound=Unit)
@@ -65,33 +63,7 @@ class Group(Generic[UnitT, PointT]):
         self.points.append(point)
 
     def set_password(self, password: str) -> None:
-        # see https://www.reddit.com/r/hoggit/comments/uf2sh0/psa_creating_the_new_slot_passwords_outside_of_dcs/
-
-        # encode from https://github.com/simonwhitaker/base64url
-        def encode(b: bytes, trim: bool = False, break_at: int = 0) -> str:
-            encoded_string = base64.urlsafe_b64encode(b).decode("utf-8")
-            if trim:
-                encoded_string = encoded_string.rstrip("=")
-
-            if break_at > 0:
-                i = 0
-                result = ""
-                while i < len(encoded_string):
-                    result += encoded_string[i: i + break_at] + "\n"
-                    i += break_at
-                return result
-            else:
-                return encoded_string
-
-        SALT_SIZE = 11
-        DIGEST_SIZE = 32
-
-        key = ''.join(random.sample(string.digits + string.ascii_letters, SALT_SIZE))
-        p_hash = hashlib.blake2b(key=key.encode(), digest_size=DIGEST_SIZE)
-        p_hash.update(password.encode())
-        b64url_hash = encode(p_hash.digest(), trim=True)
-
-        self.password = key + ":" + b64url_hash
+        self.password = password_hash(password)
 
     def set_no_password(self) -> None:
         self.password = None


### PR DESCRIPTION
* Password is not base64 encoded, but base64URL encoded. Missed that in the initial read.