### PR TITLE
Support miz files saved by old versions of pydcs where not all countries in a coalition were saved

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -358,8 +358,13 @@ class Mission:
         for col_name in ["blue", "red", "neutrals"]:
             if col_name in imp_mission["coalition"]:
                 self.coalition[col_name] = Coalition(col_name, imp_mission["coalition"][col_name]["bullseye"])
+                # Support .miz files saved by earlier versions of DCS or pydcs where countries in coalition 
+                # were not saved.
+                countries_in_coalition = {}
+                if col_name in imp_mission["coalitions"]:
+                    countries_in_coalition = imp_mission["coalitions"][col_name]
                 status += self.coalition[col_name].load_from_dict(self, imp_mission["coalition"][col_name],
-                                                                  imp_mission["coalitions"][col_name])
+                                                                  countries_in_coalition)
 
         # triggers
         self.bypassed_triggers = None


### PR DESCRIPTION
This PR changes mission loading behavior to support .miz files saved by legacy versions of pydcs  (prior to #355 )  where countries without units were not saved. The DCS ME supports loading these files, so pydcs should probably support these files to the best extent it can. AFAICT the change introduced in this PR means that the legacy behavior is maintained for legacy .miz files.