### PR TITLE
DCS Export for 2.9.5.55918

### DIFF
--- a/dcs/countries.py
+++ b/dcs/countries.py
@@ -344,6 +344,7 @@ class Russia(Country):
         Mi_28N = helicopters.Mi_28N
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -358,6 +359,7 @@ class Russia(Country):
         Helicopter.Mi_28N,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -842,6 +844,7 @@ class Ukraine(Country):
         Ka_27 = helicopters.Ka_27
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -855,6 +858,7 @@ class Ukraine(Country):
         Helicopter.Ka_27,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -1239,6 +1243,7 @@ class USA(Country):
         UH_1H = helicopters.UH_1H
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -1257,6 +1262,7 @@ class USA(Country):
         Helicopter.UH_1H,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -1634,6 +1640,7 @@ class Turkey(Country):
         UH_1H = helicopters.UH_1H
         CH_47D = helicopters.CH_47D
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -1647,6 +1654,7 @@ class Turkey(Country):
         Helicopter.UH_1H,
         Helicopter.CH_47D,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -2022,6 +2030,7 @@ class UK(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -2035,6 +2044,7 @@ class UK(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -2409,6 +2419,7 @@ class France(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -2419,6 +2430,7 @@ class France(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -2861,6 +2873,7 @@ class Germany(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -2871,6 +2884,7 @@ class Germany(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -3605,6 +3619,7 @@ class USAFAggressors(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -3627,6 +3642,7 @@ class USAFAggressors(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -4035,6 +4051,7 @@ class Canada(Country):
         UH_1H = helicopters.UH_1H
         CH_47D = helicopters.CH_47D
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -4046,6 +4063,7 @@ class Canada(Country):
         Helicopter.UH_1H,
         Helicopter.CH_47D,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -4407,6 +4425,7 @@ class Spain(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -4418,6 +4437,7 @@ class Spain(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -4800,6 +4820,7 @@ class TheNetherlands(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -4813,6 +4834,7 @@ class TheNetherlands(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -5170,6 +5192,7 @@ class Belgium(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -5180,6 +5203,7 @@ class Belgium(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -5521,6 +5545,7 @@ class Norway(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -5531,6 +5556,7 @@ class Norway(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -5870,6 +5896,7 @@ class Denmark(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -5880,6 +5907,7 @@ class Denmark(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -6243,6 +6271,7 @@ class Israel(Country):
         UH_1H = helicopters.UH_1H
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -6257,6 +6286,7 @@ class Israel(Country):
         Helicopter.UH_1H,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -6653,6 +6683,7 @@ class Georgia(Country):
         Mi_8MT = helicopters.Mi_8MT
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -6664,6 +6695,7 @@ class Georgia(Country):
         Helicopter.Mi_8MT,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -7015,6 +7047,7 @@ class Insurgents(Country):
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
         Ka_50 = helicopters.Ka_50
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -7025,6 +7058,7 @@ class Insurgents(Country):
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
         Helicopter.Ka_50,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -7313,6 +7347,7 @@ class Abkhazia(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -7324,6 +7359,7 @@ class Abkhazia(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -7595,6 +7631,7 @@ class SouthOssetia(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -7606,6 +7643,7 @@ class SouthOssetia(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -7871,6 +7909,7 @@ class Italy(Country):
         UH_1H = helicopters.UH_1H
         CH_47D = helicopters.CH_47D
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -7882,6 +7921,7 @@ class Italy(Country):
         Helicopter.UH_1H,
         Helicopter.CH_47D,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -8237,6 +8277,7 @@ class Australia(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -8249,6 +8290,7 @@ class Australia(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -8568,6 +8610,7 @@ class Switzerland(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -8576,6 +8619,7 @@ class Switzerland(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -8883,6 +8927,7 @@ class Austria(Country):
         Ka_50 = helicopters.Ka_50
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -8892,6 +8937,7 @@ class Austria(Country):
         Helicopter.Ka_50,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -9312,6 +9358,7 @@ class Belarus(Country):
         Mi_8MT = helicopters.Mi_8MT
         Mi_26 = helicopters.Mi_26
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -9323,6 +9370,7 @@ class Belarus(Country):
         Helicopter.Mi_8MT,
         Helicopter.Mi_26,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -9646,6 +9694,7 @@ class Bulgaria(Country):
         Mi_24V = helicopters.Mi_24V
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -9656,6 +9705,7 @@ class Bulgaria(Country):
         Helicopter.Mi_24V,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -10021,6 +10071,7 @@ class CzechRepublic(Country):
         Mi_24V = helicopters.Mi_24V
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -10031,6 +10082,7 @@ class CzechRepublic(Country):
         Helicopter.Mi_24V,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -10398,6 +10450,7 @@ class China(Country):
         Mi_26 = helicopters.Mi_26
         Ka_27 = helicopters.Ka_27
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -10409,6 +10462,7 @@ class China(Country):
         Helicopter.Mi_26,
         Helicopter.Ka_27,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -10645,6 +10699,7 @@ class Croatia(Country):
         Mi_8MT = helicopters.Mi_8MT
         OH_58D = helicopters.OH_58D
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -10656,6 +10711,7 @@ class Croatia(Country):
         Helicopter.Mi_8MT,
         Helicopter.OH_58D,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -11061,6 +11117,7 @@ class Egypt(Country):
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
         Mi_8MT = helicopters.Mi_8MT
         Mi_24V = helicopters.Mi_24V
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -11075,6 +11132,7 @@ class Egypt(Country):
         Helicopter.AH_64D_BLK_II,
         Helicopter.Mi_8MT,
         Helicopter.Mi_24V,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -11448,6 +11506,7 @@ class Finland(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -11456,6 +11515,7 @@ class Finland(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -11832,6 +11892,7 @@ class Greece(Country):
         SH_60B = helicopters.SH_60B
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -11846,6 +11907,7 @@ class Greece(Country):
         Helicopter.SH_60B,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -12237,6 +12299,7 @@ class Hungary(Country):
         Mi_24V = helicopters.Mi_24V
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -12247,6 +12310,7 @@ class Hungary(Country):
         Helicopter.Mi_24V,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -12606,6 +12670,7 @@ class India(Country):
         Mi_26 = helicopters.Mi_26
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -12618,6 +12683,7 @@ class India(Country):
         Helicopter.Mi_26,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -13015,6 +13081,7 @@ class Iran(Country):
         Mi_8MT = helicopters.Mi_8MT
         CH_47D = helicopters.CH_47D
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -13028,6 +13095,7 @@ class Iran(Country):
         Helicopter.Mi_8MT,
         Helicopter.CH_47D,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -13414,6 +13482,7 @@ class Iraq(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -13423,6 +13492,7 @@ class Iraq(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -13782,6 +13852,7 @@ class Japan(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -13794,6 +13865,7 @@ class Japan(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -14227,6 +14299,7 @@ class Kazakhstan(Country):
         Mi_26 = helicopters.Mi_26
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -14239,6 +14312,7 @@ class Kazakhstan(Country):
         Helicopter.Mi_26,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -14572,6 +14646,7 @@ class NorthKorea(Country):
         Ka_50 = helicopters.Ka_50
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -14581,6 +14656,7 @@ class NorthKorea(Country):
         Helicopter.Ka_50,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -14924,6 +15000,7 @@ class Pakistan(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -14932,6 +15009,7 @@ class Pakistan(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -15323,6 +15401,7 @@ class Poland(Country):
         Ka_50 = helicopters.Ka_50
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -15332,6 +15411,7 @@ class Poland(Country):
         Helicopter.Ka_50,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -15722,6 +15802,7 @@ class Romania(Country):
         Ka_50 = helicopters.Ka_50
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -15731,6 +15812,7 @@ class Romania(Country):
         Helicopter.Ka_50,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -16089,6 +16171,7 @@ class SaudiArabia(Country):
         CH_47D = helicopters.CH_47D
         AH_64A = helicopters.AH_64A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -16103,6 +16186,7 @@ class SaudiArabia(Country):
         Helicopter.CH_47D,
         Helicopter.AH_64A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -16469,6 +16553,7 @@ class Serbia(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -16478,6 +16563,7 @@ class Serbia(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -16822,6 +16908,7 @@ class Slovakia(Country):
         Ka_50 = helicopters.Ka_50
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -16831,6 +16918,7 @@ class Slovakia(Country):
         Helicopter.Ka_50,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -17173,6 +17261,7 @@ class SouthKorea(Country):
         Ka_27 = helicopters.Ka_27
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -17183,6 +17272,7 @@ class SouthKorea(Country):
         Helicopter.Ka_27,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -17501,6 +17591,7 @@ class Sweden(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -17509,6 +17600,7 @@ class Sweden(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -17895,6 +17987,7 @@ class Syria(Country):
         SA342Minigun = helicopters.SA342Minigun
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -17905,6 +17998,7 @@ class Syria(Country):
         Helicopter.SA342Minigun,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -18243,6 +18337,7 @@ class Yemen(Country):
         Mi_24V = helicopters.Mi_24V
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -18254,6 +18349,7 @@ class Yemen(Country):
         Helicopter.Mi_24V,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -18612,6 +18708,7 @@ class Vietnam(Country):
         Ka_27 = helicopters.Ka_27
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -18622,6 +18719,7 @@ class Vietnam(Country):
         Helicopter.Ka_27,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -18962,6 +19060,7 @@ class Venezuela(Country):
         Mi_26 = helicopters.Mi_26
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -18972,6 +19071,7 @@ class Venezuela(Country):
         Helicopter.Mi_26,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -19280,6 +19380,7 @@ class Tunisia(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -19288,6 +19389,7 @@ class Tunisia(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -19608,6 +19710,7 @@ class Thailand(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -19619,6 +19722,7 @@ class Thailand(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -19950,6 +20054,7 @@ class Sudan(Country):
         Ka_50 = helicopters.Ka_50
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -19959,6 +20064,7 @@ class Sudan(Country):
         Helicopter.Ka_50,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -20260,6 +20366,7 @@ class Philippines(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -20268,6 +20375,7 @@ class Philippines(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -20613,6 +20721,7 @@ class Morocco(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -20623,6 +20732,7 @@ class Morocco(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -20930,6 +21040,7 @@ class Mexico(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -20941,6 +21052,7 @@ class Mexico(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -21257,6 +21369,7 @@ class Malaysia(Country):
         Ka_50 = helicopters.Ka_50
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -21266,6 +21379,7 @@ class Malaysia(Country):
         Helicopter.Ka_50,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -21614,6 +21728,7 @@ class Libya(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -21622,6 +21737,7 @@ class Libya(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -21961,6 +22077,7 @@ class Jordan(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -21973,6 +22090,7 @@ class Jordan(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -22334,6 +22452,7 @@ class Indonesia(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -22345,6 +22464,7 @@ class Indonesia(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -22647,6 +22767,7 @@ class Honduras(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -22656,6 +22777,7 @@ class Honduras(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -22989,6 +23111,7 @@ class Ethiopia(Country):
         Ka_50 = helicopters.Ka_50
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -22998,6 +23121,7 @@ class Ethiopia(Country):
         Helicopter.Ka_50,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -23333,6 +23457,7 @@ class Chile(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -23344,6 +23469,7 @@ class Chile(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -23675,6 +23801,7 @@ class Brazil(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -23685,6 +23812,7 @@ class Brazil(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -24010,6 +24138,7 @@ class Bahrain(Country):
         Ka_50 = helicopters.Ka_50
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -24019,6 +24148,7 @@ class Bahrain(Country):
         Helicopter.Ka_50,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -24349,6 +24479,7 @@ class ThirdReich(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -24357,6 +24488,7 @@ class ThirdReich(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -24705,6 +24837,7 @@ class Yugoslavia(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -24714,6 +24847,7 @@ class Yugoslavia(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -25099,6 +25233,7 @@ class USSR(Country):
         Mi_26 = helicopters.Mi_26
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -25111,6 +25246,7 @@ class USSR(Country):
         Helicopter.Mi_26,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -25370,6 +25506,7 @@ class ItalianSocialRepublic(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -25378,6 +25515,7 @@ class ItalianSocialRepublic(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -25810,6 +25948,7 @@ class Algeria(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -25825,6 +25964,7 @@ class Algeria(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -26170,6 +26310,7 @@ class Kuwait(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -26179,6 +26320,7 @@ class Kuwait(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -26501,6 +26643,7 @@ class Qatar(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -26509,6 +26652,7 @@ class Qatar(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -26845,6 +26989,7 @@ class Oman(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -26854,6 +26999,7 @@ class Oman(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -27205,6 +27351,7 @@ class UnitedArabEmirates(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -27218,6 +27365,7 @@ class UnitedArabEmirates(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -27526,6 +27674,7 @@ class SouthAfrica(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -27535,6 +27684,7 @@ class SouthAfrica(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -27913,6 +28063,7 @@ class Cuba(Country):
         Mi_8MT = helicopters.Mi_8MT
         Mi_24V = helicopters.Mi_24V
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -27923,6 +28074,7 @@ class Cuba(Country):
         Helicopter.Mi_8MT,
         Helicopter.Mi_24V,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -28252,6 +28404,7 @@ class Portugal(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -28260,6 +28413,7 @@ class Portugal(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -28620,6 +28774,7 @@ class GDR(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -28628,6 +28783,7 @@ class GDR(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -28965,6 +29121,7 @@ class Lebanon(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -28974,6 +29131,7 @@ class Lebanon(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -29701,6 +29859,7 @@ class CombinedJointTaskForcesBlue(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -29723,6 +29882,7 @@ class CombinedJointTaskForcesBlue(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -30512,6 +30672,7 @@ class CombinedJointTaskForcesRed(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -30534,6 +30695,7 @@ class CombinedJointTaskForcesRed(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -31323,6 +31485,7 @@ class UnitedNationsPeacekeepers(Country):
     class Helicopter:
         Ka_50 = helicopters.Ka_50
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -31345,6 +31508,7 @@ class UnitedNationsPeacekeepers(Country):
     helicopters = [
         Helicopter.Ka_50,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -31720,6 +31884,7 @@ class Argentina(Country):
         UH_1H = helicopters.UH_1H
         UH_60A = helicopters.UH_60A
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -31732,6 +31897,7 @@ class Argentina(Country):
         Helicopter.UH_1H,
         Helicopter.UH_60A,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -32065,6 +32231,7 @@ class Cyprus(Country):
         SA342Minigun = helicopters.SA342Minigun
         Mi_8MT = helicopters.Mi_8MT
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -32074,6 +32241,7 @@ class Cyprus(Country):
         Helicopter.SA342Minigun,
         Helicopter.Mi_8MT,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:
@@ -32393,6 +32561,7 @@ class Slovenia(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -32403,6 +32572,7 @@ class Slovenia(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -32725,6 +32895,7 @@ class Bolivia(Country):
         Ka_50 = helicopters.Ka_50
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -32734,6 +32905,7 @@ class Bolivia(Country):
         Helicopter.Ka_50,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -33042,6 +33214,7 @@ class Ghana(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -33052,6 +33225,7 @@ class Ghana(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -33372,6 +33546,7 @@ class Nigeria(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -33383,6 +33558,7 @@ class Nigeria(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -33717,6 +33893,7 @@ class Peru(Country):
         Mi_8MT = helicopters.Mi_8MT
         UH_1H = helicopters.UH_1H
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
         SA342M = helicopters.SA342M
         SA342L = helicopters.SA342L
         SA342Mistral = helicopters.SA342Mistral
@@ -33729,6 +33906,7 @@ class Peru(Country):
         Helicopter.Mi_8MT,
         Helicopter.UH_1H,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
         Helicopter.SA342M,
         Helicopter.SA342L,
         Helicopter.SA342Mistral,
@@ -34050,6 +34228,7 @@ class Ecuador(Country):
         SA342Mistral = helicopters.SA342Mistral
         SA342Minigun = helicopters.SA342Minigun
         AH_64D_BLK_II = helicopters.AH_64D_BLK_II
+        OH58D = helicopters.OH58D
 
     helicopters = [
         Helicopter.Ka_50,
@@ -34060,6 +34239,7 @@ class Ecuador(Country):
         Helicopter.SA342Mistral,
         Helicopter.SA342Minigun,
         Helicopter.AH_64D_BLK_II,
+        Helicopter.OH58D,
     ]
 
     class Ship:

--- a/dcs/helicopters.py
+++ b/dcs/helicopters.py
@@ -2194,6 +2194,345 @@ class Mi_24P(HelicopterType):
     task_default = task.CAS
 
 
+class OH58D(HelicopterType):
+    id = "OH58D"
+    flyable = True
+    height = 2.77
+    width = 10.668
+    length = 10.2
+    fuel_max = 333.69
+    max_speed = 230
+    chaff = 0
+    flare = 30
+    charge_total = 30
+    chaff_charge_size = 1
+    flare_charge_size = 1
+    eplrs = True
+    radio_frequency = 116
+
+    panel_radio = {
+        1: {
+            "channels": {
+                1: 260,
+                2: 225,
+                4: 240,
+                8: 280,
+                16: 360,
+                17: 370,
+                9: 290,
+                18: 380,
+                5: 250,
+                10: 300,
+                20: 395,
+                11: 310,
+                3: 230,
+                6: 260,
+                12: 320,
+                13: 330,
+                7: 270,
+                14: 340,
+                19: 390,
+                15: 350
+            },
+        },
+        2: {
+            "channels": {
+                1: 131,
+                2: 116,
+                4: 120,
+                8: 128,
+                16: 144,
+                17: 146,
+                9: 130,
+                18: 148,
+                5: 122,
+                10: 132,
+                20: 151,
+                11: 134,
+                3: 118,
+                6: 124,
+                12: 136,
+                13: 138,
+                7: 126,
+                14: 140,
+                19: 150,
+                15: 142
+            },
+        },
+        4: {
+            "channels": {
+                1: 30,
+                2: 40.4,
+                4: 32,
+                8: 44,
+                16: 68,
+                17: 72,
+                9: 48,
+                18: 74,
+                5: 36,
+                10: 50,
+                20: 80,
+                21: 84,
+                11: 54,
+                3: 30,
+                6: 38,
+                12: 56,
+                13: 60,
+                7: 42,
+                14: 62,
+                19: 78,
+                15: 66
+            },
+        },
+        3: {
+            "channels": {
+                1: 30,
+                2: 40.4,
+                4: 32,
+                8: 44,
+                16: 68,
+                17: 72,
+                9: 48,
+                18: 74,
+                5: 36,
+                10: 50,
+                20: 80,
+                21: 84,
+                11: 54,
+                3: 30,
+                6: 38,
+                12: 56,
+                13: 60,
+                7: 42,
+                14: 62,
+                19: 78,
+                15: 66
+            },
+        },
+    }
+
+    callnames: Dict[str, List[str]] = {
+        "USA": [
+            "Anvil",
+            "Azrael",
+            "Bam-Bam",
+            "Blackjack",
+            "Bootleg",
+            "Burnin' Stogie",
+            "Chaos",
+            "Crazyhorse",
+            "Crusader",
+            "Darkhorse",
+            "Eagle",
+            "Lighthorse",
+            "Mustang",
+            "Outcast",
+            "Palehorse",
+            "Pegasus",
+            "Pistol",
+            "Roughneck",
+            "Saber",
+            "Shamus",
+            "Spur",
+            "Stetson",
+            "Wrath",
+        ]
+    }
+
+    property_defaults: Dict[str, Any] = {
+        "NetCrewControlPriority": 0,
+        "Remove_doors": True,
+        "PDU": False,
+        "Rifles": True,
+        "MMS_removal": False,
+        "Rapid_Deployment_Gear": False,
+        "ALQ144": False,
+        "importDrawings": True,
+        "tacNet": 1,
+    }
+
+    class Properties:
+
+        class NetCrewControlPriority:
+            id = "NetCrewControlPriority"
+
+            class Values:
+                Pilot = 0
+                Copilot = 1
+                Ask_Always = -1
+                Equally_Responsible = -2
+
+        class Remove_doors:
+            id = "Remove doors"
+
+        class PDU:
+            id = "PDU"
+
+        class Rifles:
+            id = "Rifles"
+
+        class MMS_removal:
+            id = "MMS removal"
+
+        class Rapid_Deployment_Gear:
+            id = "Rapid Deployment Gear"
+
+        class ALQ144:
+            id = "ALQ144"
+
+        class importDrawings:
+            id = "importDrawings"
+
+        class tacNet:
+            id = "tacNet"
+
+    properties = {
+        "NetCrewControlPriority": UnitPropertyDescription(
+            identifier="NetCrewControlPriority",
+            control="comboList",
+            label="Aircraft Control Priority",
+            player_only=True,
+            default=0,
+            w_ctrl=150,
+            values={
+                0: "Pilot",
+                1: "Copilot",
+                -1: "Ask Always",
+                -2: "Equally Responsible",
+            },
+        ),
+        "Remove doors": UnitPropertyDescription(
+            identifier="Remove doors",
+            control="checkbox",
+            label="Remove Doors",
+            default=True,
+            weight_when_on=-3.6,
+        ),
+        "PDU": UnitPropertyDescription(
+            identifier="PDU",
+            control="checkbox",
+            label="Install Pilot Display Unit",
+            default=False,
+            weight_when_on=5,
+        ),
+        "Rifles": UnitPropertyDescription(
+            identifier="Rifles",
+            control="checkbox",
+            label="Equip Personal Weapons",
+            player_only=True,
+            default=True,
+        ),
+        "MMS removal": UnitPropertyDescription(
+            identifier="MMS removal",
+            control="checkbox",
+            label="Remove Mast Mounted Sight",
+            default=False,
+            weight_when_on=-122.47,
+        ),
+        "Rapid Deployment Gear": UnitPropertyDescription(
+            identifier="Rapid Deployment Gear",
+            control="checkbox",
+            label="Rapid Deployment Gear",
+            default=False,
+        ),
+        "ALQ144": UnitPropertyDescription(
+            identifier="ALQ144",
+            control="checkbox",
+            label="Install AN/ALQ-144 IRCM",
+            default=False,
+            weight_when_on=-12.7,
+        ),
+        "importDrawings": UnitPropertyDescription(
+            identifier="importDrawings",
+            control="checkbox",
+            label="Import Editor Drawings",
+            player_only=True,
+            default=True,
+        ),
+        "tacNet": UnitPropertyDescription(
+            identifier="tacNet",
+            control="spinbox",
+            label="IDM Net",
+            minimum=1,
+            maximum=20,
+            default=1,
+            dimension=" ",
+        ),
+    }
+
+    livery_name = "OH58D"  # from type
+
+    class Pylon1:
+        OH58D_AGM_114_L1 = (1, Weapons.OH58D_AGM_114_L1)
+        OH58D_AGM_114_L = (1, Weapons.OH58D_AGM_114_L)
+        OH58D_FIM_92_L = (1, Weapons.OH58D_FIM_92_L)
+        OH58D_M3P_L100 = (1, Weapons.OH58D_M3P_L100)
+        OH58D_M3P_L200 = (1, Weapons.OH58D_M3P_L200)
+        OH58D_M3P_L300 = (1, Weapons.OH58D_M3P_L300)
+        OH58D_M3P_L400 = (1, Weapons.OH58D_M3P_L400)
+        OH58D_M3P_L500 = (1, Weapons.OH58D_M3P_L500)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259 = (1, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259)
+        M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS = (1, Weapons.M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS)
+
+    class Pylon2:
+        OH58D_Red_Smoke_Grenade = (2, Weapons.OH58D_Red_Smoke_Grenade)
+        OH58D_Blue_Smoke_Grenade = (2, Weapons.OH58D_Blue_Smoke_Grenade)
+        OH58D_Green_Smoke_Grenade = (2, Weapons.OH58D_Green_Smoke_Grenade)
+        OH58D_Yellow_Smoke_Grenade = (2, Weapons.OH58D_Yellow_Smoke_Grenade)
+        OH58D_Violet_Smoke_Grenade = (2, Weapons.OH58D_Violet_Smoke_Grenade)
+        OH58D_White_Smoke_Grenade = (2, Weapons.OH58D_White_Smoke_Grenade)
+
+    class Pylon3:
+        OH58D_Red_Smoke_Grenade = (3, Weapons.OH58D_Red_Smoke_Grenade)
+        OH58D_Blue_Smoke_Grenade = (3, Weapons.OH58D_Blue_Smoke_Grenade)
+        OH58D_Green_Smoke_Grenade = (3, Weapons.OH58D_Green_Smoke_Grenade)
+        OH58D_Yellow_Smoke_Grenade = (3, Weapons.OH58D_Yellow_Smoke_Grenade)
+        OH58D_Violet_Smoke_Grenade = (3, Weapons.OH58D_Violet_Smoke_Grenade)
+        OH58D_White_Smoke_Grenade = (3, Weapons.OH58D_White_Smoke_Grenade)
+
+    class Pylon4:
+        OH58D_Red_Smoke_Grenade = (4, Weapons.OH58D_Red_Smoke_Grenade)
+        OH58D_Blue_Smoke_Grenade = (4, Weapons.OH58D_Blue_Smoke_Grenade)
+        OH58D_Green_Smoke_Grenade = (4, Weapons.OH58D_Green_Smoke_Grenade)
+        OH58D_Yellow_Smoke_Grenade = (4, Weapons.OH58D_Yellow_Smoke_Grenade)
+        OH58D_Violet_Smoke_Grenade = (4, Weapons.OH58D_Violet_Smoke_Grenade)
+        OH58D_White_Smoke_Grenade = (4, Weapons.OH58D_White_Smoke_Grenade)
+
+    class Pylon5:
+        OH58D_AGM_114_R1 = (5, Weapons.OH58D_AGM_114_R1)
+        OH58D_AGM_114_R = (5, Weapons.OH58D_AGM_114_R)
+        OH58D_FIM_92_R = (5, Weapons.OH58D_FIM_92_R)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257)
+        M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259 = (5, Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259)
+        M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS = (5, Weapons.M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS)
+
+    pylons: Set[int] = {1, 2, 3, 4, 5}
+
+    tasks = [task.CAP, task.CAS, task.GroundAttack, task.AFAC, task.Escort, task.Transport, task.AntishipStrike, task.Reconnaissance]
+    task_default = task.AFAC
+
+
 class SA342M(HelicopterType):
     id = "SA342M"
     flyable = True
@@ -2641,6 +2980,7 @@ helicopter_map = {
     "Ka-50": Ka_50,
     "Ka-50_3": Ka_50_3,
     "Mi-24P": Mi_24P,
+    "OH58D": OH58D,
     "SA342M": SA342M,
     "SA342L": SA342L,
     "SA342Mistral": SA342Mistral,

--- a/dcs/weapons_data.py
+++ b/dcs/weapons_data.py
@@ -843,6 +843,20 @@ class Weapons:
     M2000_Fuel_tank = {"clsid": "{414DA830-B61A-4F9E-B71B-C2F6832E1D7A}", "name": "M2000 Fuel tank", "weight": 1050}
     M260_HYDRA = {"clsid": "M260_HYDRA", "name": "M260 pod - 7 x 2.75\" Hydra, UnGd Rkts Mk5, HEAT", "weight": 112}
     M260_HYDRA_WP = {"clsid": "M260_HYDRA_WP", "name": "M260 pod - 7 x 2.75\" Hydra, UnGd Rkts M156, Wht Phos", "weight": 112}
+    M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS = {"clsid": "{M260_APKWS_M151}", "name": "M260 - 7 x Laser Guided Rkts, 70 mm Hydra 70 M151 HE APKWS", "weight": 120.9}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE = {"clsid": "{M260_M151}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M151 HE", "weight": 88.7}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM = {"clsid": "{M260_M156}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M156 SM", "weight": 89.96}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE = {"clsid": "{M260_M229}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M229 HE", "weight": 112.99}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL = {"clsid": "{M260_M257}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M257 IL", "weight": 94.3}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM = {"clsid": "{M260_M259}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M259 SM", "weight": 86.32}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM = {"clsid": "{M260_M274}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70 M274 TP-SM", "weight": 88.7}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156 = {"clsid": "{M260_A_M151_B_M156}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M151; B - M156", "weight": 89.24}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257 = {"clsid": "{M260_A_M151_B_M257}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M151; B - M257", "weight": 91.1}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259 = {"clsid": "{M260_A_M151_B_M259}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M151; B - M259", "weight": 87.68}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M274 = {"clsid": "{M260_A_M151_B_M274}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M151; B - M274", "weight": 88.7}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156 = {"clsid": "{M260_A_M229_B_M156}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M229; B - M156", "weight": 103.12}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257 = {"clsid": "{M260_A_M229_B_M257}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M229; B - M257", "weight": 104.98}
+    M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259 = {"clsid": "{M260_A_M229_B_M259}", "name": "M260 - 7 x UnGd Rkts, 70 mm Hydra 70, Pod Zones: A - M229; B - M259", "weight": 101.56}
     M261_MK151 = {"clsid": "M261_MK151", "name": "M261 - 19 x UnGd Rkts, 70 mm Hydra 70 M151 HE", "weight": 237}
     M261_MK156 = {"clsid": "M261_MK156", "name": "M261 - 19 x UnGd Rkts, 70 mm Hydra 70 M156 SM", "weight": 240.42}
     M261___19_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE__M433_RC_Fuze = {"clsid": "{M261_M151_M433}", "name": "M261 - 19 x UnGd Rkts, 70 mm Hydra 70 M151 HE, M433 RC Fuze", "weight": 237}
@@ -1033,6 +1047,23 @@ class Weapons:
     ODAB_500PM___525_kg__bomb__parachute__simulated_aerosol = {"clsid": "{ODAB-500PM}", "name": "ODAB-500PM - 525 kg, bomb, parachute, simulated aerosol", "weight": 520}
     OFAB_100_120_TU_x_4 = {"clsid": "{OFAB-100-120-TU}", "name": "OFAB-100-120-TU x 4", "weight": 557}
     OFAB_100_Jupiter___100kg_GP_Bomb_HD = {"clsid": "{OFAB_100_Jupiter}", "name": "OFAB-100 Jupiter - 100kg GP Bomb HD", "weight": 121}
+    OH58D_AGM_114_L = {"clsid": "OH58D_AGM_114_L", "name": "2xAGM-114K", "weight": 138.23}
+    OH58D_AGM_114_L1 = {"clsid": "OH58D_AGM_114_L1", "name": "1xAGM-114K", "weight": 93.05}
+    OH58D_AGM_114_R = {"clsid": "OH58D_AGM_114_R", "name": "2xAGM-114K", "weight": 138.23}
+    OH58D_AGM_114_R1 = {"clsid": "OH58D_AGM_114_R1", "name": "1xAGM-114K", "weight": 93.05}
+    OH58D_Blue_Smoke_Grenade = {"clsid": "OH58D_Blue_Smoke_Grenade", "name": "1xBlue Smoke Grenade", "weight": 0.5}
+    OH58D_FIM_92_L = {"clsid": "OH58D_FIM_92_L", "name": "2xFIM-92", "weight": 42.8}
+    OH58D_FIM_92_R = {"clsid": "OH58D_FIM_92_R", "name": "2xFIM-92", "weight": 42.8}
+    OH58D_Green_Smoke_Grenade = {"clsid": "OH58D_Green_Smoke_Grenade", "name": "1xGreen Smoke Grenade", "weight": 0.5}
+    OH58D_M3P_L100 = {"clsid": "OH58D_M3P_L100", "name": "M3P100", "weight": 85.868}
+    OH58D_M3P_L200 = {"clsid": "OH58D_M3P_L200", "name": "M3P200", "weight": 99.186}
+    OH58D_M3P_L300 = {"clsid": "OH58D_M3P_L300", "name": "M3P300", "weight": 112.504}
+    OH58D_M3P_L400 = {"clsid": "OH58D_M3P_L400", "name": "M3P400", "weight": 125.822}
+    OH58D_M3P_L500 = {"clsid": "OH58D_M3P_L500", "name": "M3P500", "weight": 139.14}
+    OH58D_Red_Smoke_Grenade = {"clsid": "OH58D_Red_Smoke_Grenade", "name": "1xRed Smoke Grenade", "weight": 0.5}
+    OH58D_Violet_Smoke_Grenade = {"clsid": "OH58D_Violet_Smoke_Grenade", "name": "1xViolet Smoke Grenade", "weight": 0.5}
+    OH58D_White_Smoke_Grenade = {"clsid": "OH58D_White_Smoke_Grenade", "name": "1xWhite Smoke Grenade", "weight": 0.5}
+    OH58D_Yellow_Smoke_Grenade = {"clsid": "OH58D_Yellow_Smoke_Grenade", "name": "1xYellow Smoke Grenade", "weight": 0.5}
     ORO_57K___S_5M1_HE_FRAG_FFAR_x_8 = {"clsid": "{ORO57K_S5M1_HEFRAG}", "name": "ORO-57K - S-5M1 HE-FRAG FFAR x 8", "weight": 63.88}
     ORO_57K___S_5MO_HE_FRAG_FFAR_x_8 = {"clsid": "{ORO57K_S5MO_HEFRAG}", "name": "ORO-57K - S-5MO HE-FRAG FFAR x 8", "weight": 63.88}
     ORO_57K___S_5M_x_8 = {"clsid": "{ORO57K_S5M_HEFRAG}", "name": "ORO-57K - S-5M x 8", "weight": 64.92}
@@ -2481,6 +2512,20 @@ weapon_ids = {
     "{414DA830-B61A-4F9E-B71B-C2F6832E1D7A}": Weapons.M2000_Fuel_tank,
     "M260_HYDRA": Weapons.M260_HYDRA,
     "M260_HYDRA_WP": Weapons.M260_HYDRA_WP,
+    "{M260_APKWS_M151}": Weapons.M260___7_x_Laser_Guided_Rkts__70_mm_Hydra_70_M151_HE_APKWS,
+    "{M260_M151}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE,
+    "{M260_M156}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M156_SM,
+    "{M260_M229}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M229_HE,
+    "{M260_M257}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M257_IL,
+    "{M260_M259}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M259_SM,
+    "{M260_M274}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70_M274_TP_SM,
+    "{M260_A_M151_B_M156}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M156,
+    "{M260_A_M151_B_M257}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M257,
+    "{M260_A_M151_B_M259}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M259,
+    "{M260_A_M151_B_M274}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M151__B___M274,
+    "{M260_A_M229_B_M156}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M156,
+    "{M260_A_M229_B_M257}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M257,
+    "{M260_A_M229_B_M259}": Weapons.M260___7_x_UnGd_Rkts__70_mm_Hydra_70__Pod_Zones_A___M229__B___M259,
     "M261_MK151": Weapons.M261_MK151,
     "M261_MK156": Weapons.M261_MK156,
     "{M261_M151_M433}": Weapons.M261___19_x_UnGd_Rkts__70_mm_Hydra_70_M151_HE__M433_RC_Fuze,
@@ -2671,6 +2716,23 @@ weapon_ids = {
     "{ODAB-500PM}": Weapons.ODAB_500PM___525_kg__bomb__parachute__simulated_aerosol,
     "{OFAB-100-120-TU}": Weapons.OFAB_100_120_TU_x_4,
     "{OFAB_100_Jupiter}": Weapons.OFAB_100_Jupiter___100kg_GP_Bomb_HD,
+    "OH58D_AGM_114_L": Weapons.OH58D_AGM_114_L,
+    "OH58D_AGM_114_L1": Weapons.OH58D_AGM_114_L1,
+    "OH58D_AGM_114_R": Weapons.OH58D_AGM_114_R,
+    "OH58D_AGM_114_R1": Weapons.OH58D_AGM_114_R1,
+    "OH58D_Blue_Smoke_Grenade": Weapons.OH58D_Blue_Smoke_Grenade,
+    "OH58D_FIM_92_L": Weapons.OH58D_FIM_92_L,
+    "OH58D_FIM_92_R": Weapons.OH58D_FIM_92_R,
+    "OH58D_Green_Smoke_Grenade": Weapons.OH58D_Green_Smoke_Grenade,
+    "OH58D_M3P_L100": Weapons.OH58D_M3P_L100,
+    "OH58D_M3P_L200": Weapons.OH58D_M3P_L200,
+    "OH58D_M3P_L300": Weapons.OH58D_M3P_L300,
+    "OH58D_M3P_L400": Weapons.OH58D_M3P_L400,
+    "OH58D_M3P_L500": Weapons.OH58D_M3P_L500,
+    "OH58D_Red_Smoke_Grenade": Weapons.OH58D_Red_Smoke_Grenade,
+    "OH58D_Violet_Smoke_Grenade": Weapons.OH58D_Violet_Smoke_Grenade,
+    "OH58D_White_Smoke_Grenade": Weapons.OH58D_White_Smoke_Grenade,
+    "OH58D_Yellow_Smoke_Grenade": Weapons.OH58D_Yellow_Smoke_Grenade,
     "{ORO57K_S5M1_HEFRAG}": Weapons.ORO_57K___S_5M1_HE_FRAG_FFAR_x_8,
     "{ORO57K_S5MO_HEFRAG}": Weapons.ORO_57K___S_5MO_HE_FRAG_FFAR_x_8,
     "{ORO57K_S5M_HEFRAG}": Weapons.ORO_57K___S_5M_x_8,

--- a/tools/pydcs_export.lua
+++ b/tools/pydcs_export.lua
@@ -283,6 +283,7 @@ flyable["Ka-50"] = true
 flyable["Ka-50_3"] = true
 flyable["Mi-8MT"] = true
 flyable["Mi-24P"] = true
+flyable["OH58D"] = true
 flyable["SA342L"] = true
 flyable["SA342M"] = true
 flyable["SA342Minigun"] = true


### PR DESCRIPTION
This PR updates the DCS export for 2.9.5.55918 to support the Kiowa Warrior.