### PR TITLE
Fix spawns on carriers and FARPs in DCS 2.9.6

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -1006,7 +1006,7 @@ class Mission:
             ptask.auto = True
             mp.tasks.append(ptask)
         return mp
-        
+
     def update_warehouses(self):
         """Some units need to have warehouse entries. This function updates warehouse entries based on units defined
         in the mission.

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -673,6 +673,7 @@ class Mission:
         sg.add_point(sp)
 
         country.add_static_group(sg)
+        self.warehouses.warehouses[str(sg.id)] = terrain_.terrain.Warehouse().dict()
         return sg
 
     def vehicle(self, name: str, _type: Type[unittype.VehicleType]) -> Vehicle:
@@ -847,12 +848,12 @@ class Mission:
         wp.ETA_locked = True
 
         country.add_ship_group(sg)
-        
-        # If ship can support aircraft or helicopters, add warehouse data as DCS requires 
+
+        # If ship can support aircraft or helicopters, add warehouse data as DCS requires
         # this information to spawn any aircraft on the ship.
         if _type.parking > 0:
-            self.warehouses.warehouses[sg.id] = terrain_.terrain.Warehouse().dict()
-        
+            self.warehouses.warehouses[str(sg.id)] = terrain_.terrain.Warehouse().dict()
+
         return sg
 
     def plane_group(self, name: str) -> unitgroup.PlaneGroup:

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -847,6 +847,12 @@ class Mission:
         wp.ETA_locked = True
 
         country.add_ship_group(sg)
+        
+        # If ship can support aircraft or helicopters, add warehouse data as DCS requires 
+        # this information to spawn any aircraft on the ship.
+        if _type.parking > 0:
+            self.warehouses.warehouses[sg.id] = terrain_.terrain.Warehouse().dict()
+        
         return sg
 
     def plane_group(self, name: str) -> unitgroup.PlaneGroup:

--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -22,6 +22,7 @@ import dcs.helicopters as helicopters
 import dcs.lua as lua
 import dcs.mapping as mapping
 import dcs.planes as planes
+import dcs.ships as ships
 import dcs.task as task
 import dcs.unitgroup as unitgroup
 import dcs.unittype as unittype
@@ -673,7 +674,6 @@ class Mission:
         sg.add_point(sp)
 
         country.add_static_group(sg)
-        self.warehouses.warehouses[str(sg.id)] = terrain_.terrain.Warehouse().dict()
         return sg
 
     def vehicle(self, name: str, _type: Type[unittype.VehicleType]) -> Vehicle:
@@ -848,12 +848,6 @@ class Mission:
         wp.ETA_locked = True
 
         country.add_ship_group(sg)
-
-        # If ship can support aircraft or helicopters, add warehouse data as DCS requires
-        # this information to spawn any aircraft on the ship.
-        if _type.parking > 0:
-            self.warehouses.warehouses[str(sg.id)] = terrain_.terrain.Warehouse().dict()
-
         return sg
 
     def plane_group(self, name: str) -> unitgroup.PlaneGroup:
@@ -1012,6 +1006,27 @@ class Mission:
             ptask.auto = True
             mp.tasks.append(ptask)
         return mp
+        
+    def update_warehouses(self):
+        """Some units need to have warehouse entries. This function updates warehouse entries based on units defined
+        in the mission.
+        """
+        coalition_to_warehouse_names = {'red': 'RED', 'blue': 'BLUE', 'neutrals': 'NEUTRAL'}
+        for coalition_name in self.coalition:
+            coalition_name_in_warehouse = coalition_to_warehouse_names[coalition_name]
+            for country_name in self.coalition[coalition_name].countries:
+                # Ships that can have aircraft parked need a warehouse entry.
+                for ship_group in self.coalition[coalition_name].countries[country_name].ship_group:
+                    for unit_ in ship_group.units:
+                        if ships.ship_map[unit_.type].parking > 0:
+                            self.warehouses.warehouses[str(unit_.id)] = terrain_.terrain.Warehouse().dict()
+                            self.warehouses.warehouses[str(unit_.id)]['coalition'] = coalition_name_in_warehouse
+                # FARPs need a warehouse entry.
+                for static_group in self.coalition[coalition_name].countries[country_name].static_group:
+                    for unit_ in static_group.units:
+                        if isinstance(unit_, unit.BaseFARP):
+                            self.warehouses.warehouses[str(unit_.id)] = terrain_.terrain.Warehouse().dict()
+                            self.warehouses.warehouses[str(unit_.id)]['coalition'] = coalition_name_in_warehouse
 
     def _flying_group_from_airport(self, _country, group: unitgroup.FlyingGroup,
                                    maintask: Type[task.MainTask],
@@ -2062,6 +2077,7 @@ class Mission:
         self.filename = filename  # store filename
 
         options = str(self.options)
+        self.update_warehouses()  # update warehouses to make sure units that need warehouses have them.
         warehouses = str(self.warehouses)
         mission = str(self)
 

--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -114,8 +114,8 @@ class RunwayOccupiedError(RuntimeError):
 
 class NoParkingSlotError(RuntimeError):
     pass
-    
-    
+
+
 class Warehouse:
 
     def __init__(self):

--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -136,6 +136,8 @@ class Warehouse:
         self.methanol_mixture_init = 100
         self.diesel_init = 100
         self.jet_init = 100
+        self.dynamic_spawn = False
+        self.dynamic_cargo = False
 
     def load_from_dict(self, d):
         self.coalition = d["coalition"]
@@ -155,6 +157,8 @@ class Warehouse:
         self.methanol_mixture_init = d.get("methanol_mixture", {}).get("InitFuel", 100)
         self.diesel_init = d.get("diesel", {}).get("InitFuel", 100)
         self.jet_init = d.get("jet_fuel", {}).get("InitFuel", 100)
+        self.dynamic_spawn = d.get("dynamicSpawn", False)
+        self.dynamic_cargo = d.get("dynamicCargo", False)
 
     def dict(self):
         d = {
@@ -174,7 +178,9 @@ class Warehouse:
             "gasoline": {"InitFuel": self.gasoline_init},
             "methanol_mixture": {"InitFuel": self.methanol_mixture_init},
             "diesel": {"InitFuel": self.diesel_init},
-            "jet_fuel": {"InitFuel": self.jet_init}
+            "jet_fuel": {"InitFuel": self.jet_init},
+            "dynamicSpawn": self.dynamic_spawn,
+            "dynamicCargo": self.dynamic_cargo
         }
         return d
 

--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -114,31 +114,11 @@ class RunwayOccupiedError(RuntimeError):
 
 class NoParkingSlotError(RuntimeError):
     pass
+    
+    
+class Warehouse:
 
-
-class Airport:
-    id: int
-    name: str
-    tacan = None
-    frequencies: List[float] = []
-    unit_zones: List[mapping.Rectangle] = []
-    civilian = True
-    slot_version = 1
-    atc_radio: Optional[AtcRadio]
-
-    def __init__(self, position: mapping.Point, terrain: Terrain) -> None:
-        self.position = position
-        self._terrain = terrain
-        self.runway_used = None
-        self.runways = []  # type: List[Runway]
-        self.parking_slots = []  # type: List[ParkingSlot]
-        # This is currently the raw data from DCS, not a useful API. We don't (yet) have
-        # the info for the beacons themselves, so the beacon associations are not useful
-        # unless that information is available elsewhere. This data contained in this
-        # field will change once pydcs has more data for beacons.
-        self.beacons: list[AirportBeacon] = []
-
-        # warehouse values
+    def __init__(self):
         self.coalition = "NEUTRAL"
         self.size = 100
         self.speed = 16.666666
@@ -159,21 +139,68 @@ class Airport:
 
     def load_from_dict(self, d):
         self.coalition = d["coalition"]
-        self.speed = d["speed"]
         self.size = d["size"]
+        self.speed = d["speed"]
         self.periodicity = d["periodicity"]
         self.unlimited_munitions = d["unlimitedMunitions"]
-        self.unlimited_fuel = d["unlimitedFuel"]
         self.unlimited_aircrafts = d["unlimitedAircrafts"]
+        self.unlimited_fuel = d["unlimitedFuel"]
         self.operating_level_air = d["OperatingLevel_Air"]
-        self.operating_level_equipment = d["OperatingLevel_Eqp"]
         self.operating_level_fuel = d["OperatingLevel_Fuel"]
-        self.gasoline_init = d.get("gasoline", {}).get("InitFuel", 100)
-        self.diesel_init = d.get("diesel", {}).get("InitFuel", 100)
-        self.jet_init = d.get("jet_fuel", {}).get("InitFuel", 100)
-        self.methanol_mixture_init = d.get("methanol_mixture", {}).get("InitFuel", 100)
+        self.operating_level_equipment = d["OperatingLevel_Eqp"]
         self.aircrafts = d["aircrafts"]
         self.weapons = d["weapons"]
+        self.suppliers = d["suppliers"]
+        self.gasoline_init = d.get("gasoline", {}).get("InitFuel", 100)
+        self.methanol_mixture_init = d.get("methanol_mixture", {}).get("InitFuel", 100)
+        self.diesel_init = d.get("diesel", {}).get("InitFuel", 100)
+        self.jet_init = d.get("jet_fuel", {}).get("InitFuel", 100)
+
+    def dict(self):
+        d = {
+            "coalition": self.coalition,
+            "size": self.size,
+            "speed": self.speed,
+            "periodicity": self.periodicity,
+            "unlimitedMunitions": self.unlimited_munitions,
+            "unlimitedAircrafts": self.unlimited_aircrafts,
+            "unlimitedFuel": self.unlimited_fuel,
+            "OperatingLevel_Air": self.operating_level_air,
+            "OperatingLevel_Fuel": self.operating_level_fuel,
+            "OperatingLevel_Eqp": self.operating_level_equipment,
+            "aircrafts": self.aircrafts,
+            "weapons": self.weapons,
+            "suppliers": self.suppliers,
+            "gasoline": {"InitFuel": self.gasoline_init},
+            "methanol_mixture": {"InitFuel": self.methanol_mixture_init},
+            "diesel": {"InitFuel": self.diesel_init},
+            "jet_fuel": {"InitFuel": self.jet_init}
+        }
+        return d
+
+
+class Airport(Warehouse):
+    id: int
+    name: str
+    tacan = None
+    frequencies: List[float] = []
+    unit_zones: List[mapping.Rectangle] = []
+    civilian = True
+    slot_version = 1
+    atc_radio: Optional[AtcRadio]
+
+    def __init__(self, position: mapping.Point, terrain: Terrain) -> None:
+        self.position = position
+        self._terrain = terrain
+        self.runway_used = None
+        self.runways = []  # type: List[Runway]
+        self.parking_slots = []  # type: List[ParkingSlot]
+        # This is currently the raw data from DCS, not a useful API. We don't (yet) have
+        # the info for the beacons themselves, so the beacon associations are not useful
+        # unless that information is available elsewhere. This data contained in this
+        # field will change once pydcs has more data for beacons.
+        self.beacons: list[AirportBeacon] = []
+        super().__init__()
 
     def set_blue(self):
         self.set_coalition("BLUE")
@@ -280,28 +307,6 @@ class Airport:
         if slots:
             return slots[0]
         return None
-
-    def dict(self):
-        d = {
-            "coalition": self.coalition,
-            "speed": self.speed,
-            "size": self.size,
-            "periodicity": self.periodicity,
-            "unlimitedMunitions": self.unlimited_munitions,
-            "unlimitedFuel": self.unlimited_fuel,
-            "unlimitedAircrafts": self.unlimited_aircrafts,
-            "OperatingLevel_Air": self.operating_level_air,
-            "OperatingLevel_Eqp": self.operating_level_equipment,
-            "OperatingLevel_Fuel": self.operating_level_fuel,
-            "gasoline": {"InitFuel": self.gasoline_init},
-            "diesel": {"InitFuel": self.diesel_init},
-            "jet_fuel": {"InitFuel": self.jet_init},
-            "methanol_mixture": {"InitFuel": self.methanol_mixture_init},
-            "aircrafts": self.aircrafts,
-            "weapons": self.weapons,
-            "suppliers": self.suppliers
-        }
-        return d
 
     def __repr__(self):
         return "Airport(" + self.name + ")"


### PR DESCRIPTION
With DCS2.9.6, a warehouse is needed for aircraft to spawn on carriers and FARPs. This change in DCS means the following trivial example missions would fail:

```
from dcs.mission import Mission
from dcs.ships import Stennis, HarborTug
from dcs.planes import FA_18C_hornet
from dcs.helicopters import Mi_8MT
from dcs import countries  
from dcs import mapping
from dcs import unit


mission = Mission()
blue = mission.country("USA")
sg = mission.ship_group(blue, "Carrier", Stennis, mapping.Point(-200000, 450000, mission.terrain))
ag = mission.flight_group_from_unit(blue, "Player", FA_18C_hornet, sg)
ag.units[0].skill = unit.Skill.Player
mission.save("carrier_spawn.miz")

mission = Mission()
blue = mission.country("USA")
farp = mission.farp(blue, "FARP", mapping.Point(-284879, 636819, mission.terrain))
ag = mission.flight_group_from_unit(blue, "Player", Mi_8MT, farp)
ag.units[0].skill = unit.Skill.Player
mission.save("farp_spawn.miz")

```

This PR introduces a function to update warehouses for units in a mission and calls this function before saving a mission to a .miz file. This PR also refactors how warehouses are represented and adds new mandatory Warehouse fields.