### PR TITLE
Fix typo leading to failure when parsing payloads

### DIFF
--- a/dcs/task.py
+++ b/dcs/task.py
@@ -1570,7 +1570,7 @@ class Nothing(MainTask):
 class AFAC(MainTask):
     id = 16
     name = "AFAC"
-    internal_name = "AFAK"
+    internal_name = "AFAC"
     sub_tasks = [OrbitAction, Follow, AttackGroup, AttackUnit, Bombing, AttackMapObject]
 
 


### PR DESCRIPTION
This PR fixes a typo which prevents UnitPayloads for F4E being loaded as an AFAC task is used.