### PR TITLE
Fix carrier and FARP spawns in multiplayer

### DIFF
--- a/dcs/mission.py
+++ b/dcs/mission.py
@@ -1027,14 +1027,14 @@ class Mission:
                 for ship_group in self.coalition[coalition_name].countries[country_name].ship_group:
                     for unit_ in ship_group.units:
                         if ships.ship_map[unit_.type].parking > 0:
-                            self.warehouses.warehouses[str(unit_.id)] = terrain_.terrain.Warehouse().dict()
-                            self.warehouses.warehouses[str(unit_.id)]['coalition'] = coalition_name_in_warehouse
+                            self.warehouses.warehouses[int(unit_.id)] = terrain_.terrain.Warehouse().dict()
+                            self.warehouses.warehouses[int(unit_.id)]['coalition'] = coalition_name_in_warehouse
                 # FARPs need a warehouse entry.
                 for static_group in self.coalition[coalition_name].countries[country_name].static_group:
                     for unit_ in static_group.units:
                         if isinstance(unit_, unit.BaseFARP):
-                            self.warehouses.warehouses[str(unit_.id)] = terrain_.terrain.Warehouse().dict()
-                            self.warehouses.warehouses[str(unit_.id)]['coalition'] = coalition_name_in_warehouse
+                            self.warehouses.warehouses[int(unit_.id)] = terrain_.terrain.Warehouse().dict()
+                            self.warehouses.warehouses[int(unit_.id)]['coalition'] = coalition_name_in_warehouse
 
     def _flying_group_from_airport(self, _country, group: unitgroup.FlyingGroup,
                                    maintask: Type[task.MainTask],

--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -138,6 +138,7 @@ class Warehouse:
         self.jet_init = 100
         self.dynamic_spawn = False
         self.dynamic_cargo = False
+        self.allow_hot_start = False
 
     def load_from_dict(self, d):
         self.coalition = d["coalition"]
@@ -159,6 +160,7 @@ class Warehouse:
         self.jet_init = d.get("jet_fuel", {}).get("InitFuel", 100)
         self.dynamic_spawn = d.get("dynamicSpawn", False)
         self.dynamic_cargo = d.get("dynamicCargo", False)
+        self.allow_hot_start = d.get("allowHotStart", False)
 
     def dict(self):
         d = {
@@ -180,7 +182,8 @@ class Warehouse:
             "diesel": {"InitFuel": self.diesel_init},
             "jet_fuel": {"InitFuel": self.jet_init},
             "dynamicSpawn": self.dynamic_spawn,
-            "dynamicCargo": self.dynamic_cargo
+            "dynamicCargo": self.dynamic_cargo,
+            "allowHotStart": self.allow_hot_start
         }
         return d
 


### PR DESCRIPTION
This PR updates the population of warehouses to add the `allowHotStart` key and uses ints instead of strings as unit IDs. These changes affected multiplayer missions where units spawned on carriers / FARPs.

Without these changes, the following will generate a .miz file that works fine for single player but does not allow spawning in multiplayer.

```
from dcs.mission import Mission
from dcs.ships import Stennis, HarborTug
from dcs.planes import FA_18C_hornet
from dcs.helicopters import Mi_8MT
from dcs import countries  
from dcs import mapping
from dcs import unit


mission = Mission()
blue = mission.country("USA")
sg = mission.ship_group(blue, "Carrier", Stennis, mapping.Point(-200000, 450000, mission.terrain))
ag = mission.flight_group_from_unit(blue, "Player", FA_18C_hornet, sg)
ag.units[0].skill = unit.Skill.Client
mission.save("carrier_spawn.miz")
```