### PR TITLE
Read warehouses in Warehouses.load_dict (symmetric with serialization)

### DIFF
--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -614,6 +614,8 @@ class Warehouses:
     def load_dict(self, data):
         for x in data.get("airports", {}):
             self.terrain.airport_by_id(x).load_from_dict(data["airports"][x])
+        for uid, wh_data in data.get("warehouses", {}).items():
+            self.warehouses[int(uid)] = wh_data
 
     def __str__(self):
         airports = self.terrain.airports

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -94,6 +94,24 @@ class NevadaTest(unittest.TestCase):
         slots = m.terrain.airports["Nellis"].free_parking_slots(dcs.planes.KC_135)
 
 
+class WarehousesTest(unittest.TestCase):
+
+    def test_load_dict_reads_warehouses(self):
+        # __str__ serializes both "airports" and "warehouses", but load_dict
+        # historically read only "airports", silently dropping unit/FARP/ship
+        # warehouse state on every save->load round-trip.  load_dict must read
+        # "warehouses" symmetrically with the serializer.
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+        m.warehouses.load_dict({
+            "airports": {},
+            "warehouses": {"4242": {"coalition": "BLUE", "size": 100}},
+        })
+
+        self.assertIn(4242, m.warehouses.warehouses)
+        self.assertEqual(m.warehouses.warehouses[4242]["coalition"], "BLUE")
+        self.assertEqual(m.warehouses.warehouses[4242]["size"], 100)
+
+
 class NormandyTest(unittest.TestCase):
 
     def test_creation(self):


### PR DESCRIPTION
Warehouses.load_dict reads only data["airports"] and silently drops
data["warehouses"], so unit/FARP/ship warehouse state is lost on every
save->load round-trip even though the serializer writes it. This is the read-side
mirror of the write-side gap in #427 -- together, unit warehouse state survives
neither save nor reload.

Read the warehouses sub-dict symmetrically with the airports loop.

Adds a round-trip test that loads a payload with a warehouse entry and asserts it
survives.

Closes #428.