### PR TITLE
load_payloads: tolerate globbed-but-uncached payload files

### DIFF
--- a/dcs/unittype.py
+++ b/dcs/unittype.py
@@ -137,7 +137,7 @@ class FlyingType(UnitType):
             if not payload_dir.exists():
                 continue
             for payload_path in payload_dir.glob("*.lua"):
-                if FlyingType._payload_cache[payload_path] == cls.id and payload_path.exists():
+                if FlyingType._payload_cache.get(payload_path) == cls.id and payload_path.exists():
                     try:
                         payload_main = lua.loads(payload_path.read_text(), _globals=FlyingType._UnitPayloadGlobals)
                     except SyntaxError:

--- a/tests/test_unittype.py
+++ b/tests/test_unittype.py
@@ -1,11 +1,15 @@
 import textwrap
 from pathlib import Path
 
+import pytest
+
 import dcs.countries
 from dcs.liveries.livery import Livery
 from dcs.liveries.liverycache import LiveryCache
 from dcs.liveries.liveryscanner import LiveryScanner
+from dcs.payloads import PayloadDirectories
 from dcs.planes import F_16C_50
+from dcs.unittype import FlyingType
 
 
 def test_plane_liveries(tmp_path: Path) -> None:
@@ -83,3 +87,69 @@ def test_plane_liveries_for_country(tmp_path: Path) -> None:
         set(F_16C_50.iter_liveries_for_country(dcs.countries.get_by_short_name("USA")))
         == expected
     )
+
+
+def test_load_payloads_skips_globbed_but_uncached_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A payload .lua that scan_payload_dir globs but does not cache must be
+    skipped, not raise.
+
+    scan_payload_dir only records a payload file in _payload_cache when its
+    content matches the `["unitType"] = "..."` regex, but load_payloads globs
+    every *.lua and read the cache with a bare subscript. A globbed-but-uncached
+    file (e.g. the shipping F-100D module, whose payload syntax the regex does
+    not match) therefore raised KeyError and aborted the entire mission load.
+    """
+    payload_dir = tmp_path / "UnitPayloads"
+    payload_dir.mkdir(parents=True)
+
+    # A payload file the regex cannot cache: it has no `["unitType"] = "..."`
+    # line, so scan_payload_dir globs it but stores no cache entry for it.
+    (payload_dir / "Uncacheable.lua").write_text(
+        textwrap.dedent(
+            """\
+            local unitPayloads = {
+                name = "F-100D",
+                payloads = {},
+            }
+            return unitPayloads
+            """
+        )
+    )
+
+    # A normal, cacheable payload file for the unit under test, so we also
+    # confirm the valid file is still loaded while the uncacheable one is
+    # simply skipped.
+    (payload_dir / "Viper.lua").write_text(
+        textwrap.dedent(
+            f"""\
+            local unitPayloads = {{
+                ["unitType"] = "{F_16C_50.id}",
+                ["payloads"] = {{
+                    [1] = {{
+                        ["name"] = "Test Loadout",
+                        ["pylons"] = {{}},
+                    }},
+                }},
+            }}
+            return unitPayloads
+            """
+        )
+    )
+
+    # Point the scanner only at our temp dir (no real DCS install paths), and
+    # reset the process-global caches so the scan re-runs against it.
+    monkeypatch.setattr(PayloadDirectories, "preferred", payload_dir)
+    monkeypatch.setattr(PayloadDirectories, "_dcs", [])
+    monkeypatch.setattr(PayloadDirectories, "_mod", [])
+    monkeypatch.setattr(PayloadDirectories, "_user", tmp_path / "does-not-exist")
+    monkeypatch.setattr(PayloadDirectories, "fallback", None)
+    monkeypatch.setattr(FlyingType, "_payload_cache", None)
+    monkeypatch.setattr(F_16C_50, "payloads", None)
+
+    # Must not raise KeyError on the globbed-but-uncached file.
+    payloads = F_16C_50.load_payloads()
+
+    # The cacheable file still loads; the uncacheable one was skipped.
+    assert "Test Loadout" in payloads


### PR DESCRIPTION
## Problem

FlyingType.load_payloads() aborts the entire mission load with a KeyError
when a payload directory contains a *.lua file that scan_payload_dir()
globbed but did not cache.

The two halves of the payload machinery use mismatched guards:

- scan_payload_dir() globs every *.lua in each payload dir, but only inserts
  a cache entry when the file content matches the regex
  `\["unitType"]\s*=\s*"([^"]*)` (dcs/unittype.py, ~L108-122). A file whose
  unitType is written in a form the regex doesn't match is globbed but never
  cached.
- load_payloads() then re-globs the same *.lua files and reads the cache with
  a bare subscript (dcs/unittype.py:140):

```python
  if FlyingType._payload_cache[payload_path] == cls.id and payload_path.exists():
```

  For any globbed-but-uncached path, _payload_cache[path] raises KeyError,
  which propagates out of load_payloads() and aborts loading the whole mission.

Concrete current motivating case: the shipping ED F-100D module ships
CoreMods/aircraft/F-100D/UnitPayloads/F-100D.lua. That directory is on the
payload search path, so the file globs -- but its content isn't matched by the
["unitType"] regex, so it isn't cached. The result: loading any mission that
references an F-100D crashes in load_payloads().

## Relationship to #317

Issue #317 ("replace our lua parser with lupa?") diagnoses the same underlying
cause -- the regex-based payload scanner can't handle certain payload-file
syntaxes (the F-100D among them) -- and proposes a larger lupa-based parser
rewrite.

This PR is the small, complementary, defensive fix: it does not attempt to fix
the parser or make the uncacheable file parse. It only stops one
unparseable-but-globbed file from taking down the entire mission load, regardless
of whether or when the larger parser rewrite in #317 lands. A file the scanner
can't cache is simply skipped (which is already the intended outcome for a file
that doesn't match a unit) instead of raising.

## Fix

One call, in load_payloads():

```diff
-                if FlyingType._payload_cache[payload_path] == cls.id and payload_path.exists():
+                if FlyingType._payload_cache.get(payload_path) == cls.id and payload_path.exists():
```

An uncached path -> .get() returns None -> None != cls.id -> the file is
skipped. Cached files are unaffected; nothing else changes.

## Test

Added test_load_payloads_skips_globbed_but_uncached_file to
tests/test_unittype.py (matching the existing tmp_path/monkeypatch style).
It creates a payload directory containing:

- an uncacheable .lua (no ["unitType"]="..." line -- the F-100D failure
  shape), and
- a normal cacheable payload .lua for the unit under test,

points the scanner at the temp directory, and asserts that load_payloads() does
not raise and still loads the valid payload. The test fails with KeyError
against the pre-fix bare subscript and passes with .get().