### PR TITLE
Warehouses.load_dict: skip warehouse refs to airports absent from terrain

### DIFF
--- a/dcs/terrain/terrain.py
+++ b/dcs/terrain/terrain.py
@@ -613,7 +613,14 @@ class Warehouses:
 
     def load_dict(self, data):
         for x in data.get("airports", {}):
-            self.terrain.airport_by_id(x).load_from_dict(data["airports"][x])
+            airport = self.terrain.airport_by_id(x)
+            if airport is None:
+                # Warehouse data references an airport id not present in the
+                # current terrain (e.g. a mission authored before a map update
+                # that renumbered or removed airports).  Skip it rather than
+                # crash the whole load on None.load_from_dict().
+                continue
+            airport.load_from_dict(data["airports"][x])
         for uid, wh_data in data.get("warehouses", {}).items():
             self.warehouses[int(uid)] = wh_data
 

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -111,6 +111,33 @@ class WarehousesTest(unittest.TestCase):
         self.assertEqual(m.warehouses.warehouses[4242]["coalition"], "BLUE")
         self.assertEqual(m.warehouses.warehouses[4242]["size"], 100)
 
+    def test_load_dict_skips_airport_absent_from_terrain(self):
+        # airport_by_id() returns None when warehouse data references an airport
+        # id not present in the current terrain (e.g. a mission authored before
+        # a map update that renumbered or removed airports).  load_dict must
+        # skip the absent id instead of crashing on None.load_from_dict(), and
+        # must still load any valid airport entries in the same dict.
+        m = dcs.mission.Mission(terrain=dcs.terrain.Caucasus())
+
+        present = m.terrain.airport_by_id(12)  # Anapa-Vityazevo
+        self.assertIsNotNone(present)
+        present_data = present.dict()
+        present_data["coalition"] = "BLUE"
+        present_data["size"] = 7777
+
+        # The absent id is iterated first, so the loop must continue past it to
+        # reach the present id.  This must not raise.
+        m.warehouses.load_dict({
+            "airports": {
+                999999: {},   # not present in Caucasus -> airport_by_id() is None
+                12: present_data,
+            },
+            "warehouses": {},
+        })
+
+        self.assertEqual(present.coalition, "BLUE")
+        self.assertEqual(present.size, 7777)
+
 
 class NormandyTest(unittest.TestCase):
 


### PR DESCRIPTION
## Problem

Warehouses.load_dict() calls airport_by_id(x).load_from_dict(...) with no
None-guard:

```python
def load_dict(self, data):
    for x in data.get("airports", {}):
        self.terrain.airport_by_id(x).load_from_dict(data["airports"][x])
    ...
```

But airport_by_id() is typed Optional[Airport] and returns None when a
warehouse references an airport id that isn't present in the current terrain.
That makes the call None.load_from_dict(...) → AttributeError, which aborts
the entire mission load.

This is reachable from real missions: when a mission is authored before a
terrain/map update that renumbers or removes airports, its saved warehouse data
keeps the old airport ids. The additive Syria map update is a concrete
trigger — it renumbered airports, leaving some previously-used ids (e.g. 78)
unused, so any pre-update Syria mission referencing them now fails to load.

## Prior art

This is the same defect reported in #223 ("mission.load() on syria fails,
likely due to undefined warehouse-airport pairs", 2022) — a NoneType in
load_dict. That issue was self-closed by the reporter without a code fix, so
the unguarded call survived. The Syria renumber re-exposes it.

## Fix

One-spot guard: if airport_by_id() returns None, skip that id and continue
to the next entry instead of crashing.

```python
def load_dict(self, data):
    for x in data.get("airports", {}):
        airport = self.terrain.airport_by_id(x)
        if airport is None:
            # Warehouse data references an airport id not present in the
            # current terrain (e.g. a mission authored before a map update
            # that renumbered or removed airports).  Skip it rather than
            # crash the whole load on None.load_from_dict().
            continue
        airport.load_from_dict(data["airports"][x])
    ...
```

Minimal and behavior-preserving for the present-airport path: a valid airport id
loads exactly as before. Only the previously-crashing absent-id case changes —
from AttributeError to a skip. The warehouses sub-dict loop is untouched.

## Test

Adds WarehousesTest.test_load_dict_skips_airport_absent_from_terrain: calls
load_dict with an airports dict containing an id not in the Caucasus
terrain followed by a valid id, and asserts (a) it does not raise and (b) the
valid airport entry still loads. The absent id is iterated first so the loop
must continue past it. (Confirmed to fail with the pre-fix AttributeError
without the guard.)